### PR TITLE
Add beforeScript in the local harvester

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemParams.java
@@ -41,6 +41,7 @@ public class LocalFilesystemParams extends AbstractParams {
 	public boolean recurse;
     public boolean checkFileLastModifiedForUpdate;
 	public boolean nodelete;
+	public String beforeScript;
 	
 	public LocalFilesystemParams(DataManager dm) {
 		super(dm);
@@ -83,7 +84,7 @@ public class LocalFilesystemParams extends AbstractParams {
         nodelete = (nodeleteString.equals("on") || nodeleteString.equals("true"));
         String checkFileLastModifiedForUpdateString = Util.getParam(site, "checkFileLastModifiedForUpdate", "true");
         checkFileLastModifiedForUpdate = (checkFileLastModifiedForUpdateString.equals("on") || checkFileLastModifiedForUpdateString.equals("true"));
-        
+        beforeScript = Util.getParam(site, "beforeScript", "");
     }
 
 	public LocalFilesystemParams copy() {
@@ -94,6 +95,7 @@ public class LocalFilesystemParams extends AbstractParams {
 		copy.recurse = recurse;
 		copy.nodelete = nodelete;
         copy.checkFileLastModifiedForUpdate = checkFileLastModifiedForUpdate;
+		copy.beforeScript = beforeScript;
 		return copy;
 	}
 }

--- a/web-ui/src/main/resources/catalog/locales/du-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/du-admin.json
@@ -318,6 +318,8 @@
     "filesystem-nodeleteHelp": "Behoud catalogusbestand ook al is deze verwijderd bij de bron",
     "filesystem-recurse": "Zoek ook in submappen",
     "filesystem-recurseHelp": "Indien aangevinkt, dan worden ook de onderliggende mappen doorzocht op metadata",
+    "filesystem-beforeScript": "Script to run before harvesting",
+    "filesystem-beforeScriptHelp": "Can be used to do a rsync or something similar. Runs nothing if empty.",
     "flyTo": "Vlieg naar",
     "formatter": "Formatter",
     "formatterFileUpdateError": "Fout opgetreden tijdens het opslaan van {{FILE}}",

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -326,6 +326,8 @@
     "filesystem-nodeleteHelp": "Keep catalog record even if deleted at source",
     "filesystem-recurse": "Also search in subfolders",
     "filesystem-recurseHelp": "If true then the subfolders will also be search for metadata",
+    "filesystem-beforeScript": "Script to run before harvesting",
+    "filesystem-beforeScriptHelp": "Can be used to do a rsync or something similar. Runs nothing if empty.",
     "flyTo": "Fly to",
     "formatter": "Formatter",
     "formatterFileUpdateError": "Error occured while saving {{file}}",

--- a/web-ui/src/main/resources/catalog/locales/es-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/es-admin.json
@@ -318,6 +318,8 @@
     "filesystem-nodeleteHelp": "Manatener la entrada en el catálogo incluso si se elimina en la fuente",
     "filesystem-recurse": "Buscar también en subcarpetas",
     "filesystem-recurseHelp": "Si se habilita, los metadatos también se buscarán en las subcarpetas.",
+    "filesystem-beforeScript": "Script to run before harvesting",
+    "filesystem-beforeScriptHelp": "Can be used to do a rsync or something similar. Runs nothing if empty.",
     "flyTo": "Ir a",
     "formatter": "Formateador",
     "formatterFileUpdateError": "Ocurrió un error salvando {{file}}",

--- a/web-ui/src/main/resources/catalog/locales/fr-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-admin.json
@@ -325,6 +325,8 @@
   "filesystem-nodeleteHelp": "Conserver les fiches dans le catalogue même si elles ont été supprimées dans le répertoire",
   "filesystem-recurse": "Parcourrir les sous-répertoires",
   "filesystem-recurseHelp": "Si sélectionné, les fiches des sous répertoires seront également recherchées",
+  "filesystem-beforeScript": "Script à exécuter avant moissonage",
+  "filesystem-beforeScriptHelp": "Peut être utiliser pour exécuter un rsync ou quelque chose d'équivalent. N'exécute rien si vide.",
   "flyTo": "Se déplacer vers",
   "formatter": "Mise en page",
   "formatterFileUpdateError": "Erreur lors de la sauvegarde du fichier {{file}}",

--- a/web-ui/src/main/resources/catalog/locales/ge-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/ge-admin.json
@@ -325,6 +325,8 @@
   "filesystem-nodeleteHelp": "Keep catalog record even if deleted at source",
   "filesystem-recurse": "Also search in subfolders",
   "filesystem-recurseHelp": "If true then the subfolders will also be search for metadata",
+  "filesystem-beforeScript": "Script to run before harvesting",
+  "filesystem-beforeScriptHelp": "Can be used to do a rsync or something similar. Runs nothing if empty.",
   "flyTo": "Fly to",
   "formatter": "Formatter",
   "formatterFileUpdateError": "Error occured while saving {{file}}",

--- a/web-ui/src/main/resources/catalog/locales/it-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/it-admin.json
@@ -321,6 +321,8 @@
     "filesystem-nodeleteHelp": "Keep catalog record even if deleted at source",
     "filesystem-recurse": "Also search in subfolders",
     "filesystem-recurseHelp": "If true then the subfolders will also be search for metadata",
+    "filesystem-beforeScript": "Script to run before harvesting",
+    "filesystem-beforeScriptHelp": "Can be used to do a rsync or something similar. Runs nothing if empty.",
     "flyTo": "Fly to",
     "formatter": "Formatter",
     "formatterFileUpdateError": "Error occured while saving {{file}}",

--- a/web-ui/src/main/resources/catalog/locales/ko-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/ko-admin.json
@@ -318,6 +318,8 @@
     "filesystem-nodeleteHelp": "원본에서 삭제된 경우에도 카탈로그 레코드 보관",
     "filesystem-recurse": "하위폴더에서도 검색",
     "filesystem-recurseHelp": "True이면 하위폴더에서도 메타데이터를 검색합니다",
+    "filesystem-beforeScript": "Script to run before harvesting",
+    "filesystem-beforeScriptHelp": "Can be used to do a rsync or something similar. Runs nothing if empty.",
     "flyTo": "도착",
     "formatter": "포메터",
     "formatterFileUpdateError": "{{file}} 파일을 저장하는 중 오류가 발생했습니다",

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.html
@@ -67,6 +67,12 @@
 
             <p class="help-block" data-translate="">applyXSLToRecordHelp</p>
         </div>
+
+        <div>
+            <label class="control-label" data-translate="">filesystem-beforeScript</label>
+            <input type="text" class="form-control" data-ng-model="harvesterSelected.site.beforeScript"/>
+            <p class="help-block" data-translate="">filesystem-beforeScriptHelp</p>
+        </div>
     </fieldset>
 
 

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/filesystem.js
@@ -15,7 +15,8 @@ var gnHarvesterfilesystem = {
                 "recurse" : true,
                 "nodelete" : true,
                 "checkFileLastModifiedForUpdate" : true,
-                "icon" : "blank.png"
+                "icon" : "blank.png",
+                "beforeScript": ""
             },
             "content" : {
                 "validate" : "NOVALIDATION",
@@ -53,7 +54,8 @@ var gnHarvesterfilesystem = {
                 + '    <checkFileLastModifiedForUpdate>' + h.site.checkFileLastModifiedForUpdate + '</checkFileLastModifiedForUpdate>'
                 + '    <directory>' + h.site.directory + '</directory>'
                 + '    <icon>' + h.site.icon + '</icon>'
-                + '  </site>' 
+                + '    <beforeScript>' + h.site.beforeScript + '</beforeScript>'
+                + '  </site>'
                 + '  <options>' 
                 + '    <oneRunOnly>' + h.options.oneRunOnly + '</oneRunOnly>' 
                 + '    <every>' + h.options.every + '</every>' 

--- a/web/src/main/webapp/loc/eng/xml/harvesting.xml
+++ b/web/src/main/webapp/loc/eng/xml/harvesting.xml
@@ -224,6 +224,7 @@
 	<schematronValidation>Xsd and Schematron Validation</schematronValidation>
 	<recurse>Also search in subfolders</recurse>
 	<checkFileLastModifiedForUpdate>Update catalog record only if file was updated</checkFileLastModifiedForUpdate>
+	<beforeScript>Script to run before harvesting</beforeScript>
 	<nodelete>Keep catalog record even if deleted at source</nodelete>
 	<server>Server</server>	
 	<database>Database</database>	

--- a/web/src/main/webapp/loc/fre/xml/harvesting.xml
+++ b/web/src/main/webapp/loc/fre/xml/harvesting.xml
@@ -224,6 +224,7 @@
 	<schematronValidation>Validation Xsd et Schematron</schematronValidation>
 	<recurse>Rechercher dans les sous répertoires également</recurse>
 	<checkFileLastModifiedForUpdate>Mettre à jour la fiche du catalogue si le fichier est plus récent</checkFileLastModifiedForUpdate>
+	<beforeScript>Script à exécuter avant moissonage</beforeScript>
 	<nodelete>Conserver la fiche du catalogue même si le fichier n'est plus présent</nodelete>
 	<server>Serveur</server>
 	<database>Base de données</database>

--- a/web/src/main/webapp/loc/ger/xml/harvesting.xml
+++ b/web/src/main/webapp/loc/ger/xml/harvesting.xml
@@ -265,6 +265,7 @@
 	<validate>Validieren</validate>
 	<recurse>Also search in subfolders</recurse>
 	<checkFileLastModifiedForUpdate>Update catalog record only if file was updated</checkFileLastModifiedForUpdate>
+	<beforeScript>Script to run before harvesting</beforeScript>
 	<nodelete>Behalte lokal, wenn Quelle gelöscht wird</nodelete>
 	<server>Server</server>
 	<database>Datenbank</database>

--- a/web/src/main/webapp/loc/ita/xml/harvesting.xml
+++ b/web/src/main/webapp/loc/ita/xml/harvesting.xml
@@ -216,6 +216,7 @@
 	<validate>Convalidare</validate>
 	<recurse>Ricorsione</recurse>
 	<checkFileLastModifiedForUpdate>Update catalog record only if file was updated</checkFileLastModifiedForUpdate>
+	<beforeScript>Script to run before harvesting</beforeScript>
 	<nodelete>Mantieni localmente se eliminato sul sito originario</nodelete>
  	<server>Server</server>	
  	<database>Database</database>	

--- a/web/src/main/webapp/xsl/harvesting/filesystem/filesystem.xsl
+++ b/web/src/main/webapp/xsl/harvesting/filesystem/filesystem.xsl
@@ -48,12 +48,17 @@
 				<td class="padded"><label for="filesystem.name"><xsl:value-of select="/root/gui/harvesting/name"/></label></td>
 				<td class="padded"><input id="filesystem.name" class="content" type="text" value="" size="200"/></td>
 			</tr>
-			
+
 			<tr>
 				<td class="padded"><label for="filesystem.directoryname"><xsl:value-of select="/root/gui/harvesting/directoryname"/></label></td>
 				<td class="padded"><input id="filesystem.directoryname" class="content" type="text" value="" size="300"/></td>
 			</tr>
-			
+
+			<tr>
+				<td class="padded"><label for="filesystem.beforeScript"><xsl:value-of select="/root/gui/harvesting/beforeScript"/></label></td>
+				<td class="padded"><input id="filesystem.beforeScript" class="content" type="text" value="" size="300"/></td>
+			</tr>
+
 			<tr>
 				<td class="padded"><label for="filesystem.recurse"><xsl:value-of select="/root/gui/harvesting/recurse"/></label></td>
 				<td class="padded"><input id="filesystem.recurse" type="checkbox" checked="on"/></td>

--- a/web/src/main/webapp/xsl/xml/harvesting/filesystem.xsl
+++ b/web/src/main/webapp/xsl/xml/harvesting/filesystem.xsl
@@ -16,6 +16,7 @@
 		<nodelete><xsl:value-of select="nodelete/value" /></nodelete>
 		<checkFileLastModifiedForUpdate><xsl:value-of select="checkFileLastModifiedForUpdate/value" /></checkFileLastModifiedForUpdate>
 		<icon><xsl:value-of select="icon/value" /></icon>
+		<beforeScript><xsl:value-of select="beforeScript/value" /></beforeScript>
 	</xsl:template>
 
 	<!-- ============================================================================================= -->


### PR DESCRIPTION
Now, the user can configure a local harvester to run a script before the
files are harvested. For example, this can be used to do a rsync of a remote
directory.