### PR TITLE
AAP

### DIFF
--- a/core/src/main/java/org/fao/geonet/geocat/kernel/AapMetadataReport.java
+++ b/core/src/main/java/org/fao/geonet/geocat/kernel/AapMetadataReport.java
@@ -1,0 +1,168 @@
+package org.fao.geonet.geocat.kernel;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.schema.iso19139.ISO19139Namespaces;
+import org.fao.geonet.schema.iso19139che.ISO19139cheNamespaces;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Attribute;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.jdom.Namespace;
+import org.jdom.Text;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import jeeves.interfaces.Service;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
+
+public class AapMetadataReport implements Service {
+
+    private final String xpMdOwner = "gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact"
+            + "/che:CHE_CI_ResponsibleParty[/gmd:role/gmd:CI_RoleCode/@codeListValue='owner']";
+    private final String xpTitle = "gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation"
+            + "/gmd:CI_Citation/gmd:title/gco:CharacterString/text()";
+    private final String xpBasicGeodataIdentifier = "gmd:identificationInfo/gmd:MD_DataIdentification"
+            + "/che:basicGeodataId/gco:CharacterString/text()";
+    private final String xpUuid = "gmd:fileIdentifier/gco:CharacterString/text()";
+    
+    // MD_geodataType ? ReferenceGeodata ???
+    
+    // TODO: point of contact with role "Specialist authority"
+    
+    
+    // maintenanceAndUpdateFrequency
+    private final String xpMaintAndUpdateFreq = "gmd:identificationInfo/che:CHE_MD_DataIdentification"
+            + "/gmd:resourceMaintenance/che:CHE_MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency"
+            + "/gmd:MD_MaintenanceFrequencyCode/@codeListValue";
+
+    // TODO: not validated by GeoCat yet ...
+
+    // AAP duration of conservation
+    private final String xpAapDuration = "gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation"
+            + "/che:CHE_Appraisal_AAP/che:CHE_DurationOfConservation/gco:integer/text()";    
+    
+    // AAP comment on the duration
+    private final String xpAapCommentDuration = "gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation"
+            + "/che:CHE_Appraisal_AAP/che:CHE_CommentOnDurationOfConservation/gco:CharacterString/text()";
+    
+    // AAP comment on archival
+    private final String xpAapCommentOnArchival = "gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation"
+            + "/che:CHE_Appraisal_AAP/che:CHE_CommentOnArchivalValue/gco:CharacterString/text()";
+    // AAP appraisal of archival
+    private final String xpAapAppraisalOfArchival = "gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation"
+            + "/che:CHE_Appraisal_AAP/che:CHE_AppraisalOfArchivalValue"
+            + "/che:CHE_AppraisalOfArchivalValueCode/@codeListValue";
+    // AAP reason for archiving value
+    private final String xpAapReasonForArchiving = "gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation"
+            + "/che:CHE_Appraisal_AAP/che:CHE_ReasonForArchivingValue"
+            + "/che:CHE_ReasonForArchivingValueCode/@codeListValue";
+
+    private final List<Namespace> xpNamespaces = Arrays.asList(new Namespace[] {
+            ISO19139Namespaces.GMD,
+            ISO19139Namespaces.GCO,
+            ISO19139cheNamespaces.CHE
+            });
+    @Override
+    public void init(Path appPath, ServiceConfig params) throws Exception {}
+
+    private String safeGetText(Element metadata, String xpath) {
+        String ret = "";
+        try {
+            Text txt = (Text) Xml.selectSingle(metadata, xpath, xpNamespaces);
+            if (txt != null) {
+                ret = txt.getText();
+            }
+        } catch (JDOMException e) {
+            return "";
+        }
+        return ret;
+    }
+    
+    private String safeGetAttribute(Element metadata, String xpath) {
+        String ret = "";
+        try {
+            Attribute att = (Attribute) Xml.selectSingle(metadata, xpath, xpNamespaces);
+            if (att != null) {
+                ret = att.getValue();
+            }
+        } catch (JDOMException e) {
+            return "";
+        }
+        return ret;
+    }
+    
+    @VisibleForTesting
+    public Element extractAapInfo(Metadata m) throws IOException, JDOMException {
+        if (m == null) {
+            throw new NullPointerException("Metadata cannot be null");
+        }
+        Element mi = new Element("metadata");
+
+        Element rawMd = m.getXmlData(false);
+
+        // TODO point of contact ? several fields, which to consider ?
+        String title = this.safeGetText(rawMd, xpTitle);        
+        String basicGeodataId = this.safeGetText(rawMd, xpBasicGeodataIdentifier);
+        String uuid = this.safeGetText(rawMd, xpUuid);
+
+        // TODO MD_GeodataType ?
+        // TODO point of contact with new role code "specialist authority"
+
+        // maintenance and update frequency
+        String updateFreq = this.safeGetAttribute(rawMd, xpMaintAndUpdateFreq);
+        // duration of conservation (xpAapDuration)
+        String durationConservation = this.safeGetText(rawMd, xpAapDuration);
+        // comment on duration (xpAapCommentDuration)
+        String commentDuration = this.safeGetText(rawMd, xpAapCommentDuration);
+        // comment on archival
+        String commentOnArchival = this.safeGetText(rawMd, xpAapCommentOnArchival);
+        // appraisal of archival (xpAapAppraisalOnArchival)
+        String appraisalOfArchival = this.safeGetAttribute(rawMd, xpAapAppraisalOfArchival);
+        //reason for archiving
+        String reasonForArchiving = this.safeGetAttribute(rawMd, xpAapReasonForArchiving);
+
+        // TODO Still missing point of contact (owner)
+        mi.addContent(new Element("title").setText(title));
+        mi.addContent(new Element("identifier").setText(basicGeodataId));
+        mi.addContent(new Element("uuid").setText(uuid));
+        // TODO md geodatatype
+        // TODO Point of contact / role code "Specialist authority"
+        mi.addContent(new Element("updateFrequency").setText(updateFreq));
+        mi.addContent(new Element("durationOfConservation").setText(durationConservation));
+        mi.addContent(new Element("commentOnDuration").setText(commentDuration));
+        mi.addContent(new Element("commentOnArchival").setText(commentOnArchival));
+        mi.addContent(new Element("appraisalOfArchival").setText(appraisalOfArchival));
+        mi.addContent(new Element("reasonForArchiving").setText(reasonForArchiving));
+
+        
+        System.out.println(Xml.getString(mi));
+        return mi;
+    }
+    
+    @Override
+    public Element exec(Element params, ServiceContext context) throws Exception {
+
+        // Point of contact (Owner)
+        // Md title
+        // identifier (basicGeodataID)
+        // UUID
+        // MD_geodataType (referenceGeodata)
+        // Point of contact (specialist authority)
+        // maintenance and update frequency (AAP)
+        // duration of conservation (AAP)
+        // comment on duration
+        //   -- 5 empty columns --
+        // comment on archival value (AAP)
+        // appraisal on archival value  (AAP)
+        // reason for archival value (AAP)
+        // -- 11 empty columns --
+        return new Element("empty");
+
+    }
+}

--- a/core/src/main/java/org/fao/geonet/geocat/kernel/AapMetadataReport.java
+++ b/core/src/main/java/org/fao/geonet/geocat/kernel/AapMetadataReport.java
@@ -34,7 +34,6 @@ public class AapMetadataReport implements Service {
     private final String xpOwnerEn = xpMdOwnerBase + "gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#EN']/text()";
     private final String xpOwnerIt = xpMdOwnerBase + "gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#IT']/text()";
 
-    // StringUtils.join() ? anyone ?
     private final String xpMdOwnerDef = xpOwnerDe +"|"+ xpOwnerFr +"|"+ xpOwnerEn +"|"+ xpOwnerIt;
 
     // SpecialistAuthority
@@ -47,9 +46,14 @@ public class AapMetadataReport implements Service {
 
     private final String xpSpecialistDef = xpSpecialistDe +"|"+ xpSpecialistFr +"|"+ xpSpecialistEn +"|"+ xpSpecialistIt;
 
+    private final String xpTitleBase = "gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title";
+    private final String xpTitleDe = xpTitleBase + "/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#DE']/text()";
+    private final String xpTitleFr = xpTitleBase + "/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#DE']/text()";
+    private final String xpTitleEn = xpTitleBase + "/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#DE']/text()";
+    private final String xpTitleIt = xpTitleBase + "/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#DE']/text()";
 
-    private final String xpTitle = "gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation"
-            + "/gmd:CI_Citation/gmd:title/gco:CharacterString/text()";
+    private final String xpTitle = xpTitleBase + "/gco:CharacterString/text()" + "|" + xpTitleDe + "|" + xpTitleFr + "|" + xpTitleEn + "|" + xpTitleIt;
+
     private final String xpBasicGeodataIdentifier = "gmd:identificationInfo//che:basicGeodataID/gco:CharacterString/text()";
     private final String xpGeodataType = "gmd:identificationInfo//che:geodataType/che:MD_geodataTypeCode/@codeListValue";
     private final String xpUuid = "gmd:fileIdentifier/gco:CharacterString/text()";
@@ -58,7 +62,7 @@ public class AapMetadataReport implements Service {
             + "gmd:MD_MaintenanceFrequencyCode/@codeListValue";
 
     // AAP
-    private final String xpAap = "gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/che:appraisal/";
+    private final String xpAap = "gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:resourceMaintenance/che:CHE_MD_MaintenanceInformation/che:appraisal/";
     // AAP duration of conservation
     private final String xpAapDuration = xpAap + "che:CHE_MD_Appraisal_AAP/che:durationOfConservation/gco:Integer/text()";
     // AAP comment on the duration
@@ -80,10 +84,16 @@ public class AapMetadataReport implements Service {
 
     private String safeGetText(Element metadata, String xpath) {
         String ret = "";
+        Object txt = null;
         try {
-            Text txt = (Text) Xml.selectSingle(metadata, xpath, xpNamespaces);
-            if (txt != null) {
-                ret = txt.getText();
+            txt = Xml.selectSingle(metadata, xpath, xpNamespaces);
+            if (txt == null) {
+                return "";
+            }
+            if (txt instanceof Text) {
+                ret = ((Text) txt).getText();
+            } else {
+                ret = txt.toString();
             }
         } catch (JDOMException e) {
             return "";
@@ -93,10 +103,17 @@ public class AapMetadataReport implements Service {
 
     private String safeGetAttribute(Element metadata, String xpath) {
         String ret = "";
+        Object att = null;
         try {
-            Attribute att = (Attribute) Xml.selectSingle(metadata, xpath, xpNamespaces);
-            if (att != null) {
-                ret = att.getValue();
+            att =  Xml.selectSingle(metadata, xpath, xpNamespaces);
+            if (att == null) {
+                return "";
+            }
+            if (att instanceof Attribute) {
+                ret = ((Attribute) att).getValue();
+            } else {
+                
+                ret = att.toString();
             }
         } catch (JDOMException e) {
             return "";
@@ -113,7 +130,7 @@ public class AapMetadataReport implements Service {
 
         Element rawMd = m.getXmlData(false);
 
-        String title = this.safeGetText(rawMd, xpTitle);        
+        String title = this.safeGetText(rawMd, xpTitle);
         String basicGeodataId = this.safeGetText(rawMd, xpBasicGeodataIdentifier);
         String uuid = this.safeGetText(rawMd, xpUuid);
         String geodataType = this.safeGetAttribute(rawMd, xpGeodataType);

--- a/core/src/main/java/org/fao/geonet/geocat/kernel/AapMetadataReport.java
+++ b/core/src/main/java/org/fao/geonet/geocat/kernel/AapMetadataReport.java
@@ -41,28 +41,17 @@ public class AapMetadataReport implements Service {
             + "/gmd:resourceMaintenance/che:CHE_MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency"
             + "/gmd:MD_MaintenanceFrequencyCode/@codeListValue";
 
-    // TODO: not validated by GeoCat yet ...
-
+    private final String xpAap = "gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/che:CHE_Appraisal_AAP/";
     // AAP duration of conservation
-    private final String xpAapDuration = "gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation"
-            + "/che:CHE_Appraisal_AAP/che:CHE_DurationOfConservation/gco:integer/text()";    
-    
+    private final String xpAapDuration = xpAap + "che:CHE_DurationOfConservation/gco:Integer/text()";
     // AAP comment on the duration
-    private final String xpAapCommentDuration = "gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation"
-            + "/che:CHE_Appraisal_AAP/che:CHE_CommentOnDurationOfConservation/gco:CharacterString/text()";
-    
-    // AAP comment on archival
-    private final String xpAapCommentOnArchival = "gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation"
-            + "/che:CHE_Appraisal_AAP/che:CHE_CommentOnArchivalValue/gco:CharacterString/text()";
+    private final String xpAapCommentDuration = xpAap + "che:CHE_CommentOnDurationOfConservation/gco:CharacterString/text()";
     // AAP appraisal of archival
-    private final String xpAapAppraisalOfArchival = "gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation"
-            + "/che:CHE_Appraisal_AAP/che:CHE_AppraisalOfArchivalValue"
-            + "/che:CHE_AppraisalOfArchivalValueCode/@codeListValue";
+    private final String xpAapAppraisalOfArchival = xpAap + "che:CHE_AppraisalOfArchivalValue/che:CHE_AppraisalOfArchivalValueCode/@codeListValue";
     // AAP reason for archiving value
-    private final String xpAapReasonForArchiving = "gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation"
-            + "/che:CHE_Appraisal_AAP/che:CHE_ReasonForArchivingValue"
-            + "/che:CHE_ReasonForArchivingValueCode/@codeListValue";
-
+    private final String xpAapReasonForArchiving = xpAap + "che:CHE_ReasonForArchivingValue/che:CHE_ReasonForArchivingValueCode/@codeListValue";
+    // AAP comment on archival
+    private final String xpAapCommentOnArchival = xpAap + "che:CHE_CommentOnArchivalValue/gco:CharacterString/text()";
     private final List<Namespace> xpNamespaces = Arrays.asList(new Namespace[] {
             ISO19139Namespaces.GMD,
             ISO19139Namespaces.GCO,
@@ -140,8 +129,6 @@ public class AapMetadataReport implements Service {
         mi.addContent(new Element("appraisalOfArchival").setText(appraisalOfArchival));
         mi.addContent(new Element("reasonForArchiving").setText(reasonForArchiving));
 
-        
-        System.out.println(Xml.getString(mi));
         return mi;
     }
     

--- a/core/src/main/java/org/fao/geonet/geocat/kernel/AapMetadataReport.java
+++ b/core/src/main/java/org/fao/geonet/geocat/kernel/AapMetadataReport.java
@@ -6,9 +6,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-import javax.persistence.EntityManager;
-
-import org.apache.lucene.search.SearcherManager;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.kernel.search.SearchManager;
 import org.fao.geonet.repository.MetadataRepository;
@@ -29,35 +26,53 @@ import jeeves.server.context.ServiceContext;
 
 public class AapMetadataReport implements Service {
 
-    private final String xpMdOwner = "gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact"
-            + "/che:CHE_CI_ResponsibleParty[/gmd:role/gmd:CI_RoleCode/@codeListValue='owner']";
+    // Owner
+    private final String xpMdOwnerBase = "gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact"
+            + "/che:CHE_CI_ResponsibleParty[gmd:role/gmd:CI_RoleCode/@codeListValue='owner']/che:organisationAcronym/";
+    private final String xpOwnerDe = xpMdOwnerBase + "gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#DE']/text()";
+    private final String xpOwnerFr = xpMdOwnerBase + "gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#FR']/text()";
+    private final String xpOwnerEn = xpMdOwnerBase + "gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#EN']/text()";
+    private final String xpOwnerIt = xpMdOwnerBase + "gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#IT']/text()";
+
+    // StringUtils.join() ? anyone ?
+    private final String xpMdOwnerDef = xpOwnerDe +"|"+ xpOwnerFr +"|"+ xpOwnerEn +"|"+ xpOwnerIt;
+
+    // SpecialistAuthority
+    private final String xpMdSpecialistBase = "gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact"
+            + "/che:CHE_CI_ResponsibleParty[gmd:role/gmd:CI_RoleCode/@codeListValue='specialistAuthority']/che:organisationAcronym/";
+    private final String xpSpecialistDe = xpMdSpecialistBase + "gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#DE']/text()";
+    private final String xpSpecialistFr = xpMdSpecialistBase + "gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#FR']/text()";
+    private final String xpSpecialistEn = xpMdSpecialistBase + "gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#EN']/text()";
+    private final String xpSpecialistIt = xpMdSpecialistBase + "gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#IT']/text()";
+
+    private final String xpSpecialistDef = xpSpecialistDe +"|"+ xpSpecialistFr +"|"+ xpSpecialistEn +"|"+ xpSpecialistIt;
+
+
     private final String xpTitle = "gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation"
             + "/gmd:CI_Citation/gmd:title/gco:CharacterString/text()";
-    private final String xpBasicGeodataIdentifier = "gmd:identificationInfo/gmd:MD_DataIdentification"
-            + "/che:basicGeodataId/gco:CharacterString/text()";
+    private final String xpBasicGeodataIdentifier = "gmd:identificationInfo//che:basicGeodataID/gco:CharacterString/text()";
+    private final String xpGeodataType = "gmd:identificationInfo//che:geodataType/che:MD_geodataTypeCode/@codeListValue";
     private final String xpUuid = "gmd:fileIdentifier/gco:CharacterString/text()";
-    
-    // MD_geodataType ? ReferenceGeodata ???
-    
-    // TODO: point of contact with role "Specialist authority"
-    
-    
+
+
     // maintenanceAndUpdateFrequency
     private final String xpMaintAndUpdateFreq = "gmd:identificationInfo/che:CHE_MD_DataIdentification"
             + "/gmd:resourceMaintenance/che:CHE_MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency"
             + "/gmd:MD_MaintenanceFrequencyCode/@codeListValue";
 
-    private final String xpAap = "gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/che:CHE_Appraisal_AAP/";
+    // AAP
+    private final String xpAap = "gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/che:appraisal/";
     // AAP duration of conservation
-    private final String xpAapDuration = xpAap + "che:CHE_DurationOfConservation/gco:Integer/text()";
+    private final String xpAapDuration = xpAap + "che:CHE_MD_Appraisal_AAP/che:durationOfConservation/gco:Integer/text()";
     // AAP comment on the duration
-    private final String xpAapCommentDuration = xpAap + "che:CHE_CommentOnDurationOfConservation/gco:CharacterString/text()";
+    private final String xpAapCommentDuration = xpAap + "che:CHE_MD_Appraisal_AAP/che:commentOnDurationOfConservation/gco:CharacterString/text()";
     // AAP appraisal of archival
-    private final String xpAapAppraisalOfArchival = xpAap + "che:CHE_AppraisalOfArchivalValue/che:CHE_AppraisalOfArchivalValueCode/@codeListValue";
+    private final String xpAapAppraisalOfArchival = xpAap + "che:CHE_MD_Appraisal_AAP/che:appraisalOfArchivalValue/che:CHE_AppraisalOfArchivalValueCode/@codeListValue";
     // AAP reason for archiving value
-    private final String xpAapReasonForArchiving = xpAap + "che:CHE_ReasonForArchivingValue/che:CHE_ReasonForArchivingValueCode/@codeListValue";
+    private final String xpAapReasonForArchiving = xpAap + "che:CHE_MD_Appraisal_AAP/che:reasonForArchivingValue/che:CHE_ReasonForArchivingValueCode/@codeListValue";
     // AAP comment on archival
-    private final String xpAapCommentOnArchival = xpAap + "che:CHE_CommentOnArchivalValue/gco:CharacterString/text()";
+    private final String xpAapCommentOnArchival = xpAap + "che:CHE_MD_Appraisal_AAP/che:commentOnArchivalValue/gco:CharacterString/text()";
+
     private final List<Namespace> xpNamespaces = Arrays.asList(new Namespace[] {
             ISO19139Namespaces.GMD,
             ISO19139Namespaces.GCO,
@@ -78,7 +93,7 @@ public class AapMetadataReport implements Service {
         }
         return ret;
     }
-    
+
     private String safeGetAttribute(Element metadata, String xpath) {
         String ret = "";
         try {
@@ -91,7 +106,7 @@ public class AapMetadataReport implements Service {
         }
         return ret;
     }
-    
+
     @VisibleForTesting
     public Element extractAapInfo(Metadata m) throws IOException, JDOMException {
         if (m == null) {
@@ -101,13 +116,11 @@ public class AapMetadataReport implements Service {
 
         Element rawMd = m.getXmlData(false);
 
-        // TODO point of contact ? several fields, which to consider ?
         String title = this.safeGetText(rawMd, xpTitle);        
         String basicGeodataId = this.safeGetText(rawMd, xpBasicGeodataIdentifier);
         String uuid = this.safeGetText(rawMd, xpUuid);
+        String geodataType = this.safeGetAttribute(rawMd, xpGeodataType);
 
-        // TODO MD_GeodataType ?
-        // TODO point of contact with new role code "specialist authority"
 
         // maintenance and update frequency
         String updateFreq = this.safeGetAttribute(rawMd, xpMaintAndUpdateFreq);
@@ -122,11 +135,17 @@ public class AapMetadataReport implements Service {
         //reason for archiving
         String reasonForArchiving = this.safeGetAttribute(rawMd, xpAapReasonForArchiving);
 
-        // TODO Still missing point of contact (owner)
+        String mdOwner      = this.safeGetText(rawMd, xpMdOwnerDef);
+        String mdSpecialist = this.safeGetText(rawMd, xpSpecialistDef);
+
         mi.addContent(new Element("title").setText(title));
         mi.addContent(new Element("identifier").setText(basicGeodataId));
         mi.addContent(new Element("uuid").setText(uuid));
-        // TODO md geodatatype
+
+        mi.addContent(new Element("geodatatype").setText(geodataType.equals("ReferenceGeodata") ? "Ja" : "Nein"));
+        mi.addContent(new Element("owner").setText(mdOwner));
+        mi.addContent(new Element("specialistAuthority").setText(mdSpecialist));
+
         // TODO Point of contact / role code "Specialist authority"
         mi.addContent(new Element("updateFrequency").setText(updateFreq));
         mi.addContent(new Element("durationOfConservation").setText(durationConservation));
@@ -137,21 +156,21 @@ public class AapMetadataReport implements Service {
 
         return mi;
     }
-    
+
     @Override
     public Element exec(Element params, ServiceContext context) throws Exception {
         Element records = new Element("records");
-        
+
         SearchManager sm = context.getBean(SearchManager.class);
         MetadataRepository mdRepo = context.getBean(MetadataRepository.class);
-        
+
         Set<Integer> mds = sm.getDocsWithAap();
         for (Integer mdId : mds) {
             Metadata curMd = mdRepo.findOne(mdId);
             
             records.addContent(extractAapInfo(curMd));
         } 
-        System.out.println(Xml.getString(records));
+
         return records;
 
     }

--- a/core/src/main/java/org/fao/geonet/geocat/kernel/AapMetadataReport.java
+++ b/core/src/main/java/org/fao/geonet/geocat/kernel/AapMetadataReport.java
@@ -28,7 +28,7 @@ public class AapMetadataReport implements Service {
 
     // Owner
     private final String xpMdOwnerBase = "gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact"
-            + "/che:CHE_CI_ResponsibleParty[gmd:role/gmd:CI_RoleCode/@codeListValue='owner']/che:organisationAcronym/";
+            + "/che:CHE_CI_ResponsibleParty[gmd:role/gmd:CI_RoleCode/@codeListValue='owner']/gmd:organisationName/";
     private final String xpOwnerDe = xpMdOwnerBase + "gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#DE']/text()";
     private final String xpOwnerFr = xpMdOwnerBase + "gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#FR']/text()";
     private final String xpOwnerEn = xpMdOwnerBase + "gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#EN']/text()";
@@ -54,11 +54,8 @@ public class AapMetadataReport implements Service {
     private final String xpGeodataType = "gmd:identificationInfo//che:geodataType/che:MD_geodataTypeCode/@codeListValue";
     private final String xpUuid = "gmd:fileIdentifier/gco:CharacterString/text()";
 
-
-    // maintenanceAndUpdateFrequency
-    private final String xpMaintAndUpdateFreq = "gmd:identificationInfo/che:CHE_MD_DataIdentification"
-            + "/gmd:resourceMaintenance/che:CHE_MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency"
-            + "/gmd:MD_MaintenanceFrequencyCode/@codeListValue";
+    private final String xpMaintAndUpdateFreq = "gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency/"
+            + "gmd:MD_MaintenanceFrequencyCode/@codeListValue";
 
     // AAP
     private final String xpAap = "gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/che:appraisal/";

--- a/core/src/test/java/org/fao/geonet/geocat/kernel/AapMetadataReportTest.java
+++ b/core/src/test/java/org/fao/geonet/geocat/kernel/AapMetadataReportTest.java
@@ -1,5 +1,6 @@
 package org.fao.geonet.geocat.kernel;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
@@ -38,8 +39,40 @@ public class AapMetadataReportTest {
         Metadata tested = new Metadata();
         tested.setData(rawMd);
 
-        Element el = amr.extractAapInfo(tested);
-        System.out.println(Xml.getString(el));
+        String el = Xml.getString(amr.extractAapInfo(tested));
+        assertTrue("Unexpected content element extracted from mdaaptest.xml",
+                   el.contains("<title>Lisières forestières prioritaires</title>")              &&
+                   el.contains("<uuid>d2ab7e4e-d135-4442-b0af-2f8892d87843</uuid>")             &&
+                   el.contains("<updateFrequency>userDefined</updateFrequency>")                &&
+                   el.contains("<durationOfConservation>3</durationOfConservation>")            &&
+                   el.contains("<commentOnDuration>3 years should be sufficient "
+                           + "for any MD - sample comment</commentOnDuration>")                 &&
+                   el.contains("<commentOnArchival>Sample comment on "
+                           + "the archival value</commentOnArchival>")                          &&
+                   el.contains("<appraisalOfArchival>S</appraisalOfArchival>")                  &&
+                   el.contains("<reasonForArchiving>evidenceOfBusinessPractice</reasonForArchiving>")
+                );
+    }
+
+    @Test
+    public void extractAapInfoOnNonAapMdTest() throws Exception {
+        URL rawMdUrl = this.getClass().getResource("mdaaptest-noaap.xml");
+        assumeTrue(rawMdUrl != null);
+        File rawMdF = new File(rawMdUrl.toURI());
+        assumeTrue(rawMdF.exists());
+
+        String rawMd = FileUtils.readFileToString(rawMdF);
+        Metadata tested = new Metadata();
+        tested.setData(rawMd);
+
+        String el = Xml.getString(amr.extractAapInfo(tested));
+
+        assertTrue("Unexpected content element extracted from mdaaptest-noaap.xml",
+                el.contains("<durationOfConservation />") &&
+                el.contains("<commentOnDuration />")      &&
+                el.contains("<commentOnArchival />")      &&
+                el.contains("<reasonForArchiving />")     &&
+                el.contains("<appraisalOfArchival />"));
     }
     
 }

--- a/core/src/test/java/org/fao/geonet/geocat/kernel/AapMetadataReportTest.java
+++ b/core/src/test/java/org/fao/geonet/geocat/kernel/AapMetadataReportTest.java
@@ -9,6 +9,8 @@ import java.net.URL;
 
 import org.apache.commons.io.FileUtils;
 import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,8 +38,8 @@ public class AapMetadataReportTest {
         Metadata tested = new Metadata();
         tested.setData(rawMd);
 
-        amr.extractAapInfo(tested);
-
+        Element el = amr.extractAapInfo(tested);
+        System.out.println(Xml.getString(el));
     }
     
 }

--- a/core/src/test/java/org/fao/geonet/geocat/kernel/AapMetadataReportTest.java
+++ b/core/src/test/java/org/fao/geonet/geocat/kernel/AapMetadataReportTest.java
@@ -40,17 +40,32 @@ public class AapMetadataReportTest {
         tested.setData(rawMd);
 
         String el = Xml.getString(amr.extractAapInfo(tested));
-        assertTrue("Unexpected content element extracted from mdaaptest.xml",
-                   el.contains("<title>Lisières forestières prioritaires</title>")              &&
-                   el.contains("<uuid>d2ab7e4e-d135-4442-b0af-2f8892d87843</uuid>")             &&
-                   el.contains("<updateFrequency>userDefined</updateFrequency>")                &&
-                   el.contains("<durationOfConservation>3</durationOfConservation>")            &&
-                   el.contains("<commentOnDuration>3 years should be sufficient "
-                           + "for any MD - sample comment</commentOnDuration>")                 &&
+
+        assertTrue("Unexpected title",
+                   el.contains("<title>Lisières forestières prioritaires</title>"));
+        assertTrue("Unexpected geodata ID",
+                el.contains("<identifier>101.2-TG</identifier>"));
+        assertTrue("Unexpected UUID",
+                el.contains("<uuid>d2ab7e4e-d135-4442-b0af-2f8892d87843</uuid>"));
+        assertTrue("Unexpected geodatatype",
+                el.contains("<geodatatype>Ja</geodatatype>"));
+        assertTrue("Unexpected owner",
+                el.contains("<owner>SFF</owner>"));
+        assertTrue("Unexpected owner",
+        el.contains("<specialistAuthority>Camptocamp</specialistAuthority>"));
+        assertTrue("Unexpected update frequency",
+                   el.contains("<updateFrequency>userDefined</updateFrequency>"));
+        assertTrue("Unexpected duration of conservation",
+                   el.contains("<durationOfConservation>3</durationOfConservation>"));
+        assertTrue("Unexpected comment on duration",
+                   el.contains("<commentOnDuration>Sample comment on the duration of conservation</commentOnDuration>"));
+        assertTrue("Unexpected comment on archival",
                    el.contains("<commentOnArchival>Sample comment on "
-                           + "the archival value</commentOnArchival>")                          &&
-                   el.contains("<appraisalOfArchival>S</appraisalOfArchival>")                  &&
-                   el.contains("<reasonForArchiving>evidenceOfBusinessPractice</reasonForArchiving>")
+                           + "the archival value</commentOnArchival>"));
+        assertTrue("Unexpected appraisal of archival value",
+                   el.contains("<appraisalOfArchival>S</appraisalOfArchival>"));
+        assertTrue("Unexpected reason for archiving value",
+                   el.contains("<reasonForArchiving>definingPowers</reasonForArchiving>")
                 );
     }
 

--- a/core/src/test/java/org/fao/geonet/geocat/kernel/AapMetadataReportTest.java
+++ b/core/src/test/java/org/fao/geonet/geocat/kernel/AapMetadataReportTest.java
@@ -1,0 +1,43 @@
+package org.fao.geonet.geocat.kernel;
+
+import static org.junit.Assume.assumeTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.apache.commons.io.FileUtils;
+import org.fao.geonet.domain.Metadata;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class AapMetadataReportTest {
+
+    private final AapMetadataReport amr = new AapMetadataReport();
+
+    @Before
+    public void setUp() {    
+    }
+    
+    @After
+    public void tearDown() {}
+    
+    @Test
+    public void extractAapInfoTest() throws Exception {
+        URL rawMdUrl = this.getClass().getResource("mdaaptest.xml");
+        assumeTrue(rawMdUrl != null);
+        File rawMdF = new File(rawMdUrl.toURI());
+        assumeTrue(rawMdF.exists());
+
+        String rawMd = FileUtils.readFileToString(rawMdF);
+        Metadata tested = new Metadata();
+        tested.setData(rawMd);
+
+        amr.extractAapInfo(tested);
+
+    }
+    
+}

--- a/core/src/test/java/org/fao/geonet/geocat/kernel/AapMetadataReportTest.java
+++ b/core/src/test/java/org/fao/geonet/geocat/kernel/AapMetadataReportTest.java
@@ -1,19 +1,16 @@
 package org.fao.geonet.geocat.kernel;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.apache.commons.io.FileUtils;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.utils.Xml;
-import org.jdom.Element;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 
@@ -21,17 +18,10 @@ public class AapMetadataReportTest {
 
     private final AapMetadataReport amr = new AapMetadataReport();
 
-    @Before
-    public void setUp() {
-    }
-    
-    @After
-    public void tearDown() {}
-    
     @Test
     public void extractAapInfoTest() throws Exception {
         URL rawMdUrl = this.getClass().getResource("mdaaptest.xml");
-        assumeTrue(rawMdUrl != null);
+        assumeNotNull(rawMdUrl);
         File rawMdF = new File(rawMdUrl.toURI());
         assumeTrue(rawMdF.exists());
 
@@ -40,7 +30,7 @@ public class AapMetadataReportTest {
         tested.setData(rawMd);
 
         String el = Xml.getString(amr.extractAapInfo(tested));
-
+        System.out.println(el);
         assertTrue("Unexpected title",
                    el.contains("<title>Lisières forestières prioritaires</title>"));
         assertTrue("Unexpected geodata ID",
@@ -50,11 +40,11 @@ public class AapMetadataReportTest {
         assertTrue("Unexpected geodatatype",
                 el.contains("<geodatatype>Ja</geodatatype>"));
         assertTrue("Unexpected owner",
-                el.contains("<owner>SFF</owner>"));
+                el.contains("<owner>Service des forêts et de la faune</owner>"));
         assertTrue("Unexpected owner",
         el.contains("<specialistAuthority>Camptocamp</specialistAuthority>"));
         assertTrue("Unexpected update frequency",
-                   el.contains("<updateFrequency>userDefined</updateFrequency>"));
+                   el.contains("<updateFrequency>asNeeded</updateFrequency>"));
         assertTrue("Unexpected duration of conservation",
                    el.contains("<durationOfConservation>3</durationOfConservation>"));
         assertTrue("Unexpected comment on duration",
@@ -72,7 +62,7 @@ public class AapMetadataReportTest {
     @Test
     public void extractAapInfoOnNonAapMdTest() throws Exception {
         URL rawMdUrl = this.getClass().getResource("mdaaptest-noaap.xml");
-        assumeTrue(rawMdUrl != null);
+        assumeNotNull(rawMdUrl);
         File rawMdF = new File(rawMdUrl.toURI());
         assumeTrue(rawMdF.exists());
 
@@ -93,7 +83,7 @@ public class AapMetadataReportTest {
     @Test
     public void extractAapInfoFromCustomerProvidedMd() throws Exception {
         URL rawMdUrl = this.getClass().getResource("aap.xml");
-        assumeTrue(rawMdUrl != null);
+        assumeNotNull(rawMdUrl);
         File rawMdF = new File(rawMdUrl.toURI());
         assumeTrue(rawMdF.exists());
         
@@ -103,22 +93,34 @@ public class AapMetadataReportTest {
         tested.setData(rawMd);
 
         
-        String el = Xml.getString(amr.extractAapInfo(tested));  
-        System.out.println(el);
+        String el = Xml.getString(amr.extractAapInfo(tested));
+        assertFalse("Unexpected content element extracted from aap.xml",
+                el.contains("<title />")                  &&
+                el.contains("<identifier />")             &&
+                el.contains("<uuid />")                   &&
+                el.contains("<geodatatype />")            &&
+                el.contains("<owner />")                  &&
+                el.contains("<specialistAuthority />")    &&
+                el.contains("<updateFrequency />")        &&
+                el.contains("<durationOfConservation />") &&
+                el.contains("<commentOnDuration />")      &&
+                el.contains("<commentOnArchival />")      &&
+                el.contains("<appraisalOfArchival />")    &&
+                el.contains("<reasonForArchiving />"));
     }
     
     @Test
     public void testXpathIndexFieldAap() throws Exception {
         // mdaaptest-noaap.xml for not containing kw, aap.xml for a containing one
         URL rawMdUrl = this.getClass().getResource("aap.xml");
-        assumeTrue(rawMdUrl != null);
+        assumeNotNull(rawMdUrl);
         File rawMdF = new File(rawMdUrl.toURI());
         assumeTrue(rawMdF.exists());
         String rawMd = FileUtils.readFileToString(rawMdF);
 
-        // xpath used for AAP field indexation (see iso19139.che/default.xsl around line 453)
+        // xpath used for AAP field indexation (see iso19139.che/default-language.xsl around line 453)
         String xpath = "gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:descriptiveKeywords"+
-                "/gmd:MD_Keywords/gmd:keyword/gco:CharacterString[text() = 'AAP-Bund']";
+                "/gmd:MD_Keywords/gmd:keyword/gco:CharacterString[text() = 'Aufbewahrungs- und Archivierungsplanung AAP']";
 
         boolean b = Xml.selectBoolean(Xml.loadString(rawMd, false), xpath);
         assertTrue("Expected true, false found", b);

--- a/core/src/test/java/org/fao/geonet/geocat/kernel/AapMetadataReportTest.java
+++ b/core/src/test/java/org/fao/geonet/geocat/kernel/AapMetadataReportTest.java
@@ -22,7 +22,7 @@ public class AapMetadataReportTest {
     private final AapMetadataReport amr = new AapMetadataReport();
 
     @Before
-    public void setUp() {    
+    public void setUp() {
     }
     
     @After
@@ -88,6 +88,40 @@ public class AapMetadataReportTest {
                 el.contains("<commentOnArchival />")      &&
                 el.contains("<reasonForArchiving />")     &&
                 el.contains("<appraisalOfArchival />"));
+    }
+    
+    @Test
+    public void extractAapInfoFromCustomerProvidedMd() throws Exception {
+        URL rawMdUrl = this.getClass().getResource("aap.xml");
+        assumeTrue(rawMdUrl != null);
+        File rawMdF = new File(rawMdUrl.toURI());
+        assumeTrue(rawMdF.exists());
+        
+
+        String rawMd = FileUtils.readFileToString(rawMdF);
+        Metadata tested = new Metadata();
+        tested.setData(rawMd);
+
+        
+        String el = Xml.getString(amr.extractAapInfo(tested));  
+        System.out.println(el);
+    }
+    
+    @Test
+    public void testXpathIndexFieldAap() throws Exception {
+        // mdaaptest-noaap.xml for not containing kw, aap.xml for a containing one
+        URL rawMdUrl = this.getClass().getResource("aap.xml");
+        assumeTrue(rawMdUrl != null);
+        File rawMdF = new File(rawMdUrl.toURI());
+        assumeTrue(rawMdF.exists());
+        String rawMd = FileUtils.readFileToString(rawMdF);
+
+        // xpath used for AAP field indexation (see iso19139.che/default.xsl around line 453)
+        String xpath = "gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:descriptiveKeywords"+
+                "/gmd:MD_Keywords/gmd:keyword/gco:CharacterString[text() = 'AAP-Bund']";
+
+        boolean b = Xml.selectBoolean(Xml.loadString(rawMd, false), xpath);
+        assertTrue("Expected true, false found", b);
     }
     
 }

--- a/core/src/test/resources/org/fao/geonet/geocat/kernel/aap.xml
+++ b/core/src/test/resources/org/fao/geonet/geocat/kernel/aap.xml
@@ -7,10 +7,10 @@
     <gco:CharacterString>ger</gco:CharacterString>
   </gmd:language>
   <gmd:characterSet xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
-    <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+    <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8"/>
   </gmd:characterSet>
   <gmd:hierarchyLevel xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
-    <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset" />
+    <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset"/>
   </gmd:hierarchyLevel>
   <gmd:contact xmlns:xlink="http://www.w3.org/1999/xlink" xlink:show="embed">
     <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
@@ -94,7 +94,7 @@
         </gmd:CI_Contact>
       </gmd:contactInfo>
       <gmd:role>
-        <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="pointOfContact" />
+        <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="pointOfContact"/>
       </gmd:role>
       <che:individualFirstName>
         <gco:CharacterString>Rolf</gco:CharacterString>
@@ -133,50 +133,50 @@
   <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
     <gmd:PT_Locale id="DE">
       <gmd:languageCode>
-        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger" />
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger"/>
       </gmd:languageCode>
       <gmd:characterEncoding>
-        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8"/>
       </gmd:characterEncoding>
     </gmd:PT_Locale>
   </gmd:locale>
   <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
     <gmd:PT_Locale id="FR">
       <gmd:languageCode>
-        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre"/>
       </gmd:languageCode>
       <gmd:characterEncoding>
-        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8"/>
       </gmd:characterEncoding>
     </gmd:PT_Locale>
   </gmd:locale>
   <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
     <gmd:PT_Locale id="IT">
       <gmd:languageCode>
-        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ita" />
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ita"/>
       </gmd:languageCode>
       <gmd:characterEncoding>
-        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8"/>
       </gmd:characterEncoding>
     </gmd:PT_Locale>
   </gmd:locale>
   <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
     <gmd:PT_Locale id="EN">
       <gmd:languageCode>
-        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng" />
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng"/>
       </gmd:languageCode>
       <gmd:characterEncoding>
-        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8"/>
       </gmd:characterEncoding>
     </gmd:PT_Locale>
   </gmd:locale>
   <gmd:locale>
     <gmd:PT_Locale id="RM">
       <gmd:languageCode>
-        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="roh" />
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="roh"/>
       </gmd:languageCode>
       <gmd:characterEncoding>
-        <gmd:MD_CharacterSetCode codeListValue="utf8" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" />
+        <gmd:MD_CharacterSetCode codeListValue="utf8" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode"/>
       </gmd:characterEncoding>
     </gmd:PT_Locale>
   </gmd:locale>
@@ -185,7 +185,7 @@
       <gmd:geometricObjects>
         <gmd:MD_GeometricObjects>
           <gmd:geometricObjectType>
-            <gmd:MD_GeometricObjectTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_GeometricObjectTypeCode" codeListValue="surface" />
+            <gmd:MD_GeometricObjectTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_GeometricObjectTypeCode" codeListValue="surface"/>
           </gmd:geometricObjectType>
           <gmd:geometricObjectCount>
             <gco:Integer>1</gco:Integer>
@@ -269,7 +269,7 @@
                 <gco:Date>2009-01-01</gco:Date>
               </gmd:date>
               <gmd:dateType>
-                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision" />
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision"/>
               </gmd:dateType>
             </gmd:CI_Date>
           </gmd:date>
@@ -309,8 +309,41 @@
           </gmd:textGroup>
         </gmd:PT_FreeText>
       </gmd:abstract>
+      <gmd:resourceMaintenance>
+        <che:CHE_MD_MaintenanceInformation gco:isoType="gmd:MD_MaintenanceInformation">
+          <che:appraisal>
+            <che:CHE_MD_Appraisal_AAP>
+              <che:durationOfConservation>
+                <gco:Integer>178</gco:Integer>
+              </che:durationOfConservation>
+              <che:commentOnDurationOfConservation xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>180 minus 2</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">180 minus 2</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </che:commentOnDurationOfConservation>
+              <che:appraisalOfArchivalValue>
+                <che:CHE_AppraisalOfArchivalValueCode codeList="#CHE_AppraisalOfArchivalValueCode" codeListValue="S"/>
+              </che:appraisalOfArchivalValue>
+              <che:reasonForArchivingValue>
+                <che:CHE_ReasonForArchivingValueCode codeList="#CHE_ReasonForArchivingValueCode" codeListValue="legalRelevance"/>
+              </che:reasonForArchivingValue>
+              <che:commentOnArchivalValue xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Beispiel zu "Remarque concernant la valeur archivistique"</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Beispiel zu "Remarque concernant la valeur archivistique"</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </che:commentOnArchivalValue>
+            </che:CHE_MD_Appraisal_AAP>
+          </che:appraisal>
+        </che:CHE_MD_MaintenanceInformation>
+      </gmd:resourceMaintenance>
       <gmd:status>
-        <gmd:MD_ProgressCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ProgressCode" codeListValue="completed" />
+        <gmd:MD_ProgressCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ProgressCode" codeListValue="completed"/>
       </gmd:status>
       <gmd:pointOfContact xmlns:xlink="http://www.w3.org/1999/xlink" xlink:show="embed">
         <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
@@ -394,7 +427,7 @@
             </gmd:CI_Contact>
           </gmd:contactInfo>
           <gmd:role>
-            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="pointOfContact" />
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="pointOfContact"/>
           </gmd:role>
           <che:individualFirstName>
             <gco:CharacterString>Rolf</gco:CharacterString>
@@ -509,7 +542,7 @@
             </gmd:CI_Contact>
           </gmd:contactInfo>
           <gmd:role>
-            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="specialistAuthority" />
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="specialistAuthority"/>
           </gmd:role>
           <che:individualFirstName>
             <gco:CharacterString>André</gco:CharacterString>
@@ -579,7 +612,7 @@
             </gmd:CI_Contact>
           </gmd:contactInfo>
           <gmd:role>
-            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="owner" />
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="owner"/>
           </gmd:role>
           <che:individualFirstName>
             <gco:CharacterString>Carla</gco:CharacterString>
@@ -592,7 +625,7 @@
       <gmd:descriptiveKeywords xmlns:xlink="http://www.w3.org/1999/xlink">
         <gmd:MD_Keywords>
           <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>AAP-Bund</gco:CharacterString>
+            <gco:CharacterString>Aufbewahrungs- und Archivierungsplanung AAP</gco:CharacterString>
             <gmd:PT_FreeText>
               <gmd:textGroup>
                 <gmd:LocalisedCharacterString locale="#EN">AAP-Bund</gmd:LocalisedCharacterString>
@@ -612,7 +645,7 @@
             </gmd:PT_FreeText>
           </gmd:keyword>
           <gmd:type>
-            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="_none_" />
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="_none_"/>
           </gmd:type>
           <gmd:thesaurusName>
             <gmd:CI_Citation>
@@ -625,7 +658,7 @@
                     <gco:Date>2016-07-25</gco:Date>
                   </gmd:date>
                   <gmd:dateType>
-                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
                   </gmd:dateType>
                 </gmd:CI_Date>
               </gmd:date>
@@ -658,7 +691,7 @@
                 <gmd:LocalisedCharacterString locale="#FR">conservation du sol</gmd:LocalisedCharacterString>
               </gmd:textGroup>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#RM" />
+                <gmd:LocalisedCharacterString locale="#RM"/>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:keyword>
@@ -678,7 +711,7 @@
                 <gmd:LocalisedCharacterString locale="#FR">planification de l'espace physique</gmd:LocalisedCharacterString>
               </gmd:textGroup>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#RM" />
+                <gmd:LocalisedCharacterString locale="#RM"/>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:keyword>
@@ -698,7 +731,7 @@
                 <gmd:LocalisedCharacterString locale="#FR">développement durable</gmd:LocalisedCharacterString>
               </gmd:textGroup>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#RM" />
+                <gmd:LocalisedCharacterString locale="#RM"/>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:keyword>
@@ -718,12 +751,12 @@
                 <gmd:LocalisedCharacterString locale="#FR">protection de la montagne</gmd:LocalisedCharacterString>
               </gmd:textGroup>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#RM" />
+                <gmd:LocalisedCharacterString locale="#RM"/>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:keyword>
           <gmd:type>
-            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="_none_" />
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="_none_"/>
           </gmd:type>
           <gmd:thesaurusName>
             <gmd:CI_Citation>
@@ -736,7 +769,7 @@
                     <gco:Date>2015-09-10</gco:Date>
                   </gmd:date>
                   <gmd:dateType>
-                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
                   </gmd:dateType>
                 </gmd:CI_Date>
               </gmd:date>
@@ -769,7 +802,7 @@
                 <gmd:LocalisedCharacterString locale="#FR">transport</gmd:LocalisedCharacterString>
               </gmd:textGroup>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#RM" />
+                <gmd:LocalisedCharacterString locale="#RM"/>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:keyword>
@@ -789,12 +822,12 @@
                 <gmd:LocalisedCharacterString locale="#FR">politique environnementale</gmd:LocalisedCharacterString>
               </gmd:textGroup>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#RM" />
+                <gmd:LocalisedCharacterString locale="#RM"/>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:keyword>
           <gmd:type>
-            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="theme" />
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="theme"/>
           </gmd:type>
           <gmd:thesaurusName>
             <gmd:CI_Citation>
@@ -807,7 +840,7 @@
                     <gco:Date>2009-09-22</gco:Date>
                   </gmd:date>
                   <gmd:dateType>
-                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
                   </gmd:dateType>
                 </gmd:CI_Date>
               </gmd:date>
@@ -860,12 +893,12 @@
                 <gmd:LocalisedCharacterString locale="#FR">géoportail e-geo.ch</gmd:LocalisedCharacterString>
               </gmd:textGroup>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#RM" />
+                <gmd:LocalisedCharacterString locale="#RM"/>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:keyword>
           <gmd:type>
-            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="_none_" />
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="_none_"/>
           </gmd:type>
           <gmd:thesaurusName>
             <gmd:CI_Citation>
@@ -878,7 +911,7 @@
                     <gco:Date>2016-01-12</gco:Date>
                   </gmd:date>
                   <gmd:dateType>
-                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
                   </gmd:dateType>
                 </gmd:CI_Date>
               </gmd:date>
@@ -911,7 +944,7 @@
                 <gmd:LocalisedCharacterString locale="#FR">Unités administratives</gmd:LocalisedCharacterString>
               </gmd:textGroup>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#RM" />
+                <gmd:LocalisedCharacterString locale="#RM"/>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:keyword>
@@ -931,12 +964,12 @@
                 <gmd:LocalisedCharacterString locale="#FR">Installations de suivi environnemental</gmd:LocalisedCharacterString>
               </gmd:textGroup>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#RM" />
+                <gmd:LocalisedCharacterString locale="#RM"/>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:keyword>
           <gmd:type>
-            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="theme" />
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="theme"/>
           </gmd:type>
           <gmd:thesaurusName>
             <gmd:CI_Citation>
@@ -949,7 +982,7 @@
                     <gco:Date>2008-06-01</gco:Date>
                   </gmd:date>
                   <gmd:dateType>
-                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
                   </gmd:dateType>
                 </gmd:CI_Date>
               </gmd:date>
@@ -965,7 +998,7 @@
         </gmd:MD_Keywords>
       </gmd:descriptiveKeywords>
       <gmd:spatialRepresentationType>
-        <gmd:MD_SpatialRepresentationTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_SpatialRepresentationTypeCode" codeListValue="vector" />
+        <gmd:MD_SpatialRepresentationTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_SpatialRepresentationTypeCode" codeListValue="vector"/>
       </gmd:spatialRepresentationType>
       <gmd:spatialResolution>
         <gmd:MD_Resolution>
@@ -988,14 +1021,14 @@
         <gco:CharacterString>ita</gco:CharacterString>
       </gmd:language>
       <gmd:characterSet>
-        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8"/>
       </gmd:characterSet>
-      <gmd:topicCategory />
-      <gmd:topicCategory />
-      <gmd:topicCategory />
-      <gmd:topicCategory />
-      <gmd:topicCategory />
-      <gmd:topicCategory />
+      <gmd:topicCategory/>
+      <gmd:topicCategory/>
+      <gmd:topicCategory/>
+      <gmd:topicCategory/>
+      <gmd:topicCategory/>
+      <gmd:topicCategory/>
       <gmd:topicCategory>
         <gmd:MD_TopicCategoryCode>planningCadastre</gmd:MD_TopicCategoryCode>
       </gmd:topicCategory>
@@ -1095,7 +1128,7 @@
         <gco:CharacterString>3.1</gco:CharacterString>
       </che:basicGeodataID>
       <che:basicGeodataIDType>
-        <che:basicGeodataIDTypeCode codeList="#basicGeodataIDTypeCode" codeListValue="federal" />
+        <che:basicGeodataIDTypeCode codeList="#basicGeodataIDTypeCode" codeListValue="federal"/>
       </che:basicGeodataIDType>
     </che:CHE_MD_DataIdentification>
   </gmd:identificationInfo>
@@ -1123,14 +1156,14 @@
                 <gco:Date>2009-09-18</gco:Date>
               </gmd:date>
               <gmd:dateType>
-                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_DateTypeCode" codeListValue="creation" />
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_DateTypeCode" codeListValue="creation"/>
               </gmd:dateType>
             </gmd:CI_Date>
           </gmd:date>
         </gmd:CI_Citation>
       </gmd:featureCatalogueCitation>
       <che:modelType>
-        <che:CHE_MD_modelTypeCode codeList="#CHE_MD_modelTypeCode" codeListValue="INTERLIS2" />
+        <che:CHE_MD_modelTypeCode codeList="#CHE_MD_modelTypeCode" codeListValue="INTERLIS2"/>
       </che:modelType>
     </che:CHE_MD_FeatureCatalogueDescription>
   </gmd:contentInfo>
@@ -1158,14 +1191,14 @@
                 <gco:Date>2009-09-18</gco:Date>
               </gmd:date>
               <gmd:dateType>
-                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_DateTypeCode" codeListValue="creation" />
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_DateTypeCode" codeListValue="creation"/>
               </gmd:dateType>
             </gmd:CI_Date>
           </gmd:date>
         </gmd:CI_Citation>
       </gmd:featureCatalogueCitation>
       <che:modelType>
-        <che:CHE_MD_modelTypeCode codeList="#CHE_MD_modelTypeCode" codeListValue="INTERLIS1" />
+        <che:CHE_MD_modelTypeCode codeList="#CHE_MD_modelTypeCode" codeListValue="INTERLIS1"/>
       </che:modelType>
     </che:CHE_MD_FeatureCatalogueDescription>
   </gmd:contentInfo>
@@ -1193,14 +1226,14 @@
                 <gco:Date>2009-09-18</gco:Date>
               </gmd:date>
               <gmd:dateType>
-                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_DateTypeCode" codeListValue="creation" />
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_DateTypeCode" codeListValue="creation"/>
               </gmd:dateType>
             </gmd:CI_Date>
           </gmd:date>
         </gmd:CI_Citation>
       </gmd:featureCatalogueCitation>
       <che:modelType>
-        <che:CHE_MD_modelTypeCode codeList="#CHE_MD_modelTypeCode" codeListValue="UMLdiagram" />
+        <che:CHE_MD_modelTypeCode codeList="#CHE_MD_modelTypeCode" codeListValue="UMLdiagram"/>
       </che:modelType>
     </che:CHE_MD_FeatureCatalogueDescription>
   </gmd:contentInfo>
@@ -1228,14 +1261,14 @@
                 <gco:Date>2009-09-18</gco:Date>
               </gmd:date>
               <gmd:dateType>
-                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_DateTypeCode" codeListValue="creation" />
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_DateTypeCode" codeListValue="creation"/>
               </gmd:dateType>
             </gmd:CI_Date>
           </gmd:date>
         </gmd:CI_Citation>
       </gmd:featureCatalogueCitation>
       <che:modelType>
-        <che:CHE_MD_modelTypeCode codeList="#CHE_MD_modelTypeCode" codeListValue="FeatureDescription" />
+        <che:CHE_MD_modelTypeCode codeList="#CHE_MD_modelTypeCode" codeListValue="FeatureDescription"/>
       </che:modelType>
     </che:CHE_MD_FeatureCatalogueDescription>
   </gmd:contentInfo>
@@ -1317,7 +1350,7 @@
                 </gmd:PT_FreeText>
               </gmd:description>
               <gmd:function>
-                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download" />
+                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download"/>
               </gmd:function>
             </gmd:CI_OnlineResource>
           </gmd:onLine>
@@ -1510,7 +1543,7 @@
                 </gmd:PT_FreeText>
               </gmd:description>
               <gmd:function>
-                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information" />
+                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information"/>
               </gmd:function>
             </gmd:CI_OnlineResource>
           </gmd:onLine>
@@ -1545,7 +1578,7 @@
                 </gmd:PT_FreeText>
               </gmd:description>
               <gmd:function>
-                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information" />
+                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information"/>
               </gmd:function>
             </gmd:CI_OnlineResource>
           </gmd:onLine>
@@ -1586,7 +1619,7 @@
                 </gmd:PT_FreeText>
               </gmd:description>
               <gmd:function>
-                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information" />
+                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information"/>
               </gmd:function>
             </gmd:CI_OnlineResource>
           </gmd:onLine>
@@ -1599,7 +1632,7 @@
       <gmd:scope>
         <gmd:DQ_Scope>
           <gmd:level>
-            <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset" />
+            <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset"/>
           </gmd:level>
         </gmd:DQ_Scope>
       </gmd:scope>
@@ -1618,60 +1651,31 @@
     </gmd:DQ_DataQuality>
   </gmd:dataQualityInfo>
   <gmd:metadataConstraints>
-    <che:CHE_MD_LegalConstraints gco:isoType="gmd:MD_LegalConstraints" />
+    <che:CHE_MD_LegalConstraints gco:isoType="gmd:MD_LegalConstraints"/>
   </gmd:metadataConstraints>
   <gmd:metadataMaintenance>
     <che:CHE_MD_MaintenanceInformation gco:isoType="gmd:MD_MaintenanceInformation">
       <gmd:maintenanceAndUpdateFrequency>
-        <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="notPlanned" />
+        <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="notPlanned"/>
       </gmd:maintenanceAndUpdateFrequency>
-      <che:appraisal>
-        <che:CHE_MD_Appraisal_AAP>
-          <che:durationOfConservation>
-            <gco:Integer>178</gco:Integer>
-          </che:durationOfConservation>
-          <che:commentOnDurationOfConservation xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>180 minus 2</gco:CharacterString>
-            <gmd:PT_FreeText>
-              <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#DE">180 minus 2</gmd:LocalisedCharacterString>
-              </gmd:textGroup>
-            </gmd:PT_FreeText>
-          </che:commentOnDurationOfConservation>
-          <che:appraisalOfArchivalValue>
-            <che:CHE_AppraisalOfArchivalValueCode codeList="#CHE_AppraisalOfArchivalValueCode" codeListValue="S" />
-          </che:appraisalOfArchivalValue>
-          <che:reasonForArchivingValue>
-            <che:CHE_ReasonForArchivingValueCode codeList="#CHE_ReasonForArchivingValueCode" codeListValue="legalRelevance" />
-          </che:reasonForArchivingValue>
-          <che:commentOnArchivalValue xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>Beispiel zu "Remarque concernant la valeur archivistique"</gco:CharacterString>
-            <gmd:PT_FreeText>
-              <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#DE">Beispiel zu "Remarque concernant la valeur archivistique"</gmd:LocalisedCharacterString>
-              </gmd:textGroup>
-            </gmd:PT_FreeText>
-          </che:commentOnArchivalValue>
-        </che:CHE_MD_Appraisal_AAP>
-      </che:appraisal>
     </che:CHE_MD_MaintenanceInformation>
   </gmd:metadataMaintenance>
   <che:legislationInformation xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
     <che:CHE_MD_Legislation gco:isoType="gmd:MD_Legislation">
       <che:country>
-        <gmd:Country codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#Country" codeListValue="CH" />
+        <gmd:Country codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#Country" codeListValue="CH"/>
       </che:country>
       <che:language>
-        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger" />
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger"/>
       </che:language>
       <che:language>
-        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre"/>
       </che:language>
       <che:language>
-        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ita" />
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ita"/>
       </che:language>
       <che:legislationType>
-        <che:CHE_CI_LegislationCode codeList="#CHE_CI_LegislationCode" codeListValue="internationalObligation" />
+        <che:CHE_CI_LegislationCode codeList="#CHE_CI_LegislationCode" codeListValue="internationalObligation"/>
       </che:legislationType>
       <che:internalReference>
         <gco:CharacterString>0.700.1</gco:CharacterString>
@@ -1712,7 +1716,7 @@
                 <gco:Date>1991-11-07</gco:Date>
               </gmd:date>
               <gmd:dateType>
-                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation" />
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation"/>
               </gmd:dateType>
             </gmd:CI_Date>
           </gmd:date>
@@ -1723,19 +1727,19 @@
   <che:legislationInformation xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
     <che:CHE_MD_Legislation gco:isoType="gmd:MD_Legislation">
       <che:country>
-        <gmd:Country codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#Country" codeListValue="CH" />
+        <gmd:Country codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#Country" codeListValue="CH"/>
       </che:country>
       <che:language>
-        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger" />
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger"/>
       </che:language>
       <che:language>
-        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre"/>
       </che:language>
       <che:language>
-        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ita" />
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ita"/>
       </che:language>
       <che:legislationType>
-        <che:CHE_CI_LegislationCode codeList="#CHE_CI_LegislationCode" codeListValue="nationalDecree" />
+        <che:CHE_CI_LegislationCode codeList="#CHE_CI_LegislationCode" codeListValue="nationalDecree"/>
       </che:legislationType>
       <che:internalReference>
         <gco:CharacterString>510.620</gco:CharacterString>
@@ -1776,7 +1780,7 @@
                 <gco:Date>2008-05-21</gco:Date>
               </gmd:date>
               <gmd:dateType>
-                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation" />
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation"/>
               </gmd:dateType>
             </gmd:CI_Date>
           </gmd:date>
@@ -1786,7 +1790,7 @@
                 <gco:Date>2008-07-01</gco:Date>
               </gmd:date>
               <gmd:dateType>
-                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
               </gmd:dateType>
             </gmd:CI_Date>
           </gmd:date>

--- a/core/src/test/resources/org/fao/geonet/geocat/kernel/aap.xml
+++ b/core/src/test/resources/org/fao/geonet/geocat/kernel/aap.xml
@@ -1,0 +1,1797 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<che:CHE_MD_Metadata xmlns:che="http://www.geocat.ch/2008/che" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gml="http://www.opengis.net/gml" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" gco:isoType="gmd:MD_Metadata" xsi:schemaLocation="http://www.geocat.ch/2008/che http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd http://www.isotc211.org/2005/srv http://schemas.opengis.net/iso/19139/20060504/srv/srv.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>1dea02fb-3905-43a6-84c4-bb218167a14e</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gco:CharacterString>ger</gco:CharacterString>
+  </gmd:language>
+  <gmd:characterSet xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+  </gmd:characterSet>
+  <gmd:hierarchyLevel xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset" />
+  </gmd:hierarchyLevel>
+  <gmd:contact xmlns:xlink="http://www.w3.org/1999/xlink" xlink:show="embed">
+    <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
+      <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Bundesamt für Raumentwicklung</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">Federal Office for Spatial Development</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">Bundesamt für Raumentwicklung</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Office fédéral du développement territorial</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#IT">Ufficio federale dello sviluppo territoriale</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#RM">Bundesamt für Raumentwicklung</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:organisationName>
+      <gmd:contactInfo>
+        <gmd:CI_Contact>
+          <gmd:phone>
+            <che:CHE_CI_Telephone gco:isoType="gmd:CI_Telephone">
+              <che:directNumber>
+                <gco:CharacterString>+41 58 462 01 43</gco:CharacterString>
+              </che:directNumber>
+            </che:CHE_CI_Telephone>
+          </gmd:phone>
+          <gmd:address>
+            <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+              <gmd:city>
+                <gco:CharacterString>Ittigen</gco:CharacterString>
+              </gmd:city>
+              <gmd:postalCode>
+                <gco:CharacterString>3063</gco:CharacterString>
+              </gmd:postalCode>
+              <gmd:country>
+                <gco:CharacterString>CH</gco:CharacterString>
+              </gmd:country>
+              <gmd:electronicMailAddress>
+                <gco:CharacterString>rolf.giezendanner@are.admin.ch</gco:CharacterString>
+              </gmd:electronicMailAddress>
+              <che:streetName>
+                <gco:CharacterString>Worblentalstrasse</gco:CharacterString>
+              </che:streetName>
+              <che:streetNumber>
+                <gco:CharacterString>66</gco:CharacterString>
+              </che:streetNumber>
+            </che:CHE_CI_Address>
+          </gmd:address>
+          <gmd:onlineResource>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#EN">http://www.are.admin.ch</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">http://www.are.admin.ch</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">http://www.are.admin.ch</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#IT">http://www.are.admin.ch</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#RM">http://www.are.admin.ch</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>text/html</gco:CharacterString>
+              </gmd:protocol>
+            </gmd:CI_OnlineResource>
+          </gmd:onlineResource>
+        </gmd:CI_Contact>
+      </gmd:contactInfo>
+      <gmd:role>
+        <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="pointOfContact" />
+      </gmd:role>
+      <che:individualFirstName>
+        <gco:CharacterString>Rolf</gco:CharacterString>
+      </che:individualFirstName>
+      <che:individualLastName>
+        <gco:CharacterString>Giezendanner</gco:CharacterString>
+      </che:individualLastName>
+      <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>ARE</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">ARE</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">ARE</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">ARE</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#IT">ARE</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#RM">ARE</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </che:organisationAcronym>
+    </che:CHE_CI_ResponsibleParty>
+  </gmd:contact>
+  <gmd:dateStamp xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gco:DateTime>2016-08-03T15:56:27</gco:DateTime>
+  </gmd:dateStamp>
+  <gmd:metadataStandardName xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gco:CharacterString>GM03 2+</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:PT_Locale id="DE">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:PT_Locale id="FR">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:PT_Locale id="IT">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ita" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:PT_Locale id="EN">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale id="RM">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="roh" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeListValue="utf8" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:spatialRepresentationInfo xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:MD_VectorSpatialRepresentation>
+      <gmd:geometricObjects>
+        <gmd:MD_GeometricObjects>
+          <gmd:geometricObjectType>
+            <gmd:MD_GeometricObjectTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_GeometricObjectTypeCode" codeListValue="surface" />
+          </gmd:geometricObjectType>
+          <gmd:geometricObjectCount>
+            <gco:Integer>1</gco:Integer>
+          </gmd:geometricObjectCount>
+        </gmd:MD_GeometricObjects>
+      </gmd:geometricObjects>
+    </gmd:MD_VectorSpatialRepresentation>
+  </gmd:spatialRepresentationInfo>
+  <gmd:referenceSystemInfo xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>EPSG:21781</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">EPSG:21781</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">EPSG:21781</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">EPSG:21781</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">EPSG:21781</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:identificationInfo xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <che:CHE_MD_DataIdentification gco:isoType="gmd:MD_DataIdentification">
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Alpenkonvention Test AAP</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Convention des Alpes test AAP</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Convenzione delle alpi</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Alpine Convention</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Alpenkonvention Test AAP</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM">Convenziun da las Alps</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:alternateTitle xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Alpenkonvention</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Convention des Alpes</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Alpine Convention</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Convenzione delle alpi</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Alpenkonvention</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM">Convenziun da las Alps</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:alternateTitle>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2009-01-01</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:collectiveTitle xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Alpenkonvention</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Convention des Alpes</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Convenzione delle alpi</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Alpenkonvention</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:collectiveTitle>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Perimeter der Alpenkonvention in der Schweiz. Die Alpenkonvention ist ein völkerrechtlicher Vertrag zwischen den acht Alpenländern Deutschland, Frankreich, Italien, Liechtenstein, Monaco, Österreich, Schweiz, Slowenien sowie der Europäischen Union. Das Ziel des Übereinkommens ist der Schutz der Alpen durch eine sektorübergreifende, ganzheitliche und nachhaltige Politik.</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Périmètre de la Convention alpine en Suisse. La Convention alpine est un traité de droit international conclu par huit Etats alpins (Allemagne, Autriche, France, Italie, Liechtenstein, Monaco, Suisse, Slovénie) et l`Union européenne. L`accord vise à assurer la préservation et la protection des Alpes à travers une politique plurisectorielle, globale et durable.</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">The perimeters of the Alpine Convention in Switzerland. The Alpine Convention is an international treaty between the eight Alpine countries: Germany, France, Italy, Liechtenstein, Monaco, Austria, Switzerland and Slovenia, plus the European Union. The aim of the treaty is to protect the Alps by means of cross-sectoral, integrated and sustainable policies.</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#IT">Il perimetro della Convenzione delle Alpi. La Convenzione delle Alpi è un trattato internazionale tra gli otto Paesi alpini Germania, Francia, Italia, Liechtenstein, Monaco, Austria, Svizzera, Slovenia e l'Unione europea. Lo scopo della Convenzione è la conservazione e la protezione delle Alpi mediante una politica intersettoriale, globale e durevole.</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#RM">Perimeter da la Convenziun da las Alps en Svizra. La Convenziun da las Alps è in contract internaziunal tranter ils otg pajais alpins (Austria, Frantscha, Germania, Italia, Liechtenstein, Monaco, Slovenia, Svizra) e l'Uniun europeica. La convenziun ha la finamira da proteger las Alps cun agid d'ina politica cumplessiva ed intersecturiala.</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">Perimeter der Alpenkonvention in der Schweiz. Die Alpenkonvention ist ein völkerrechtlicher Vertrag zwischen den acht Alpenländern Deutschland, Frankreich, Italien, Liechtenstein, Monaco, Österreich, Schweiz, Slowenien sowie der Europäischen Union. Das Ziel des Übereinkommens ist der Schutz der Alpen durch eine sektorübergreifende, ganzheitliche und nachhaltige Politik.</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:abstract>
+      <gmd:status>
+        <gmd:MD_ProgressCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ProgressCode" codeListValue="completed" />
+      </gmd:status>
+      <gmd:pointOfContact xmlns:xlink="http://www.w3.org/1999/xlink" xlink:show="embed">
+        <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
+          <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Bundesamt für Raumentwicklung</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Federal Office for Spatial Development</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Bundesamt für Raumentwicklung</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Office fédéral du développement territorial</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Ufficio federale dello sviluppo territoriale</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM">Bundesamt für Raumentwicklung</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:organisationName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:phone>
+                <che:CHE_CI_Telephone gco:isoType="gmd:CI_Telephone">
+                  <che:directNumber>
+                    <gco:CharacterString>+41 58 462 01 43</gco:CharacterString>
+                  </che:directNumber>
+                </che:CHE_CI_Telephone>
+              </gmd:phone>
+              <gmd:address>
+                <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+                  <gmd:city>
+                    <gco:CharacterString>Ittigen</gco:CharacterString>
+                  </gmd:city>
+                  <gmd:postalCode>
+                    <gco:CharacterString>3063</gco:CharacterString>
+                  </gmd:postalCode>
+                  <gmd:country>
+                    <gco:CharacterString>CH</gco:CharacterString>
+                  </gmd:country>
+                  <gmd:electronicMailAddress>
+                    <gco:CharacterString>rolf.giezendanner@are.admin.ch</gco:CharacterString>
+                  </gmd:electronicMailAddress>
+                  <che:streetName>
+                    <gco:CharacterString>Worblentalstrasse</gco:CharacterString>
+                  </che:streetName>
+                  <che:streetNumber>
+                    <gco:CharacterString>66</gco:CharacterString>
+                  </che:streetNumber>
+                </che:CHE_CI_Address>
+              </gmd:address>
+              <gmd:onlineResource>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                    <che:PT_FreeURL>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#EN">http://www.are.admin.ch</che:LocalisedURL>
+                      </che:URLGroup>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#DE">http://www.are.admin.ch</che:LocalisedURL>
+                      </che:URLGroup>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#FR">http://www.are.admin.ch</che:LocalisedURL>
+                      </che:URLGroup>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#IT">http://www.are.admin.ch</che:LocalisedURL>
+                      </che:URLGroup>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#RM">http://www.are.admin.ch</che:LocalisedURL>
+                      </che:URLGroup>
+                    </che:PT_FreeURL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>text/html</gco:CharacterString>
+                  </gmd:protocol>
+                </gmd:CI_OnlineResource>
+              </gmd:onlineResource>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="pointOfContact" />
+          </gmd:role>
+          <che:individualFirstName>
+            <gco:CharacterString>Rolf</gco:CharacterString>
+          </che:individualFirstName>
+          <che:individualLastName>
+            <gco:CharacterString>Giezendanner</gco:CharacterString>
+          </che:individualLastName>
+          <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>ARE</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">ARE</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">ARE</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">ARE</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">ARE</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM">ARE</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </che:organisationAcronym>
+        </che:CHE_CI_ResponsibleParty>
+      </gmd:pointOfContact>
+      <gmd:pointOfContact xmlns:xlink="http://www.w3.org/1999/xlink" xlink:show="embed">
+        <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
+          <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Bundesamt für Landestopographie</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Office fédéral de topographie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Bundesamt für Landestopographie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Office fédéral de topographie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Office fédéral de topographie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM">Office fédéral de topographie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:organisationName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:phone>
+                <che:CHE_CI_Telephone gco:isoType="gmd:CI_Telephone">
+                  <gmd:voice>
+                    <gco:CharacterString>058 469 01 11</gco:CharacterString>
+                  </gmd:voice>
+                  <che:directNumber>
+                    <gco:CharacterString>058 469 04 02</gco:CharacterString>
+                  </che:directNumber>
+                </che:CHE_CI_Telephone>
+              </gmd:phone>
+              <gmd:address>
+                <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+                  <gmd:city>
+                    <gco:CharacterString>Wabern</gco:CharacterString>
+                  </gmd:city>
+                  <gmd:postalCode>
+                    <gco:CharacterString>3084</gco:CharacterString>
+                  </gmd:postalCode>
+                  <gmd:country>
+                    <gco:CharacterString>CH</gco:CharacterString>
+                  </gmd:country>
+                  <gmd:electronicMailAddress>
+                    <gco:CharacterString>andre.schneider@swisstopo.ch</gco:CharacterString>
+                  </gmd:electronicMailAddress>
+                  <che:streetName>
+                    <gco:CharacterString>Seftigenstrasse</gco:CharacterString>
+                  </che:streetName>
+                  <che:streetNumber>
+                    <gco:CharacterString>264</gco:CharacterString>
+                  </che:streetNumber>
+                </che:CHE_CI_Address>
+              </gmd:address>
+              <gmd:onlineResource>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                    <che:PT_FreeURL>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#EN">http://www.swisstopo.ch</che:LocalisedURL>
+                      </che:URLGroup>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#DE">http://www.swisstopo.ch</che:LocalisedURL>
+                      </che:URLGroup>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#FR">http://www.swisstopo.ch</che:LocalisedURL>
+                      </che:URLGroup>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#IT">http://www.swisstopo.ch</che:LocalisedURL>
+                      </che:URLGroup>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#RM">http://www.swisstopo.ch</che:LocalisedURL>
+                      </che:URLGroup>
+                    </che:PT_FreeURL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>text/html</gco:CharacterString>
+                  </gmd:protocol>
+                </gmd:CI_OnlineResource>
+              </gmd:onlineResource>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="specialistAuthority" />
+          </gmd:role>
+          <che:individualFirstName>
+            <gco:CharacterString>André</gco:CharacterString>
+          </che:individualFirstName>
+          <che:individualLastName>
+            <gco:CharacterString>Schneider</gco:CharacterString>
+          </che:individualLastName>
+          <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>swisstopo</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM">swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </che:organisationAcronym>
+        </che:CHE_CI_ResponsibleParty>
+      </gmd:pointOfContact>
+      <gmd:pointOfContact xmlns:xlink="http://www.w3.org/1999/xlink" xlink:show="embed">
+        <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
+          <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>swisstopo</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM">swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:organisationName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:address>
+                <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+                  <gmd:administrativeArea>
+                    <gco:CharacterString>Schweiz</gco:CharacterString>
+                  </gmd:administrativeArea>
+                  <gmd:country>
+                    <gco:CharacterString>CH</gco:CharacterString>
+                  </gmd:country>
+                  <gmd:electronicMailAddress>
+                    <gco:CharacterString>carla.sieber@swisstopo.ch</gco:CharacterString>
+                  </gmd:electronicMailAddress>
+                </che:CHE_CI_Address>
+              </gmd:address>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="owner" />
+          </gmd:role>
+          <che:individualFirstName>
+            <gco:CharacterString>Carla</gco:CharacterString>
+          </che:individualFirstName>
+          <che:individualLastName>
+            <gco:CharacterString>Sieber</gco:CharacterString>
+          </che:individualLastName>
+        </che:CHE_CI_ResponsibleParty>
+      </gmd:pointOfContact>
+      <gmd:descriptiveKeywords xmlns:xlink="http://www.w3.org/1999/xlink">
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>AAP-Bund</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">AAP-Bund</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">AAP-Bund</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">AAP-Bund</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">AAP-Confédération</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM">AAP-Bund</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="_none_" />
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>geocat.ch Thesaurus (non validated)</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2016-07-25</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xlink:href="https://tc-geocat.dev.bgdi.ch:443/geonetwork/srv/eng/thesaurus.download?ref=local._none_.non_validated">geonetwork.thesaurus.local._none_.non_validated</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords xmlns:xlink="http://www.w3.org/1999/xlink">
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Bodenschutz</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">soil conservation</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Bodenschutz</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">conservazione del suolo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">conservation du sol</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM" />
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Raumplanung</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">physical planning</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Raumplanung</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">pianificazione dello spazio fisico</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">planification de l'espace physique</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM" />
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Nachhaltige Entwicklung</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">sustainable development</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Nachhaltige Entwicklung</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">sviluppo sostenibile</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">développement durable</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM" />
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Bergschutz</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">mountain protection</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Bergschutz</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">protezione della montagna</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">protection de la montagne</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM" />
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="_none_" />
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>GEMET concepts</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2015-09-10</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xlink:href="https://tc-geocat.dev.bgdi.ch:443/geonetwork/srv/eng/thesaurus.download?ref=external._none_.gemet">geonetwork.thesaurus.external._none_.gemet</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords xmlns:xlink="http://www.w3.org/1999/xlink">
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Verkehr</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">transport</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Verkehr</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">trasporti</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">transport</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM" />
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Umweltpolitik</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">environmental policy</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Umweltpolitik</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">politica ambientale</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">politique environnementale</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM" />
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="theme" />
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>GEMET themes</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2009-09-22</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xlink:href="https://tc-geocat.dev.bgdi.ch:443/geonetwork/srv/eng/thesaurus.download?ref=external.theme.gemet-theme">geonetwork.thesaurus.external.theme.gemet-theme</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords xmlns:xlink="http://www.w3.org/1999/xlink">
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>opendata.swiss</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">opendata.swiss</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">opendata.swiss</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">opendata.swiss</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">opendata.swiss</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM">opendata.swiss</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>e-geo.ch Geoportal</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">e-geo.ch geoportal</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">e-geo.ch Geoportal</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">geoportale e-geo.ch</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">géoportail e-geo.ch</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM" />
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="_none_" />
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>geocat.ch Thesaurus</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2016-01-12</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xlink:href="https://tc-geocat.dev.bgdi.ch:443/geonetwork/srv/eng/thesaurus.download?ref=local._none_.geocat.ch">geonetwork.thesaurus.local._none_.geocat.ch</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords xmlns:xlink="http://www.w3.org/1999/xlink">
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Verwaltungseinheiten</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Administrative units</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Verwaltungseinheiten</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Unità amministrative</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Unités administratives</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM" />
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Umweltüberwachung</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Environmental monitoring facilities</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Umweltüberwachung</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Impianti di monitoraggio ambientale</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Installations de suivi environnemental</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM" />
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="theme" />
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>GEMET - INSPIRE themes, version 1.0</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2008-06-01</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xlink:href="https://tc-geocat.dev.bgdi.ch:443/geonetwork/srv/eng/thesaurus.download?ref=external.theme.inspire-theme">geonetwork.thesaurus.external.theme.inspire-theme</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:spatialRepresentationType>
+        <gmd:MD_SpatialRepresentationTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_SpatialRepresentationTypeCode" codeListValue="vector" />
+      </gmd:spatialRepresentationType>
+      <gmd:spatialResolution>
+        <gmd:MD_Resolution>
+          <gmd:equivalentScale>
+            <gmd:MD_RepresentativeFraction>
+              <gmd:denominator>
+                <gco:Integer>25000</gco:Integer>
+              </gmd:denominator>
+            </gmd:MD_RepresentativeFraction>
+          </gmd:equivalentScale>
+        </gmd:MD_Resolution>
+      </gmd:spatialResolution>
+      <gmd:language>
+        <gco:CharacterString>ger</gco:CharacterString>
+      </gmd:language>
+      <gmd:language>
+        <gco:CharacterString>fre</gco:CharacterString>
+      </gmd:language>
+      <gmd:language>
+        <gco:CharacterString>ita</gco:CharacterString>
+      </gmd:language>
+      <gmd:characterSet>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterSet>
+      <gmd:topicCategory />
+      <gmd:topicCategory />
+      <gmd:topicCategory />
+      <gmd:topicCategory />
+      <gmd:topicCategory />
+      <gmd:topicCategory />
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>planningCadastre</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>planningCadastre_Planning</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:extent xmlns:xlink="http://www.w3.org/1999/xlink" xlink:show="embed">
+        <gmd:EX_Extent>
+          <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Alpenkonvention</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Alpenkonvention</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Convention des Alpes</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Convenzione delle alpi</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Alpine Convention</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:description>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicDescription>
+              <gmd:geographicIdentifier>
+                <gmd:MD_Identifier>
+                  <gmd:code xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString>AK</gco:CharacterString>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">AK</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#FR">CA</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#IT">CA</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#EN">AC</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#RM">null</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:geographicIdentifier>
+            </gmd:EX_GeographicDescription>
+          </gmd:geographicElement>
+          <gmd:geographicElement>
+            <gmd:EX_BoundingPolygon>
+              <gmd:extentTypeCode>
+                <gco:Boolean>1</gco:Boolean>
+              </gmd:extentTypeCode>
+              <gmd:polygon>
+                <gml:MultiSurface gml:id="Nb3e475f1ef3d4b2ab9bd84b628e15e6c">
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="Nb3e475f1ef3d4b2ab9bd84b628e15e6c.1">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>6.777 45.827 6.756 47.518 10.542 47.478 10.446 45.789 6.777 45.827</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                </gml:MultiSurface>
+              </gmd:polygon>
+            </gmd:EX_BoundingPolygon>
+          </gmd:geographicElement>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicBoundingBox>
+              <gmd:extentTypeCode>
+                <gco:Boolean>1</gco:Boolean>
+              </gmd:extentTypeCode>
+              <!--native coords: 548583.0,75270.0,833855.0,263205.0-->
+              <gmd:westBoundLongitude>
+                <gco:Decimal>6.756</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>10.542</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>45.789</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>47.518</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+          </gmd:geographicElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+      <che:basicGeodataID>
+        <gco:CharacterString>3.1</gco:CharacterString>
+      </che:basicGeodataID>
+      <che:basicGeodataIDType>
+        <che:basicGeodataIDTypeCode codeList="#basicGeodataIDTypeCode" codeListValue="federal" />
+      </che:basicGeodataIDType>
+    </che:CHE_MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:contentInfo>
+    <che:CHE_MD_FeatureCatalogueDescription gco:isoType="gmd:MD_FeatureCatalogueDescription">
+      <gmd:language>
+        <gco:CharacterString>ger</gco:CharacterString>
+      </gmd:language>
+      <gmd:includedWithDataset>
+        <gco:Boolean>0</gco:Boolean>
+      </gmd:includedWithDataset>
+      <gmd:featureCatalogueCitation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Alpenkonvention (INTERLIS 2)</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Alpenkonvention (INTERLIS 2)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2009-09-18</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_DateTypeCode" codeListValue="creation" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </gmd:featureCatalogueCitation>
+      <che:modelType>
+        <che:CHE_MD_modelTypeCode codeList="#CHE_MD_modelTypeCode" codeListValue="INTERLIS2" />
+      </che:modelType>
+    </che:CHE_MD_FeatureCatalogueDescription>
+  </gmd:contentInfo>
+  <gmd:contentInfo>
+    <che:CHE_MD_FeatureCatalogueDescription gco:isoType="gmd:MD_FeatureCatalogueDescription">
+      <gmd:language>
+        <gco:CharacterString>ger</gco:CharacterString>
+      </gmd:language>
+      <gmd:includedWithDataset>
+        <gco:Boolean>0</gco:Boolean>
+      </gmd:includedWithDataset>
+      <gmd:featureCatalogueCitation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Alpenkonvention (INTERLIS 1)</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Alpenkonvention (INTERLIS 1)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2009-09-18</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_DateTypeCode" codeListValue="creation" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </gmd:featureCatalogueCitation>
+      <che:modelType>
+        <che:CHE_MD_modelTypeCode codeList="#CHE_MD_modelTypeCode" codeListValue="INTERLIS1" />
+      </che:modelType>
+    </che:CHE_MD_FeatureCatalogueDescription>
+  </gmd:contentInfo>
+  <gmd:contentInfo>
+    <che:CHE_MD_FeatureCatalogueDescription gco:isoType="gmd:MD_FeatureCatalogueDescription">
+      <gmd:language>
+        <gco:CharacterString>ger</gco:CharacterString>
+      </gmd:language>
+      <gmd:includedWithDataset>
+        <gco:Boolean>0</gco:Boolean>
+      </gmd:includedWithDataset>
+      <gmd:featureCatalogueCitation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Alpenkonvention (UML)</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Alpenkonvention (UML)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2009-09-18</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_DateTypeCode" codeListValue="creation" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </gmd:featureCatalogueCitation>
+      <che:modelType>
+        <che:CHE_MD_modelTypeCode codeList="#CHE_MD_modelTypeCode" codeListValue="UMLdiagram" />
+      </che:modelType>
+    </che:CHE_MD_FeatureCatalogueDescription>
+  </gmd:contentInfo>
+  <gmd:contentInfo>
+    <che:CHE_MD_FeatureCatalogueDescription gco:isoType="gmd:MD_FeatureCatalogueDescription">
+      <gmd:language>
+        <gco:CharacterString>ger</gco:CharacterString>
+      </gmd:language>
+      <gmd:includedWithDataset>
+        <gco:Boolean>0</gco:Boolean>
+      </gmd:includedWithDataset>
+      <gmd:featureCatalogueCitation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Alpenkonvention (Objektkatalog)</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Alpenkonvention (Objektkatalog)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2009-09-18</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_DateTypeCode" codeListValue="creation" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </gmd:featureCatalogueCitation>
+      <che:modelType>
+        <che:CHE_MD_modelTypeCode codeList="#CHE_MD_modelTypeCode" codeListValue="FeatureDescription" />
+      </che:modelType>
+    </che:CHE_MD_FeatureCatalogueDescription>
+  </gmd:contentInfo>
+  <gmd:distributionInfo xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:MD_Distribution>
+      <gmd:distributionFormat xmlns:xlink="http://www.w3.org/1999/xlink" xlink:show="embed">
+        <gmd:MD_Format>
+          <gmd:name>
+            <gco:CharacterString>ESRI Shapefile</gco:CharacterString>
+          </gmd:name>
+          <gmd:version>
+            <gco:CharacterString>-</gco:CharacterString>
+          </gmd:version>
+        </gmd:MD_Format>
+      </gmd:distributionFormat>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#EN">http://www.are.admin.ch/alpenkonvention/index.html?lang=en</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">http://www.are.admin.ch/alpenkonvention/index.html?lang=fr</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#IT">http://www.are.admin.ch/alpenkonvention/index.html?lang=it</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">http://www.are.admin.ch/alpenkonvention/index.html?lang=de</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Webseite des ARE über die Alpenkonvention</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Page web de l'ARE sur la Convention alpine</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Webseite des ARE über die Alpenkonvention</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">http://data.geo.admin.ch/ch.are.alpenkonvention/data.zip</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:DOWNLOAD-URL</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Download von data.geo.admin.ch</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN">Download server from geo.admin.ch</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Serveur de téléchargement de geo.admin.ch</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#IT">Server di download di geo.admin.ch</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Download von data.geo.admin.ch</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download" />
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">http://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>OGC:WMS-http-get-capabilities</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>ch.are.alpenkonvention</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">ch.are.alpenkonvention</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:name>
+              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>WMS Dienst von geo.admin.ch</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN">WMS Service from geo.admin.ch</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Service WMS de geo.admin.ch</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#IT">Servizio WMS di geo.admin.ch</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">WMS Dienst von geo.admin.ch</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">http://www.are.admin.ch/dienstleistungen/00904/04205/04209/index.html?lang=fr</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">http://www.are.admin.ch/dienstleistungen/00904/04205/04209/index.html?lang=de</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Minimales Geodatenmodell in INTERLIS 2.3</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Modèle de données minimal en INTERLIS 2.3</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Minimales Geodatenmodell in INTERLIS 2.3</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">http://map.are.admin.ch/?Y=660000&amp;X=190000&amp;zoom=1&amp;bgLayer=ch.swisstopo.pixelkarte-grau&amp;layers=ch.are.alpenkonvention&amp;layers_opacity=0.2&amp;layers_visibility=true&amp;lang=fr</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">http://map.are.admin.ch/?Y=660000&amp;X=190000&amp;zoom=1&amp;bgLayer=ch.swisstopo.pixelkarte-grau&amp;layers=ch.are.alpenkonvention&amp;layers_opacity=0.2&amp;layers_visibility=true&amp;lang=de</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>CHTOPO:specialised-geoportal</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Web-GIS ARE</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Web-SIG ARE</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Web-GIS ARE</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">http://wmts.geo.admin.ch</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>OGC:WMTS-http-get-capabilities</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>ch.are.alpenkonvention</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">ch.are.alpenkonvention</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:name>
+              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>WMTS für das Nationale Geoportal</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN">WMTS for the national geoportal</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">WMTS pour le géoportail national</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">WMTS für das Nationale Geoportal</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#EN">http://www.alpconv.org</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">http://www.alpconv.org</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#IT">http://www.alpconv.org</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#RM">http://www.alpconv.org</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">http://www.alpconv.org</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Offizielle Homepage der Alpenkonvention</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN">Official Website of the Alpine Convention</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Site web officiel de la Convention alpine</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#IT">Pagina web ufficiale della Convenzione delle alpi</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Offizielle Homepage der Alpenkonvention</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information" />
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">http://map.geo.admin.ch/?selectedNode=LT1_1&amp;Y=660000&amp;X=190000&amp;zoom=1&amp;bgLayer=ch.swisstopo.pixelkarte-farbe&amp;layers=ch.are.alpenkonvention&amp;layers_opacity=0.56&amp;layers_visibility=true&amp;lang=fr</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">http://map.geo.admin.ch/?selectedNode=LT1_1&amp;Y=660000&amp;X=190000&amp;zoom=1&amp;bgLayer=ch.swisstopo.pixelkarte-farbe&amp;layers=ch.are.alpenkonvention&amp;layers_opacity=0.6&amp;layers_visibility=true&amp;lang=de</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Die Alpenkonvention im Bundesgeoportal</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">La convention alpine dans le géoportail fédéral</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Die Alpenkonvention im Bundesgeoportal</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information" />
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">http://www.admin.ch/ch/f/rs/0_700_1/app1.html</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#IT">http://www.admin.ch/ch/i/rs/0_700_1/app1.html</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">http://www.admin.ch/ch/d/sr/0_700_1/app1.html</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Liste der administrativen Einheiten des Alpenraumes in der schweizerischen Eidgenossenschaft</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Liste des unités administratives de l'espace alpin dans la Confédération suisse</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#IT">Elenco delle unità amministrative dello spazio alpino nella Confederazione Svizzera</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Liste der administrativen Einheiten des Alpenraumes in der schweizerischen Eidgenossenschaft</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information" />
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+    </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+  <gmd:dataQualityInfo xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset" />
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Digitalisiert nach den administrativen Einheiten der Schweiz, die im Anhang des Übereinkommens erscheinen.</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Digitalisiert nach den administrativen Einheiten der Schweiz, die im Anhang des Übereinkommens erscheinen.</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:statement>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
+  <gmd:metadataConstraints>
+    <che:CHE_MD_LegalConstraints gco:isoType="gmd:MD_LegalConstraints" />
+  </gmd:metadataConstraints>
+  <gmd:metadataMaintenance>
+    <che:CHE_MD_MaintenanceInformation gco:isoType="gmd:MD_MaintenanceInformation">
+      <gmd:maintenanceAndUpdateFrequency>
+        <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="notPlanned" />
+      </gmd:maintenanceAndUpdateFrequency>
+      <che:appraisal>
+        <che:CHE_MD_Appraisal_AAP>
+          <che:durationOfConservation>
+            <gco:Integer>178</gco:Integer>
+          </che:durationOfConservation>
+          <che:commentOnDurationOfConservation xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>180 minus 2</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">180 minus 2</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </che:commentOnDurationOfConservation>
+          <che:appraisalOfArchivalValue>
+            <che:CHE_AppraisalOfArchivalValueCode codeList="#CHE_AppraisalOfArchivalValueCode" codeListValue="S" />
+          </che:appraisalOfArchivalValue>
+          <che:reasonForArchivingValue>
+            <che:CHE_ReasonForArchivingValueCode codeList="#CHE_ReasonForArchivingValueCode" codeListValue="legalRelevance" />
+          </che:reasonForArchivingValue>
+          <che:commentOnArchivalValue xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Beispiel zu "Remarque concernant la valeur archivistique"</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Beispiel zu "Remarque concernant la valeur archivistique"</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </che:commentOnArchivalValue>
+        </che:CHE_MD_Appraisal_AAP>
+      </che:appraisal>
+    </che:CHE_MD_MaintenanceInformation>
+  </gmd:metadataMaintenance>
+  <che:legislationInformation xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <che:CHE_MD_Legislation gco:isoType="gmd:MD_Legislation">
+      <che:country>
+        <gmd:Country codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#Country" codeListValue="CH" />
+      </che:country>
+      <che:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger" />
+      </che:language>
+      <che:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+      </che:language>
+      <che:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ita" />
+      </che:language>
+      <che:legislationType>
+        <che:CHE_CI_LegislationCode codeList="#CHE_CI_LegislationCode" codeListValue="internationalObligation" />
+      </che:legislationType>
+      <che:internalReference>
+        <gco:CharacterString>0.700.1</gco:CharacterString>
+      </che:internalReference>
+      <che:title>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Übereinkommen zum Schutz der Alpen</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Convention sur la protection des Alpes</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Convenzione per la protezione delle Alpi</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Übereinkommen zum Schutz der Alpen</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:alternateTitle xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Alpenkonvention</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Convention alpine</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Convenzione delle Alpi</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Alpenkonvention</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:alternateTitle>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>1991-11-07</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </che:title>
+    </che:CHE_MD_Legislation>
+  </che:legislationInformation>
+  <che:legislationInformation xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <che:CHE_MD_Legislation gco:isoType="gmd:MD_Legislation">
+      <che:country>
+        <gmd:Country codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#Country" codeListValue="CH" />
+      </che:country>
+      <che:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger" />
+      </che:language>
+      <che:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+      </che:language>
+      <che:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ita" />
+      </che:language>
+      <che:legislationType>
+        <che:CHE_CI_LegislationCode codeList="#CHE_CI_LegislationCode" codeListValue="nationalDecree" />
+      </che:legislationType>
+      <che:internalReference>
+        <gco:CharacterString>510.620</gco:CharacterString>
+      </che:internalReference>
+      <che:title>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Verordnung über Geoinformation : Anhang 1, Katalog der Geobasisdaten des Bundesrechts</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Ordonnance sur la géoinformation : Annexe 1, Catalogue des géodonnées de base relevant du droit fédéral</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Ordinanza sulla geoinformazione : Allegato 1, Catalogo dei geodati di base del diritto federale</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Verordnung über Geoinformation : Anhang 1, Katalog der Geobasisdaten des Bundesrechts</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:alternateTitle xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Geoinformationsverordnung GeoIV</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">OGéo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">OGI</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Geoinformationsverordnung GeoIV</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:alternateTitle>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2008-05-21</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2008-07-01</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </che:title>
+    </che:CHE_MD_Legislation>
+  </che:legislationInformation>
+</che:CHE_MD_Metadata>

--- a/core/src/test/resources/org/fao/geonet/geocat/kernel/mdaaptest-noaap.xml
+++ b/core/src/test/resources/org/fao/geonet/geocat/kernel/mdaaptest-noaap.xml
@@ -1,0 +1,882 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<che:CHE_MD_Metadata xmlns:che="http://www.geocat.ch/2008/che" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gml="http://www.opengis.net/gml" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" gco:isoType="gmd:MD_Metadata" xsi:schemaLocation="http://www.geocat.ch/2008/che http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd http://www.isotc211.org/2005/srv http://schemas.opengis.net/iso/19139/20060504/srv/srv.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>d2ab7e4e-d135-4442-b0af-2f8892d87843</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gco:CharacterString>fre</gco:CharacterString>
+  </gmd:language>
+  <gmd:characterSet xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+  </gmd:characterSet>
+  <gmd:hierarchyLevel xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset" />
+  </gmd:hierarchyLevel>
+  <gmd:contact xmlns:xlink="http://www.w3.org/1999/xlink" xlink:show="embed">
+    <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
+      <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Service des forêts et de la faune</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Service des forêts et de la faune</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:organisationName>
+      <gmd:positionName xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Collaborateur scientifique</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Collaborateur scientifique</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:positionName>
+      <gmd:contactInfo>
+        <gmd:CI_Contact>
+          <gmd:phone>
+            <che:CHE_CI_Telephone gco:isoType="gmd:CI_Telephone">
+              <gmd:facsimile>
+                <gco:CharacterString>026 / 305 23 36</gco:CharacterString>
+              </gmd:facsimile>
+              <che:directNumber>
+                <gco:CharacterString>026 / 305 23 43</gco:CharacterString>
+              </che:directNumber>
+            </che:CHE_CI_Telephone>
+          </gmd:phone>
+          <gmd:address>
+            <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+              <gmd:city>
+                <gco:CharacterString>Givisiez</gco:CharacterString>
+              </gmd:city>
+              <gmd:postalCode>
+                <gco:CharacterString>1762</gco:CharacterString>
+              </gmd:postalCode>
+              <gmd:electronicMailAddress>
+                <gco:CharacterString>forets@fr.ch</gco:CharacterString>
+              </gmd:electronicMailAddress>
+              <che:streetName>
+                <gco:CharacterString>Route du Mont-Carmel</gco:CharacterString>
+              </che:streetName>
+              <che:streetNumber>
+                <gco:CharacterString>1</gco:CharacterString>
+              </che:streetNumber>
+            </che:CHE_CI_Address>
+          </gmd:address>
+          <gmd:onlineResource>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">http://www.fr.ch/sff</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>text/html</gco:CharacterString>
+              </gmd:protocol>
+            </gmd:CI_OnlineResource>
+          </gmd:onlineResource>
+        </gmd:CI_Contact>
+      </gmd:contactInfo>
+      <gmd:role>
+        <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="pointOfContact" />
+      </gmd:role>
+      <che:individualFirstName>
+        <gco:CharacterString>Michel</gco:CharacterString>
+      </che:individualFirstName>
+      <che:individualLastName>
+        <gco:CharacterString>Spicher</gco:CharacterString>
+      </che:individualLastName>
+      <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>SFF</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">SFF</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </che:organisationAcronym>
+    </che:CHE_CI_ResponsibleParty>
+  </gmd:contact>
+  <gmd:dateStamp xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gco:DateTime>2016-05-24T14:21:36</gco:DateTime>
+  </gmd:dateStamp>
+  <gmd:metadataStandardName xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gco:CharacterString>GM03 2+</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:PT_Locale id="FR">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:PT_Locale id="DE">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:PT_Locale id="IT">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ita" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:PT_Locale id="EN">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:identificationInfo xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <che:CHE_MD_DataIdentification gco:isoType="gmd:MD_DataIdentification">
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Lisières forestières prioritaires</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Lisières forestières prioritaires</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:alternateTitle xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Lisières prioritaires</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Lisières prioritaires</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:alternateTitle>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2011-09-01</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:presentationForm>
+            <gmd:CI_PresentationFormCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_PresentationFormCode" codeListValue="mapDigital" />
+          </gmd:presentationForm>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Localisation des lisières ayant un grand potentiel de mise en valeur de leur biodiversité. Les  lisières sont ainsi classées selon ce potentiel, lui-même évalué selon les critères suivants: 
+1) Lisière attenante à un objet d'importance biologique.
+2) Lisière exposé sud-est à sud-ouest.
+3) Lisière ne se situant pas proche d'habitations.
+4) Lisière ne se situant pas proche d'une route goudronnée (jusqu'à la classe 3).
+5) Lisière ne se situant pas proche d'une voie ferrée.
+6) Lisière n'étant pas attenante à un cours d'eau important ou à un lac (sauf pour le Chablais).
+7) Lisière n'étant pas proche d'une zone d'accueil en forêt de type exclusif.
+8) Lisière n'étant pas attenante à une falaise.
+9) Lisière ne se situant pas dans une réserve forestière.</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Localisation des lisières ayant un grand potentiel de mise en valeur de leur biodiversité. Les  lisières sont ainsi classées selon ce potentiel, lui-même évalué selon les critères suivants: 
+1) Lisière attenante à un objet d'importance biologique.
+2) Lisière exposé sud-est à sud-ouest.
+3) Lisière ne se situant pas proche d'habitations.
+4) Lisière ne se situant pas proche d'une route goudronnée (jusqu'à la classe 3).
+5) Lisière ne se situant pas proche d'une voie ferrée.
+6) Lisière n'étant pas attenante à un cours d'eau important ou à un lac (sauf pour le Chablais).
+7) Lisière n'étant pas proche d'une zone d'accueil en forêt de type exclusif.
+8) Lisière n'étant pas attenante à une falaise.
+9) Lisière ne se situant pas dans une réserve forestière.</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:abstract>
+      <gmd:status>
+        <gmd:MD_ProgressCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ProgressCode" codeListValue="onGoing" />
+      </gmd:status>
+      <gmd:pointOfContact xmlns:xlink="http://www.w3.org/1999/xlink" xlink:show="embed">
+        <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
+          <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Service des forêts et de la faune</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Service des forêts et de la faune</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:organisationName>
+          <gmd:positionName xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Collaborateur scientifique</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Collaborateur scientifique</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:positionName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:phone>
+                <che:CHE_CI_Telephone gco:isoType="gmd:CI_Telephone">
+                  <gmd:facsimile>
+                    <gco:CharacterString>026 / 305 23 36</gco:CharacterString>
+                  </gmd:facsimile>
+                  <che:directNumber>
+                    <gco:CharacterString>026 / 305 23 43</gco:CharacterString>
+                  </che:directNumber>
+                </che:CHE_CI_Telephone>
+              </gmd:phone>
+              <gmd:address>
+                <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+                  <gmd:city>
+                    <gco:CharacterString>Givisiez</gco:CharacterString>
+                  </gmd:city>
+                  <gmd:postalCode>
+                    <gco:CharacterString>1762</gco:CharacterString>
+                  </gmd:postalCode>
+                  <gmd:electronicMailAddress>
+                    <gco:CharacterString>forets@fr.ch</gco:CharacterString>
+                  </gmd:electronicMailAddress>
+                  <che:streetName>
+                    <gco:CharacterString>Route du Mont-Carmel</gco:CharacterString>
+                  </che:streetName>
+                  <che:streetNumber>
+                    <gco:CharacterString>1</gco:CharacterString>
+                  </che:streetNumber>
+                </che:CHE_CI_Address>
+              </gmd:address>
+              <gmd:onlineResource>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                    <che:PT_FreeURL>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#FR">http://www.fr.ch/sff</che:LocalisedURL>
+                      </che:URLGroup>
+                    </che:PT_FreeURL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>text/html</gco:CharacterString>
+                  </gmd:protocol>
+                </gmd:CI_OnlineResource>
+              </gmd:onlineResource>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="owner" />
+          </gmd:role>
+          <che:individualFirstName>
+            <gco:CharacterString>Michel</gco:CharacterString>
+          </che:individualFirstName>
+          <che:individualLastName>
+            <gco:CharacterString>Spicher</gco:CharacterString>
+          </che:individualLastName>
+          <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>SFF</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">SFF</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </che:organisationAcronym>
+        </che:CHE_CI_ResponsibleParty>
+      </gmd:pointOfContact>
+      <gmd:resourceMaintenance>
+        <che:CHE_MD_MaintenanceInformation gco:isoType="gmd:MD_MaintenanceInformation">
+          <gmd:maintenanceAndUpdateFrequency>
+            <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="userDefined" />
+          </gmd:maintenanceAndUpdateFrequency>
+        </che:CHE_MD_MaintenanceInformation>
+      </gmd:resourceMaintenance>
+      <gmd:resourceFormat xmlns:xlink="http://www.w3.org/1999/xlink">
+        <gmd:MD_Format>
+          <gmd:name>
+            <gco:CharacterString>ESRI Enterprise Geodatabase</gco:CharacterString>
+          </gmd:name>
+          <gmd:version>
+            <gco:CharacterString>-</gco:CharacterString>
+          </gmd:version>
+        </gmd:MD_Format>
+      </gmd:resourceFormat>
+      <gmd:descriptiveKeywords xmlns:xlink="http://www.w3.org/1999/xlink">
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>forêt</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">forest</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Forst</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">foresta</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">forêt</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM" />
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>intervention au niveau de la nature et des paysages</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">intervention in nature and landscape</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Eingriff in Natur und Landschaft</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">intervento su natura e paesaggio</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">intervention au niveau de la nature et des paysages</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM" />
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="_none_" />
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>GEMET concepts</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2015-11-16</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xlink:href="http://www.geocat.ch/geonetwork/srv/eng/thesaurus.download?ref=external._none_.gemet">geonetwork.thesaurus.external._none_.gemet</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords xmlns:xlink="http://www.w3.org/1999/xlink">
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Lisière</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Forest edge</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Waldrand</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Margine forestale</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Lisière</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM" />
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="_none_" />
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>geocat.ch Thesaurus</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2016-02-02</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xlink:href="http://www.geocat.ch/geonetwork/srv/eng/thesaurus.download?ref=local._none_.geocat.ch">geonetwork.thesaurus.local._none_.geocat.ch</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:resourceConstraints>
+        <che:CHE_MD_LegalConstraints gco:isoType="gmd:MD_LegalConstraints">
+          <gmd:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Propriété de l'Etat de Fribourg, statut interne</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Propriété de l'Etat de Fribourg, statut interne</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:otherConstraints>
+        </che:CHE_MD_LegalConstraints>
+      </gmd:resourceConstraints>
+      <gmd:spatialRepresentationType>
+        <gmd:MD_SpatialRepresentationTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_SpatialRepresentationTypeCode" codeListValue="vector" />
+      </gmd:spatialRepresentationType>
+      <gmd:spatialResolution>
+        <gmd:MD_Resolution>
+          <gmd:equivalentScale>
+            <gmd:MD_RepresentativeFraction>
+              <gmd:denominator>
+                <gco:Integer>25000</gco:Integer>
+              </gmd:denominator>
+            </gmd:MD_RepresentativeFraction>
+          </gmd:equivalentScale>
+        </gmd:MD_Resolution>
+      </gmd:spatialResolution>
+      <gmd:language>
+        <gco:CharacterString>ger</gco:CharacterString>
+      </gmd:language>
+      <gmd:language>
+        <gco:CharacterString>fre</gco:CharacterString>
+      </gmd:language>
+      <gmd:characterSet>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterSet>
+      <gmd:topicCategory />
+      <gmd:topicCategory />
+      <gmd:topicCategory />
+      <gmd:topicCategory />
+      <gmd:topicCategory />
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>environment</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>environment_EnvironmentalProtection</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>environment_NatureProtection</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>biota</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:environmentDescription xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Serveur SDE : SDEUSER.SFF4030L_LISIERE_PRIORITAIRE</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Serveur SDE : SDEUSER.SFF4030L_LISIERE_PRIORITAIRE</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:environmentDescription>
+      <gmd:extent xmlns="http://www.isotc211.org/2005/gmd" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:show="embed">
+        <gmd:EX_Extent>
+          <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Fribourg</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Fribourg</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Fribourg</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Fribourg</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Fribourg</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM">Fribourg</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:description>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicDescription>
+              <gmd:geographicIdentifier>
+                <gmd:MD_Identifier>
+                  <gmd:code xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString>FR</gco:CharacterString>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#EN">FR</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">FR</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#FR">FR</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#IT">FR</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#RM">FR</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:geographicIdentifier>
+            </gmd:EX_GeographicDescription>
+          </gmd:geographicElement>
+          <gmd:geographicElement>
+            <gmd:EX_BoundingPolygon>
+              <gmd:extentTypeCode>
+                <gco:Boolean>1</gco:Boolean>
+              </gmd:extentTypeCode>
+              <gmd:polygon>
+                <gml:MultiSurface gml:id="N84bd990b5c6c4126bcbc6cdc1e1c47e8">
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="N84bd990b5c6c4126bcbc6cdc1e1c47e8.1">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>6.93 46.9 6.924 46.904 6.922 46.906 6.896 46.925 6.929 46.953 6.962 46.927 6.972 46.921 6.978 46.923 6.988 46.918 6.982 46.914 6.984 46.908 7.009 46.889 6.994 46.879 6.999 46.874 7.007 46.873 7.016 46.881 7.032 46.876 7.036 46.873 7.03 46.866 7.039 46.859 7.029 46.851 7.035 46.847 7.038 46.845 7.05 46.855 7.058 46.862 7.067 46.869 7.071 46.873 7.066 46.881 7.062 46.88 7.062 46.884 7.08 46.894 7.074 46.895 7.083 46.896 7.091 46.892 7.1 46.898 7.091 46.904 7.09 46.908 7.084 46.913 7.06 46.937 7.06 46.951 7.056 46.955 7.06 46.956 7.063 46.971 7.041 46.979 7.04 46.98 7.058 46.977 7.09 46.977 7.138 46.983 7.147 46.985 7.16 46.987 7.171 46.991 7.179 46.994 7.187 46.997 7.2 47.002 7.205 47.006 7.217 47.006 7.226 46.999 7.223 46.994 7.229 46.991 7.236 46.985 7.231 46.981 7.223 46.975 7.215 46.971 7.214 46.967 7.195 46.964 7.194 46.961 7.2 46.959 7.206 46.96 7.211 46.957 7.208 46.949 7.21 46.943 7.204 46.938 7.212 46.931 7.211 46.927 7.205 46.922 7.207 46.91 7.204 46.906 7.188 46.9 7.195 46.899 7.2 46.902 7.208 46.903 7.218 46.897 7.223 46.903 7.23 46.904 7.237 46.898 7.257 46.898 7.281 46.89 7.29 46.894 7.309 46.892 7.326 46.894 7.349 46.889 7.354 46.886 7.352 46.876 7.359 46.863 7.349 46.853 7.338 46.85 7.326 46.852 7.323 46.855 7.331 46.858 7.316 46.863 7.312 46.856 7.302 46.852 7.33 46.835 7.33 46.83 7.32 46.825 7.317 46.814 7.302 46.794 7.303 46.789 7.305 46.783 7.292 46.774 7.296 46.765 7.303 46.76 7.303 46.754 7.304 46.748 7.297 46.737 7.299 46.723 7.308 46.717 7.35 46.712 7.346 46.699 7.36 46.698 7.377 46.689 7.373 46.68 7.376 46.675 7.371 46.669 7.369 46.656 7.377 46.656 7.358 46.643 7.346 46.655 7.324 46.655 7.33 46.642 7.323 46.637 7.313 46.637 7.312 46.622 7.318 46.616 7.315 46.6 7.321 46.592 7.313 46.589 7.308 46.581 7.299 46.579 7.281 46.584 7.26 46.563 7.237 46.554 7.223 46.548 7.208 46.533 7.192 46.547 7.171 46.533 7.159 46.527 7.148 46.528 7.136 46.509 7.123 46.499 7.11 46.495 7.1 46.487 7.078 46.489 7.072 46.486 7.066 46.489 7.061 46.487 7.023 46.462 7.018 46.447 6.984 46.438 6.992 46.449 6.98 46.459 6.978 46.473 6.981 46.475 6.975 46.479 6.971 46.491 6.962 46.497 6.948 46.501 6.934 46.502 6.925 46.508 6.91 46.512 6.901 46.513 6.896 46.508 6.897 46.519 6.883 46.513 6.882 46.513 6.866 46.501 6.863 46.494 6.858 46.493 6.848 46.494 6.833 46.505 6.83 46.512 6.824 46.512 6.812 46.526 6.824 46.541 6.832 46.537 6.851 46.541 6.855 46.541 6.861 46.531 6.867 46.541 6.868 46.542 6.888 46.558 6.893 46.559 6.902 46.561 6.898 46.571 6.885 46.562 6.874 46.565 6.872 46.57 6.865 46.576 6.853 46.582 6.842 46.582 6.841 46.58 6.835 46.575 6.829 46.577 6.814 46.586 6.813 46.578 6.799 46.574 6.795 46.575 6.799 46.584 6.801 46.593 6.798 46.6 6.802 46.601 6.804 46.609 6.797 46.634 6.803 46.645 6.799 46.649 6.818 46.648 6.828 46.66 6.838 46.663 6.844 46.661 6.854 46.656 6.863 46.658 6.872 46.673 6.865 46.676 6.863 46.681 6.866 46.684 6.873 46.683 6.881 46.69 6.893 46.7 6.892 46.703 6.898 46.708 6.921 46.722 6.922 46.724 6.934 46.732 6.936 46.733 6.941 46.745 6.938 46.749 6.931 46.754 6.911 46.753 6.908 46.758 6.914 46.763 6.92 46.76 6.929 46.767 6.939 46.782 6.951 46.785 6.959 46.79 6.956 46.793 6.967 46.803 6.958 46.811 6.958 46.819 6.965 46.828 6.971 46.824 6.985 46.822 6.993 46.83 6.985 46.841 6.992 46.848 6.99 46.85 6.983 46.846 6.976 46.847 6.982 46.867 6.989 46.873 6.987 46.875 6.974 46.887 6.962 46.884 6.959 46.879 6.97 46.867 6.965 46.865 6.939 46.89 6.926 46.893 6.924 46.895 6.93 46.9</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                      <gml:interior>
+                        <gml:LinearRing>
+                          <gml:posList>7.124 46.901 7.138 46.908 7.136 46.917 7.132 46.919 7.115 46.916 7.113 46.911 7.119 46.902 7.124 46.901</gml:posList>
+                        </gml:LinearRing>
+                      </gml:interior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="N84bd990b5c6c4126bcbc6cdc1e1c47e8.2">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>6.767 46.809 6.742 46.827 6.78 46.853 6.866 46.909 6.891 46.887 6.904 46.879 6.911 46.881 6.921 46.871 6.912 46.867 6.892 46.865 6.896 46.861 6.913 46.866 6.93 46.854 6.919 46.847 6.908 46.835 6.905 46.824 6.911 46.813 6.905 46.806 6.907 46.805 6.913 46.804 6.92 46.81 6.931 46.806 6.917 46.787 6.911 46.78 6.907 46.783 6.894 46.777 6.877 46.776 6.864 46.781 6.864 46.784 6.853 46.786 6.843 46.779 6.84 46.781 6.833 46.775 6.818 46.778 6.814 46.779 6.805 46.786 6.798 46.783 6.783 46.793 6.776 46.79 6.787 46.8 6.784 46.803 6.779 46.801 6.777 46.803 6.767 46.809</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="N84bd990b5c6c4126bcbc6cdc1e1c47e8.3">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>6.829 46.753 6.829 46.756 6.844 46.765 6.846 46.771 6.85 46.775 6.86 46.766 6.86 46.764 6.868 46.76 6.873 46.758 6.882 46.75 6.867 46.733 6.868 46.728 6.862 46.725 6.852 46.726 6.852 46.727 6.838 46.733 6.828 46.735 6.817 46.733 6.811 46.728 6.806 46.727 6.788 46.728 6.794 46.736 6.798 46.734 6.816 46.738 6.829 46.753</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="N84bd990b5c6c4126bcbc6cdc1e1c47e8.4">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>6.759 46.725 6.749 46.732 6.768 46.744 6.773 46.751 6.786 46.748 6.784 46.735 6.771 46.721 6.763 46.717 6.759 46.722 6.759 46.725</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                </gml:MultiSurface>
+              </gmd:polygon>
+            </gmd:EX_BoundingPolygon>
+          </gmd:geographicElement>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicBoundingBox>
+              <gmd:extentTypeCode>
+                <gco:Boolean>1</gco:Boolean>
+              </gmd:extentTypeCode>
+              <!--native coords: 546871.0,143063.0,595318.0,206170.0-->
+              <gmd:westBoundLongitude>
+                <gco:Decimal>6.742</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>7.377</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>46.438</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>47.006</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+          </gmd:geographicElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+    </che:CHE_MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:contentInfo xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <che:CHE_MD_FeatureCatalogueDescription gco:isoType="gmd:MD_FeatureCatalogueDescription">
+      <gmd:complianceCode>
+        <gco:Boolean>0</gco:Boolean>
+      </gmd:complianceCode>
+      <gmd:language>
+        <gco:CharacterString>fre</gco:CharacterString>
+      </gmd:language>
+      <gmd:includedWithDataset>
+        <gco:Boolean>0</gco:Boolean>
+      </gmd:includedWithDataset>
+      <gmd:featureCatalogueCitation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Lisières forestières prioritaires</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Lisières forestières prioritaires</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:alternateTitle xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Lisières prioritaires</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Lisières prioritaires</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:alternateTitle>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2012-05-10</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_DateTypeCode" codeListValue="creation" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:presentationForm>
+            <gmd:CI_PresentationFormCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_PresentationFormCode" codeListValue="mapDigital" />
+          </gmd:presentationForm>
+        </gmd:CI_Citation>
+      </gmd:featureCatalogueCitation>
+      <che:class>
+        <che:CHE_MD_Class>
+          <che:name>
+            <gco:CharacterString>LISIERES_PRIORITAIRES</gco:CharacterString>
+          </che:name>
+          <che:description />
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>REMARQUE</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Remarque</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>LONGUEUR</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Longueur en m.</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>ROUTE</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Type de la route route bordant la lisière (si existante)</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>CORRIDOR</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Importance du corridor à faune (si existant)</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>REPTILE</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de site propice aux reptiles</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>P_P_SEC_CH</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de prairies et pâturages secs d'importance nationale</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>BAS_M_CH</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de bas-marais d'importance nationale</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>HAUT_M_CH</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de haut-marais d'importance nationale</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>MARECA_CH</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de site marécageux d'importance nationale</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>SIT_AMP_CH</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de site de reproduction des amphibiens d'importance nationale</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>P_MAIG_FR</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de prairie maigre du canton de Fribourg</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>BAS_M_FR</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de haut-marais d'importance cantonale</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>P_SEC_FR</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de prairie et pâturage sec d'importance nationale</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>PRIORITE</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Type de priorité 1.Très haute: si les 3 types d'objets d'importance biologique sont attenant à cette lisière / 2.Haute: si 2 types d'objets d'importance biologique sont attenant à cette lisière / 3.Basse: si 1 seul type d'objets d'importance biologique est attenant à cette lisière / 4.Secondaire: si la lisière est proche d'une route de classe 4, d'une gravière ou se situe à plus de 1400m d'altitude et cela indépendamment du nombre d'objets d'importance biologique attenant à cette lisière.</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>ARR</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Numéro de l'arrondissement forestier</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>GRAVIERE</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence d'une gravière</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>ALTITUDE</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>&lt; ou &gt; à 1400 m.</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>REF</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Numéro de référence</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+        </che:CHE_MD_Class>
+      </che:class>
+      <che:modelType>
+        <che:CHE_MD_modelTypeCode codeListValue="FeatureDescription" codeList="#CHE_MD_modelTypeCode" />
+      </che:modelType>
+    </che:CHE_MD_FeatureCatalogueDescription>
+  </gmd:contentInfo>
+  <gmd:distributionInfo>
+    <gmd:MD_Distribution>
+      <gmd:distributionFormat xmlns:xlink="http://www.w3.org/1999/xlink">
+        <gmd:MD_Format>
+          <gmd:name>
+            <gco:CharacterString>ESRI Shapefile</gco:CharacterString>
+          </gmd:name>
+          <gmd:version>
+            <gco:CharacterString>-</gco:CharacterString>
+          </gmd:version>
+        </gmd:MD_Format>
+      </gmd:distributionFormat>
+    </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+  <gmd:dataQualityInfo xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan" xmlns:gmi="http://www.isotc211.org/2005/gmi">
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset" />
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Données crées en septembre 2011 par un stagiaire du SFF, sur la base d'une analyse SIG des critères mentionnés dans le résumé.</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Données crées en septembre 2011 par un stagiaire du SFF, sur la base d'une analyse SIG des critères mentionnés dans le résumé.</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:statement>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
+  <gmd:metadataMaintenance xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <che:CHE_MD_MaintenanceInformation gco:isoType="gmd:MD_MaintenanceInformation">
+      <gmd:maintenanceAndUpdateFrequency>
+        <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="asNeeded" />
+      </gmd:maintenanceAndUpdateFrequency>
+    </che:CHE_MD_MaintenanceInformation>
+  </gmd:metadataMaintenance>
+</che:CHE_MD_Metadata>
+

--- a/core/src/test/resources/org/fao/geonet/geocat/kernel/mdaaptest.xml
+++ b/core/src/test/resources/org/fao/geonet/geocat/kernel/mdaaptest.xml
@@ -877,21 +877,21 @@
         <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="asNeeded" />
       </gmd:maintenanceAndUpdateFrequency>
       <che:CHE_Appraisal_AAP>
-        <che:CHE_durationOfConservation>
+        <che:CHE_DurationOfConservation>
           <gco:Integer>3</gco:Integer>
-        </che:CHE_durationOfConservation>
-        <che:CHE_commentOnDurationOfConservation>
+        </che:CHE_DurationOfConservation>
+        <che:CHE_CommentOnDurationOfConservation>
           <gco:CharacterString>3 years should be sufficient for any MD - sample comment</gco:CharacterString>
-        </che:CHE_commentOnDurationOfConservation>
+        </che:CHE_CommentOnDurationOfConservation>
         <che:CHE_AppraisalOfArchivalValue>
           <che:CHE_AppraisalOfArchivalValueCode codeList="#CHE_AppraisalOfArchivalValueCode" codeListValue="S"/>
         </che:CHE_AppraisalOfArchivalValue>
         <che:CHE_ReasonForArchivingValue>
-          <che:CHE_ReasonForArchingValueCode codeList="#CHE_ReasonForArchingValueCode" codeListValue="evidenceOfBusinessPractice"/>
+          <che:CHE_ReasonForArchivingValueCode codeList="#CHE_ReasonForArchingValueCode" codeListValue="evidenceOfBusinessPractice"/>
         </che:CHE_ReasonForArchivingValue>
-        <che:CHE_commentOnArchivalValue>
+        <che:CHE_CommentOnArchivalValue>
           <gco:CharacterString>Sample comment on the archival value</gco:CharacterString>
-        </che:CHE_commentOnArchivalValue>
+        </che:CHE_CommentOnArchivalValue>
       </che:CHE_Appraisal_AAP>
     </che:CHE_MD_MaintenanceInformation>
   </gmd:metadataMaintenance>

--- a/core/src/test/resources/org/fao/geonet/geocat/kernel/mdaaptest.xml
+++ b/core/src/test/resources/org/fao/geonet/geocat/kernel/mdaaptest.xml
@@ -1,0 +1,899 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<che:CHE_MD_Metadata xmlns:che="http://www.geocat.ch/2008/che" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gml="http://www.opengis.net/gml" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" gco:isoType="gmd:MD_Metadata" xsi:schemaLocation="http://www.geocat.ch/2008/che http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd http://www.isotc211.org/2005/srv http://schemas.opengis.net/iso/19139/20060504/srv/srv.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>d2ab7e4e-d135-4442-b0af-2f8892d87843</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gco:CharacterString>fre</gco:CharacterString>
+  </gmd:language>
+  <gmd:characterSet xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+  </gmd:characterSet>
+  <gmd:hierarchyLevel xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset" />
+  </gmd:hierarchyLevel>
+  <gmd:contact xmlns:xlink="http://www.w3.org/1999/xlink" xlink:show="embed">
+    <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
+      <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Service des forêts et de la faune</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Service des forêts et de la faune</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:organisationName>
+      <gmd:positionName xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Collaborateur scientifique</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Collaborateur scientifique</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:positionName>
+      <gmd:contactInfo>
+        <gmd:CI_Contact>
+          <gmd:phone>
+            <che:CHE_CI_Telephone gco:isoType="gmd:CI_Telephone">
+              <gmd:facsimile>
+                <gco:CharacterString>026 / 305 23 36</gco:CharacterString>
+              </gmd:facsimile>
+              <che:directNumber>
+                <gco:CharacterString>026 / 305 23 43</gco:CharacterString>
+              </che:directNumber>
+            </che:CHE_CI_Telephone>
+          </gmd:phone>
+          <gmd:address>
+            <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+              <gmd:city>
+                <gco:CharacterString>Givisiez</gco:CharacterString>
+              </gmd:city>
+              <gmd:postalCode>
+                <gco:CharacterString>1762</gco:CharacterString>
+              </gmd:postalCode>
+              <gmd:electronicMailAddress>
+                <gco:CharacterString>forets@fr.ch</gco:CharacterString>
+              </gmd:electronicMailAddress>
+              <che:streetName>
+                <gco:CharacterString>Route du Mont-Carmel</gco:CharacterString>
+              </che:streetName>
+              <che:streetNumber>
+                <gco:CharacterString>1</gco:CharacterString>
+              </che:streetNumber>
+            </che:CHE_CI_Address>
+          </gmd:address>
+          <gmd:onlineResource>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">http://www.fr.ch/sff</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>text/html</gco:CharacterString>
+              </gmd:protocol>
+            </gmd:CI_OnlineResource>
+          </gmd:onlineResource>
+        </gmd:CI_Contact>
+      </gmd:contactInfo>
+      <gmd:role>
+        <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="pointOfContact" />
+      </gmd:role>
+      <che:individualFirstName>
+        <gco:CharacterString>Michel</gco:CharacterString>
+      </che:individualFirstName>
+      <che:individualLastName>
+        <gco:CharacterString>Spicher</gco:CharacterString>
+      </che:individualLastName>
+      <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>SFF</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">SFF</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </che:organisationAcronym>
+    </che:CHE_CI_ResponsibleParty>
+  </gmd:contact>
+  <gmd:dateStamp xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gco:DateTime>2016-05-24T14:21:36</gco:DateTime>
+  </gmd:dateStamp>
+  <gmd:metadataStandardName xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gco:CharacterString>GM03 2+</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:PT_Locale id="FR">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:PT_Locale id="DE">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:PT_Locale id="IT">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ita" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <gmd:PT_Locale id="EN">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:identificationInfo xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <che:CHE_MD_DataIdentification gco:isoType="gmd:MD_DataIdentification">
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Lisières forestières prioritaires</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Lisières forestières prioritaires</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:alternateTitle xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Lisières prioritaires</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Lisières prioritaires</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:alternateTitle>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2011-09-01</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:presentationForm>
+            <gmd:CI_PresentationFormCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_PresentationFormCode" codeListValue="mapDigital" />
+          </gmd:presentationForm>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Localisation des lisières ayant un grand potentiel de mise en valeur de leur biodiversité. Les  lisières sont ainsi classées selon ce potentiel, lui-même évalué selon les critères suivants: 
+1) Lisière attenante à un objet d'importance biologique.
+2) Lisière exposé sud-est à sud-ouest.
+3) Lisière ne se situant pas proche d'habitations.
+4) Lisière ne se situant pas proche d'une route goudronnée (jusqu'à la classe 3).
+5) Lisière ne se situant pas proche d'une voie ferrée.
+6) Lisière n'étant pas attenante à un cours d'eau important ou à un lac (sauf pour le Chablais).
+7) Lisière n'étant pas proche d'une zone d'accueil en forêt de type exclusif.
+8) Lisière n'étant pas attenante à une falaise.
+9) Lisière ne se situant pas dans une réserve forestière.</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Localisation des lisières ayant un grand potentiel de mise en valeur de leur biodiversité. Les  lisières sont ainsi classées selon ce potentiel, lui-même évalué selon les critères suivants: 
+1) Lisière attenante à un objet d'importance biologique.
+2) Lisière exposé sud-est à sud-ouest.
+3) Lisière ne se situant pas proche d'habitations.
+4) Lisière ne se situant pas proche d'une route goudronnée (jusqu'à la classe 3).
+5) Lisière ne se situant pas proche d'une voie ferrée.
+6) Lisière n'étant pas attenante à un cours d'eau important ou à un lac (sauf pour le Chablais).
+7) Lisière n'étant pas proche d'une zone d'accueil en forêt de type exclusif.
+8) Lisière n'étant pas attenante à une falaise.
+9) Lisière ne se situant pas dans une réserve forestière.</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:abstract>
+      <gmd:status>
+        <gmd:MD_ProgressCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ProgressCode" codeListValue="onGoing" />
+      </gmd:status>
+      <gmd:pointOfContact xmlns:xlink="http://www.w3.org/1999/xlink" xlink:show="embed">
+        <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
+          <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Service des forêts et de la faune</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Service des forêts et de la faune</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:organisationName>
+          <gmd:positionName xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Collaborateur scientifique</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Collaborateur scientifique</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:positionName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:phone>
+                <che:CHE_CI_Telephone gco:isoType="gmd:CI_Telephone">
+                  <gmd:facsimile>
+                    <gco:CharacterString>026 / 305 23 36</gco:CharacterString>
+                  </gmd:facsimile>
+                  <che:directNumber>
+                    <gco:CharacterString>026 / 305 23 43</gco:CharacterString>
+                  </che:directNumber>
+                </che:CHE_CI_Telephone>
+              </gmd:phone>
+              <gmd:address>
+                <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+                  <gmd:city>
+                    <gco:CharacterString>Givisiez</gco:CharacterString>
+                  </gmd:city>
+                  <gmd:postalCode>
+                    <gco:CharacterString>1762</gco:CharacterString>
+                  </gmd:postalCode>
+                  <gmd:electronicMailAddress>
+                    <gco:CharacterString>forets@fr.ch</gco:CharacterString>
+                  </gmd:electronicMailAddress>
+                  <che:streetName>
+                    <gco:CharacterString>Route du Mont-Carmel</gco:CharacterString>
+                  </che:streetName>
+                  <che:streetNumber>
+                    <gco:CharacterString>1</gco:CharacterString>
+                  </che:streetNumber>
+                </che:CHE_CI_Address>
+              </gmd:address>
+              <gmd:onlineResource>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                    <che:PT_FreeURL>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#FR">http://www.fr.ch/sff</che:LocalisedURL>
+                      </che:URLGroup>
+                    </che:PT_FreeURL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>text/html</gco:CharacterString>
+                  </gmd:protocol>
+                </gmd:CI_OnlineResource>
+              </gmd:onlineResource>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="owner" />
+          </gmd:role>
+          <che:individualFirstName>
+            <gco:CharacterString>Michel</gco:CharacterString>
+          </che:individualFirstName>
+          <che:individualLastName>
+            <gco:CharacterString>Spicher</gco:CharacterString>
+          </che:individualLastName>
+          <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>SFF</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">SFF</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </che:organisationAcronym>
+        </che:CHE_CI_ResponsibleParty>
+      </gmd:pointOfContact>
+      <gmd:resourceMaintenance>
+        <che:CHE_MD_MaintenanceInformation gco:isoType="gmd:MD_MaintenanceInformation">
+          <gmd:maintenanceAndUpdateFrequency>
+            <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="userDefined" />
+          </gmd:maintenanceAndUpdateFrequency>
+        </che:CHE_MD_MaintenanceInformation>
+      </gmd:resourceMaintenance>
+      <gmd:resourceFormat xmlns:xlink="http://www.w3.org/1999/xlink">
+        <gmd:MD_Format>
+          <gmd:name>
+            <gco:CharacterString>ESRI Enterprise Geodatabase</gco:CharacterString>
+          </gmd:name>
+          <gmd:version>
+            <gco:CharacterString>-</gco:CharacterString>
+          </gmd:version>
+        </gmd:MD_Format>
+      </gmd:resourceFormat>
+      <gmd:descriptiveKeywords xmlns:xlink="http://www.w3.org/1999/xlink">
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>forêt</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">forest</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Forst</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">foresta</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">forêt</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM" />
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>intervention au niveau de la nature et des paysages</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">intervention in nature and landscape</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Eingriff in Natur und Landschaft</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">intervento su natura e paesaggio</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">intervention au niveau de la nature et des paysages</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM" />
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="_none_" />
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>GEMET concepts</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2015-11-16</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xlink:href="http://www.geocat.ch/geonetwork/srv/eng/thesaurus.download?ref=external._none_.gemet">geonetwork.thesaurus.external._none_.gemet</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords xmlns:xlink="http://www.w3.org/1999/xlink">
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Lisière</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Forest edge</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Waldrand</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Margine forestale</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Lisière</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM" />
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="_none_" />
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>geocat.ch Thesaurus</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2016-02-02</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xlink:href="http://www.geocat.ch/geonetwork/srv/eng/thesaurus.download?ref=local._none_.geocat.ch">geonetwork.thesaurus.local._none_.geocat.ch</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:resourceConstraints>
+        <che:CHE_MD_LegalConstraints gco:isoType="gmd:MD_LegalConstraints">
+          <gmd:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Propriété de l'Etat de Fribourg, statut interne</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Propriété de l'Etat de Fribourg, statut interne</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:otherConstraints>
+        </che:CHE_MD_LegalConstraints>
+      </gmd:resourceConstraints>
+      <gmd:spatialRepresentationType>
+        <gmd:MD_SpatialRepresentationTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_SpatialRepresentationTypeCode" codeListValue="vector" />
+      </gmd:spatialRepresentationType>
+      <gmd:spatialResolution>
+        <gmd:MD_Resolution>
+          <gmd:equivalentScale>
+            <gmd:MD_RepresentativeFraction>
+              <gmd:denominator>
+                <gco:Integer>25000</gco:Integer>
+              </gmd:denominator>
+            </gmd:MD_RepresentativeFraction>
+          </gmd:equivalentScale>
+        </gmd:MD_Resolution>
+      </gmd:spatialResolution>
+      <gmd:language>
+        <gco:CharacterString>ger</gco:CharacterString>
+      </gmd:language>
+      <gmd:language>
+        <gco:CharacterString>fre</gco:CharacterString>
+      </gmd:language>
+      <gmd:characterSet>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterSet>
+      <gmd:topicCategory />
+      <gmd:topicCategory />
+      <gmd:topicCategory />
+      <gmd:topicCategory />
+      <gmd:topicCategory />
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>environment</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>environment_EnvironmentalProtection</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>environment_NatureProtection</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>biota</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:environmentDescription xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Serveur SDE : SDEUSER.SFF4030L_LISIERE_PRIORITAIRE</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Serveur SDE : SDEUSER.SFF4030L_LISIERE_PRIORITAIRE</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:environmentDescription>
+      <gmd:extent xmlns="http://www.isotc211.org/2005/gmd" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:show="embed">
+        <gmd:EX_Extent>
+          <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Fribourg</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Fribourg</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Fribourg</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Fribourg</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Fribourg</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM">Fribourg</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:description>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicDescription>
+              <gmd:geographicIdentifier>
+                <gmd:MD_Identifier>
+                  <gmd:code xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString>FR</gco:CharacterString>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#EN">FR</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">FR</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#FR">FR</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#IT">FR</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#RM">FR</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:geographicIdentifier>
+            </gmd:EX_GeographicDescription>
+          </gmd:geographicElement>
+          <gmd:geographicElement>
+            <gmd:EX_BoundingPolygon>
+              <gmd:extentTypeCode>
+                <gco:Boolean>1</gco:Boolean>
+              </gmd:extentTypeCode>
+              <gmd:polygon>
+                <gml:MultiSurface gml:id="N84bd990b5c6c4126bcbc6cdc1e1c47e8">
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="N84bd990b5c6c4126bcbc6cdc1e1c47e8.1">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>6.93 46.9 6.924 46.904 6.922 46.906 6.896 46.925 6.929 46.953 6.962 46.927 6.972 46.921 6.978 46.923 6.988 46.918 6.982 46.914 6.984 46.908 7.009 46.889 6.994 46.879 6.999 46.874 7.007 46.873 7.016 46.881 7.032 46.876 7.036 46.873 7.03 46.866 7.039 46.859 7.029 46.851 7.035 46.847 7.038 46.845 7.05 46.855 7.058 46.862 7.067 46.869 7.071 46.873 7.066 46.881 7.062 46.88 7.062 46.884 7.08 46.894 7.074 46.895 7.083 46.896 7.091 46.892 7.1 46.898 7.091 46.904 7.09 46.908 7.084 46.913 7.06 46.937 7.06 46.951 7.056 46.955 7.06 46.956 7.063 46.971 7.041 46.979 7.04 46.98 7.058 46.977 7.09 46.977 7.138 46.983 7.147 46.985 7.16 46.987 7.171 46.991 7.179 46.994 7.187 46.997 7.2 47.002 7.205 47.006 7.217 47.006 7.226 46.999 7.223 46.994 7.229 46.991 7.236 46.985 7.231 46.981 7.223 46.975 7.215 46.971 7.214 46.967 7.195 46.964 7.194 46.961 7.2 46.959 7.206 46.96 7.211 46.957 7.208 46.949 7.21 46.943 7.204 46.938 7.212 46.931 7.211 46.927 7.205 46.922 7.207 46.91 7.204 46.906 7.188 46.9 7.195 46.899 7.2 46.902 7.208 46.903 7.218 46.897 7.223 46.903 7.23 46.904 7.237 46.898 7.257 46.898 7.281 46.89 7.29 46.894 7.309 46.892 7.326 46.894 7.349 46.889 7.354 46.886 7.352 46.876 7.359 46.863 7.349 46.853 7.338 46.85 7.326 46.852 7.323 46.855 7.331 46.858 7.316 46.863 7.312 46.856 7.302 46.852 7.33 46.835 7.33 46.83 7.32 46.825 7.317 46.814 7.302 46.794 7.303 46.789 7.305 46.783 7.292 46.774 7.296 46.765 7.303 46.76 7.303 46.754 7.304 46.748 7.297 46.737 7.299 46.723 7.308 46.717 7.35 46.712 7.346 46.699 7.36 46.698 7.377 46.689 7.373 46.68 7.376 46.675 7.371 46.669 7.369 46.656 7.377 46.656 7.358 46.643 7.346 46.655 7.324 46.655 7.33 46.642 7.323 46.637 7.313 46.637 7.312 46.622 7.318 46.616 7.315 46.6 7.321 46.592 7.313 46.589 7.308 46.581 7.299 46.579 7.281 46.584 7.26 46.563 7.237 46.554 7.223 46.548 7.208 46.533 7.192 46.547 7.171 46.533 7.159 46.527 7.148 46.528 7.136 46.509 7.123 46.499 7.11 46.495 7.1 46.487 7.078 46.489 7.072 46.486 7.066 46.489 7.061 46.487 7.023 46.462 7.018 46.447 6.984 46.438 6.992 46.449 6.98 46.459 6.978 46.473 6.981 46.475 6.975 46.479 6.971 46.491 6.962 46.497 6.948 46.501 6.934 46.502 6.925 46.508 6.91 46.512 6.901 46.513 6.896 46.508 6.897 46.519 6.883 46.513 6.882 46.513 6.866 46.501 6.863 46.494 6.858 46.493 6.848 46.494 6.833 46.505 6.83 46.512 6.824 46.512 6.812 46.526 6.824 46.541 6.832 46.537 6.851 46.541 6.855 46.541 6.861 46.531 6.867 46.541 6.868 46.542 6.888 46.558 6.893 46.559 6.902 46.561 6.898 46.571 6.885 46.562 6.874 46.565 6.872 46.57 6.865 46.576 6.853 46.582 6.842 46.582 6.841 46.58 6.835 46.575 6.829 46.577 6.814 46.586 6.813 46.578 6.799 46.574 6.795 46.575 6.799 46.584 6.801 46.593 6.798 46.6 6.802 46.601 6.804 46.609 6.797 46.634 6.803 46.645 6.799 46.649 6.818 46.648 6.828 46.66 6.838 46.663 6.844 46.661 6.854 46.656 6.863 46.658 6.872 46.673 6.865 46.676 6.863 46.681 6.866 46.684 6.873 46.683 6.881 46.69 6.893 46.7 6.892 46.703 6.898 46.708 6.921 46.722 6.922 46.724 6.934 46.732 6.936 46.733 6.941 46.745 6.938 46.749 6.931 46.754 6.911 46.753 6.908 46.758 6.914 46.763 6.92 46.76 6.929 46.767 6.939 46.782 6.951 46.785 6.959 46.79 6.956 46.793 6.967 46.803 6.958 46.811 6.958 46.819 6.965 46.828 6.971 46.824 6.985 46.822 6.993 46.83 6.985 46.841 6.992 46.848 6.99 46.85 6.983 46.846 6.976 46.847 6.982 46.867 6.989 46.873 6.987 46.875 6.974 46.887 6.962 46.884 6.959 46.879 6.97 46.867 6.965 46.865 6.939 46.89 6.926 46.893 6.924 46.895 6.93 46.9</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                      <gml:interior>
+                        <gml:LinearRing>
+                          <gml:posList>7.124 46.901 7.138 46.908 7.136 46.917 7.132 46.919 7.115 46.916 7.113 46.911 7.119 46.902 7.124 46.901</gml:posList>
+                        </gml:LinearRing>
+                      </gml:interior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="N84bd990b5c6c4126bcbc6cdc1e1c47e8.2">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>6.767 46.809 6.742 46.827 6.78 46.853 6.866 46.909 6.891 46.887 6.904 46.879 6.911 46.881 6.921 46.871 6.912 46.867 6.892 46.865 6.896 46.861 6.913 46.866 6.93 46.854 6.919 46.847 6.908 46.835 6.905 46.824 6.911 46.813 6.905 46.806 6.907 46.805 6.913 46.804 6.92 46.81 6.931 46.806 6.917 46.787 6.911 46.78 6.907 46.783 6.894 46.777 6.877 46.776 6.864 46.781 6.864 46.784 6.853 46.786 6.843 46.779 6.84 46.781 6.833 46.775 6.818 46.778 6.814 46.779 6.805 46.786 6.798 46.783 6.783 46.793 6.776 46.79 6.787 46.8 6.784 46.803 6.779 46.801 6.777 46.803 6.767 46.809</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="N84bd990b5c6c4126bcbc6cdc1e1c47e8.3">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>6.829 46.753 6.829 46.756 6.844 46.765 6.846 46.771 6.85 46.775 6.86 46.766 6.86 46.764 6.868 46.76 6.873 46.758 6.882 46.75 6.867 46.733 6.868 46.728 6.862 46.725 6.852 46.726 6.852 46.727 6.838 46.733 6.828 46.735 6.817 46.733 6.811 46.728 6.806 46.727 6.788 46.728 6.794 46.736 6.798 46.734 6.816 46.738 6.829 46.753</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="N84bd990b5c6c4126bcbc6cdc1e1c47e8.4">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>6.759 46.725 6.749 46.732 6.768 46.744 6.773 46.751 6.786 46.748 6.784 46.735 6.771 46.721 6.763 46.717 6.759 46.722 6.759 46.725</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                </gml:MultiSurface>
+              </gmd:polygon>
+            </gmd:EX_BoundingPolygon>
+          </gmd:geographicElement>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicBoundingBox>
+              <gmd:extentTypeCode>
+                <gco:Boolean>1</gco:Boolean>
+              </gmd:extentTypeCode>
+              <!--native coords: 546871.0,143063.0,595318.0,206170.0-->
+              <gmd:westBoundLongitude>
+                <gco:Decimal>6.742</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>7.377</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>46.438</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>47.006</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+          </gmd:geographicElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+    </che:CHE_MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:contentInfo xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <che:CHE_MD_FeatureCatalogueDescription gco:isoType="gmd:MD_FeatureCatalogueDescription">
+      <gmd:complianceCode>
+        <gco:Boolean>0</gco:Boolean>
+      </gmd:complianceCode>
+      <gmd:language>
+        <gco:CharacterString>fre</gco:CharacterString>
+      </gmd:language>
+      <gmd:includedWithDataset>
+        <gco:Boolean>0</gco:Boolean>
+      </gmd:includedWithDataset>
+      <gmd:featureCatalogueCitation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Lisières forestières prioritaires</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Lisières forestières prioritaires</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:alternateTitle xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Lisières prioritaires</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Lisières prioritaires</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:alternateTitle>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2012-05-10</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_DateTypeCode" codeListValue="creation" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:presentationForm>
+            <gmd:CI_PresentationFormCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_PresentationFormCode" codeListValue="mapDigital" />
+          </gmd:presentationForm>
+        </gmd:CI_Citation>
+      </gmd:featureCatalogueCitation>
+      <che:class>
+        <che:CHE_MD_Class>
+          <che:name>
+            <gco:CharacterString>LISIERES_PRIORITAIRES</gco:CharacterString>
+          </che:name>
+          <che:description />
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>REMARQUE</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Remarque</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>LONGUEUR</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Longueur en m.</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>ROUTE</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Type de la route route bordant la lisière (si existante)</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>CORRIDOR</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Importance du corridor à faune (si existant)</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>REPTILE</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de site propice aux reptiles</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>P_P_SEC_CH</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de prairies et pâturages secs d'importance nationale</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>BAS_M_CH</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de bas-marais d'importance nationale</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>HAUT_M_CH</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de haut-marais d'importance nationale</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>MARECA_CH</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de site marécageux d'importance nationale</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>SIT_AMP_CH</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de site de reproduction des amphibiens d'importance nationale</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>P_MAIG_FR</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de prairie maigre du canton de Fribourg</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>BAS_M_FR</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de haut-marais d'importance cantonale</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>P_SEC_FR</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence de prairie et pâturage sec d'importance nationale</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>PRIORITE</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Type de priorité 1.Très haute: si les 3 types d'objets d'importance biologique sont attenant à cette lisière / 2.Haute: si 2 types d'objets d'importance biologique sont attenant à cette lisière / 3.Basse: si 1 seul type d'objets d'importance biologique est attenant à cette lisière / 4.Secondaire: si la lisière est proche d'une route de classe 4, d'une gravière ou se situe à plus de 1400m d'altitude et cela indépendamment du nombre d'objets d'importance biologique attenant à cette lisière.</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>ARR</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Numéro de l'arrondissement forestier</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>GRAVIERE</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Présence / absence d'une gravière</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>ALTITUDE</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>&lt; ou &gt; à 1400 m.</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+          <che:attribute>
+            <che:name>
+              <gco:CharacterString>REF</gco:CharacterString>
+            </che:name>
+            <che:description xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Numéro de référence</gco:CharacterString>
+            </che:description>
+            <che:namedType />
+          </che:attribute>
+        </che:CHE_MD_Class>
+      </che:class>
+      <che:modelType>
+        <che:CHE_MD_modelTypeCode codeListValue="FeatureDescription" codeList="#CHE_MD_modelTypeCode" />
+      </che:modelType>
+    </che:CHE_MD_FeatureCatalogueDescription>
+  </gmd:contentInfo>
+  <gmd:distributionInfo>
+    <gmd:MD_Distribution>
+      <gmd:distributionFormat xmlns:xlink="http://www.w3.org/1999/xlink">
+        <gmd:MD_Format>
+          <gmd:name>
+            <gco:CharacterString>ESRI Shapefile</gco:CharacterString>
+          </gmd:name>
+          <gmd:version>
+            <gco:CharacterString>-</gco:CharacterString>
+          </gmd:version>
+        </gmd:MD_Format>
+      </gmd:distributionFormat>
+    </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+  <gmd:dataQualityInfo xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan" xmlns:gmi="http://www.isotc211.org/2005/gmi">
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset" />
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Données crées en septembre 2011 par un stagiaire du SFF, sur la base d'une analyse SIG des critères mentionnés dans le résumé.</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Données crées en septembre 2011 par un stagiaire du SFF, sur la base d'une analyse SIG des critères mentionnés dans le résumé.</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:statement>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
+  <gmd:metadataMaintenance xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
+    <che:CHE_MD_MaintenanceInformation gco:isoType="gmd:MD_MaintenanceInformation">
+      <gmd:maintenanceAndUpdateFrequency>
+        <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="asNeeded" />
+      </gmd:maintenanceAndUpdateFrequency>
+    <che:CHE_Appraisal_AAP>
+      <che:CHE_DurationOfConservation>
+        <gco:integer>2</gco:integer>
+      </che:CHE_DurationOfConservation>
+      <che:CHE_CommentOnDurationOfConservation>
+        <gco:CharacterString>Comment on the duration of conservation</gco:CharacterString>
+      </che:CHE_CommentOnDurationOfConservation>
+      <che:CHE_AppraisalOfArchivalValue>
+        <che:CHE_AppraisalOfArchivalValueCode codeList="#CHE_AppraisalOfArchivalTypeCode" codeListValue="S" />
+      </che:CHE_AppraisalOfArchivalValue>
+      <che:CHE_ReasonForArchivingValue>
+	<che:CHE_ReasonForArchivingValueCode codeList="#CHE_ReasonForArchivingTypeCode" codeListValue="Legal relevance" />
+      </che:CHE_ReasonForArchivingValue>
+      <che:CHE_CommentOnArchivalValue>
+        <gco:CharacterString>A sample comment "on archival value"</gco:CharacterString>
+      </che:CHE_CommentOnArchivalValue>
+    </che:CHE_Appraisal_AAP>
+    </che:CHE_MD_MaintenanceInformation>
+  </gmd:metadataMaintenance>
+</che:CHE_MD_Metadata>
+

--- a/core/src/test/resources/org/fao/geonet/geocat/kernel/mdaaptest.xml
+++ b/core/src/test/resources/org/fao/geonet/geocat/kernel/mdaaptest.xml
@@ -289,6 +289,88 @@
             </gmd:PT_FreeText>
           </che:organisationAcronym>
         </che:CHE_CI_ResponsibleParty>
+               <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
+          <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Service des forêts et de la faune</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Service des forêts et de la faune</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:organisationName>
+          <gmd:positionName xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Collaborateur scientifique</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Collaborateur scientifique</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:positionName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:phone>
+                <che:CHE_CI_Telephone gco:isoType="gmd:CI_Telephone">
+                  <gmd:facsimile>
+                    <gco:CharacterString>026 / 305 23 36</gco:CharacterString>
+                  </gmd:facsimile>
+                  <che:directNumber>
+                    <gco:CharacterString>026 / 305 23 43</gco:CharacterString>
+                  </che:directNumber>
+                </che:CHE_CI_Telephone>
+              </gmd:phone>
+              <gmd:address>
+                <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+                  <gmd:city>
+                    <gco:CharacterString>Givisiez</gco:CharacterString>
+                  </gmd:city>
+                  <gmd:postalCode>
+                    <gco:CharacterString>1762</gco:CharacterString>
+                  </gmd:postalCode>
+                  <gmd:electronicMailAddress>
+                    <gco:CharacterString>forets@fr.ch</gco:CharacterString>
+                  </gmd:electronicMailAddress>
+                  <che:streetName>
+                    <gco:CharacterString>Route du Mont-Carmel</gco:CharacterString>
+                  </che:streetName>
+                  <che:streetNumber>
+                    <gco:CharacterString>1</gco:CharacterString>
+                  </che:streetNumber>
+                </che:CHE_CI_Address>
+              </gmd:address>
+              <gmd:onlineResource>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                    <che:PT_FreeURL>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#FR">http://www.fr.ch/sff</che:LocalisedURL>
+                      </che:URLGroup>
+                    </che:PT_FreeURL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>text/html</gco:CharacterString>
+                  </gmd:protocol>
+                </gmd:CI_OnlineResource>
+              </gmd:onlineResource>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="specialistAuthority" />
+          </gmd:role>
+          <che:individualFirstName>
+            <gco:CharacterString>Pierre</gco:CharacterString>
+          </che:individualFirstName>
+          <che:individualLastName>
+            <gco:CharacterString>Mauduit</gco:CharacterString>
+          </che:individualLastName>
+          <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>SFF</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Camptocamp</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </che:organisationAcronym>
+        </che:CHE_CI_ResponsibleParty>
       </gmd:pointOfContact>
       <gmd:resourceMaintenance>
         <che:CHE_MD_MaintenanceInformation gco:isoType="gmd:MD_MaintenanceInformation">
@@ -613,6 +695,15 @@
           </gmd:geographicElement>
         </gmd:EX_Extent>
       </gmd:extent>
+      <che:basicGeodataID>
+          <gco:CharacterString>101.2-TG</gco:CharacterString>
+      </che:basicGeodataID>
+      <che:basicGeodataIDType>
+          <che:basicGeodataIDTypeCode codeList="#basicGeodataIDTypeCode" codeListValue="federal" />
+      </che:basicGeodataIDType>
+      <che:geodataType>
+          <che:MD_geodataTypeCode codeList="#MD_geodataTypeCode" codeListValue="ReferenceGeodata"/>
+      </che:geodataType>
     </che:CHE_MD_DataIdentification>
   </gmd:identificationInfo>
   <gmd:contentInfo xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
@@ -876,23 +967,25 @@
       <gmd:maintenanceAndUpdateFrequency>
         <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="asNeeded" />
       </gmd:maintenanceAndUpdateFrequency>
-      <che:CHE_Appraisal_AAP>
-        <che:CHE_DurationOfConservation>
-          <gco:Integer>3</gco:Integer>
-        </che:CHE_DurationOfConservation>
-        <che:CHE_CommentOnDurationOfConservation>
-          <gco:CharacterString>3 years should be sufficient for any MD - sample comment</gco:CharacterString>
-        </che:CHE_CommentOnDurationOfConservation>
-        <che:CHE_AppraisalOfArchivalValue>
-          <che:CHE_AppraisalOfArchivalValueCode codeList="#CHE_AppraisalOfArchivalValueCode" codeListValue="S"/>
-        </che:CHE_AppraisalOfArchivalValue>
-        <che:CHE_ReasonForArchivingValue>
-          <che:CHE_ReasonForArchivingValueCode codeList="#CHE_ReasonForArchingValueCode" codeListValue="evidenceOfBusinessPractice"/>
-        </che:CHE_ReasonForArchivingValue>
-        <che:CHE_CommentOnArchivalValue>
-          <gco:CharacterString>Sample comment on the archival value</gco:CharacterString>
-        </che:CHE_CommentOnArchivalValue>
-      </che:CHE_Appraisal_AAP>
+      <che:appraisal>
+      <che:CHE_MD_Appraisal_AAP>
+         <che:durationOfConservation>
+            <gco:Integer>3</gco:Integer>
+         </che:durationOfConservation>
+         <che:commentOnDurationOfConservation>
+            <gco:CharacterString>Sample comment on the duration of conservation</gco:CharacterString>
+         </che:commentOnDurationOfConservation>
+         <che:appraisalOfArchivalValue>
+            <che:CHE_AppraisalOfArchivalValueCode codeList="#CHE_AppraisalOfArchivalValueCode" codeListValue="S"/>
+         </che:appraisalOfArchivalValue>
+         <che:reasonForArchivingValue>
+            <che:CHE_ReasonForArchivingValueCode codeList="#CHE_ReasonForArchivingValueCode" codeListValue="definingPowers"/>
+         </che:reasonForArchivingValue>
+         <che:commentOnArchivalValue>
+            <gco:CharacterString>Sample comment on the archival value</gco:CharacterString>
+         </che:commentOnArchivalValue>
+      </che:CHE_MD_Appraisal_AAP>
+    </che:appraisal>
     </che:CHE_MD_MaintenanceInformation>
   </gmd:metadataMaintenance>
 </che:CHE_MD_Metadata>

--- a/core/src/test/resources/org/fao/geonet/geocat/kernel/mdaaptest.xml
+++ b/core/src/test/resources/org/fao/geonet/geocat/kernel/mdaaptest.xml
@@ -7,10 +7,10 @@
     <gco:CharacterString>fre</gco:CharacterString>
   </gmd:language>
   <gmd:characterSet xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
-    <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+    <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8"/>
   </gmd:characterSet>
   <gmd:hierarchyLevel xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
-    <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset" />
+    <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset"/>
   </gmd:hierarchyLevel>
   <gmd:contact xmlns:xlink="http://www.w3.org/1999/xlink" xlink:show="embed">
     <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
@@ -78,7 +78,7 @@
         </gmd:CI_Contact>
       </gmd:contactInfo>
       <gmd:role>
-        <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="pointOfContact" />
+        <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="pointOfContact"/>
       </gmd:role>
       <che:individualFirstName>
         <gco:CharacterString>Michel</gco:CharacterString>
@@ -105,40 +105,40 @@
   <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
     <gmd:PT_Locale id="FR">
       <gmd:languageCode>
-        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre"/>
       </gmd:languageCode>
       <gmd:characterEncoding>
-        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8"/>
       </gmd:characterEncoding>
     </gmd:PT_Locale>
   </gmd:locale>
   <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
     <gmd:PT_Locale id="DE">
       <gmd:languageCode>
-        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger" />
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger"/>
       </gmd:languageCode>
       <gmd:characterEncoding>
-        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8"/>
       </gmd:characterEncoding>
     </gmd:PT_Locale>
   </gmd:locale>
   <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
     <gmd:PT_Locale id="IT">
       <gmd:languageCode>
-        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ita" />
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ita"/>
       </gmd:languageCode>
       <gmd:characterEncoding>
-        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8"/>
       </gmd:characterEncoding>
     </gmd:PT_Locale>
   </gmd:locale>
   <gmd:locale xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
     <gmd:PT_Locale id="EN">
       <gmd:languageCode>
-        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng" />
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng"/>
       </gmd:languageCode>
       <gmd:characterEncoding>
-        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8"/>
       </gmd:characterEncoding>
     </gmd:PT_Locale>
   </gmd:locale>
@@ -168,12 +168,12 @@
                 <gco:Date>2011-09-01</gco:Date>
               </gmd:date>
               <gmd:dateType>
-                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation" />
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation"/>
               </gmd:dateType>
             </gmd:CI_Date>
           </gmd:date>
           <gmd:presentationForm>
-            <gmd:CI_PresentationFormCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_PresentationFormCode" codeListValue="mapDigital" />
+            <gmd:CI_PresentationFormCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_PresentationFormCode" codeListValue="mapDigital"/>
           </gmd:presentationForm>
         </gmd:CI_Citation>
       </gmd:citation>
@@ -203,8 +203,31 @@
           </gmd:textGroup>
         </gmd:PT_FreeText>
       </gmd:abstract>
+      <gmd:resourceMaintenance>
+        <che:CHE_MD_MaintenanceInformation gco:isoType="gmd:MD_MaintenanceInformation">
+          <che:appraisal>
+            <che:CHE_MD_Appraisal_AAP>
+              <che:durationOfConservation>
+                <gco:Integer>3</gco:Integer>
+              </che:durationOfConservation>
+              <che:commentOnDurationOfConservation>
+                <gco:CharacterString>Sample comment on the duration of conservation</gco:CharacterString>
+              </che:commentOnDurationOfConservation>
+              <che:appraisalOfArchivalValue>
+                <che:CHE_AppraisalOfArchivalValueCode codeList="#CHE_AppraisalOfArchivalValueCode" codeListValue="S"/>
+              </che:appraisalOfArchivalValue>
+              <che:reasonForArchivingValue>
+                <che:CHE_ReasonForArchivingValueCode codeList="#CHE_ReasonForArchivingValueCode" codeListValue="definingPowers"/>
+              </che:reasonForArchivingValue>
+              <che:commentOnArchivalValue>
+                <gco:CharacterString>Sample comment on the archival value</gco:CharacterString>
+              </che:commentOnArchivalValue>
+            </che:CHE_MD_Appraisal_AAP>
+          </che:appraisal>
+        </che:CHE_MD_MaintenanceInformation>
+      </gmd:resourceMaintenance>
       <gmd:status>
-        <gmd:MD_ProgressCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ProgressCode" codeListValue="onGoing" />
+        <gmd:MD_ProgressCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ProgressCode" codeListValue="onGoing"/>
       </gmd:status>
       <gmd:pointOfContact xmlns:xlink="http://www.w3.org/1999/xlink" xlink:show="embed">
         <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
@@ -272,7 +295,7 @@
             </gmd:CI_Contact>
           </gmd:contactInfo>
           <gmd:role>
-            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="owner" />
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="owner"/>
           </gmd:role>
           <che:individualFirstName>
             <gco:CharacterString>Michel</gco:CharacterString>
@@ -289,7 +312,7 @@
             </gmd:PT_FreeText>
           </che:organisationAcronym>
         </che:CHE_CI_ResponsibleParty>
-               <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
+        <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
           <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
             <gco:CharacterString>Service des forêts et de la faune</gco:CharacterString>
             <gmd:PT_FreeText>
@@ -354,7 +377,7 @@
             </gmd:CI_Contact>
           </gmd:contactInfo>
           <gmd:role>
-            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="specialistAuthority" />
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="specialistAuthority"/>
           </gmd:role>
           <che:individualFirstName>
             <gco:CharacterString>Pierre</gco:CharacterString>
@@ -375,7 +398,7 @@
       <gmd:resourceMaintenance>
         <che:CHE_MD_MaintenanceInformation gco:isoType="gmd:MD_MaintenanceInformation">
           <gmd:maintenanceAndUpdateFrequency>
-            <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="userDefined" />
+            <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="userDefined"/>
           </gmd:maintenanceAndUpdateFrequency>
         </che:CHE_MD_MaintenanceInformation>
       </gmd:resourceMaintenance>
@@ -407,7 +430,7 @@
                 <gmd:LocalisedCharacterString locale="#FR">forêt</gmd:LocalisedCharacterString>
               </gmd:textGroup>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#RM" />
+                <gmd:LocalisedCharacterString locale="#RM"/>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:keyword>
@@ -427,12 +450,12 @@
                 <gmd:LocalisedCharacterString locale="#FR">intervention au niveau de la nature et des paysages</gmd:LocalisedCharacterString>
               </gmd:textGroup>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#RM" />
+                <gmd:LocalisedCharacterString locale="#RM"/>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:keyword>
           <gmd:type>
-            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="_none_" />
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="_none_"/>
           </gmd:type>
           <gmd:thesaurusName>
             <gmd:CI_Citation>
@@ -445,7 +468,7 @@
                     <gco:Date>2015-11-16</gco:Date>
                   </gmd:date>
                   <gmd:dateType>
-                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
                   </gmd:dateType>
                 </gmd:CI_Date>
               </gmd:date>
@@ -478,12 +501,12 @@
                 <gmd:LocalisedCharacterString locale="#FR">Lisière</gmd:LocalisedCharacterString>
               </gmd:textGroup>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#RM" />
+                <gmd:LocalisedCharacterString locale="#RM"/>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:keyword>
           <gmd:type>
-            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="_none_" />
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="_none_"/>
           </gmd:type>
           <gmd:thesaurusName>
             <gmd:CI_Citation>
@@ -496,7 +519,7 @@
                     <gco:Date>2016-02-02</gco:Date>
                   </gmd:date>
                   <gmd:dateType>
-                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
                   </gmd:dateType>
                 </gmd:CI_Date>
               </gmd:date>
@@ -524,7 +547,7 @@
         </che:CHE_MD_LegalConstraints>
       </gmd:resourceConstraints>
       <gmd:spatialRepresentationType>
-        <gmd:MD_SpatialRepresentationTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_SpatialRepresentationTypeCode" codeListValue="vector" />
+        <gmd:MD_SpatialRepresentationTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_SpatialRepresentationTypeCode" codeListValue="vector"/>
       </gmd:spatialRepresentationType>
       <gmd:spatialResolution>
         <gmd:MD_Resolution>
@@ -544,13 +567,13 @@
         <gco:CharacterString>fre</gco:CharacterString>
       </gmd:language>
       <gmd:characterSet>
-        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8"/>
       </gmd:characterSet>
-      <gmd:topicCategory />
-      <gmd:topicCategory />
-      <gmd:topicCategory />
-      <gmd:topicCategory />
-      <gmd:topicCategory />
+      <gmd:topicCategory/>
+      <gmd:topicCategory/>
+      <gmd:topicCategory/>
+      <gmd:topicCategory/>
+      <gmd:topicCategory/>
       <gmd:topicCategory>
         <gmd:MD_TopicCategoryCode>environment</gmd:MD_TopicCategoryCode>
       </gmd:topicCategory>
@@ -696,13 +719,13 @@
         </gmd:EX_Extent>
       </gmd:extent>
       <che:basicGeodataID>
-          <gco:CharacterString>101.2-TG</gco:CharacterString>
+        <gco:CharacterString>101.2-TG</gco:CharacterString>
       </che:basicGeodataID>
       <che:basicGeodataIDType>
-          <che:basicGeodataIDTypeCode codeList="#basicGeodataIDTypeCode" codeListValue="federal" />
+        <che:basicGeodataIDTypeCode codeList="#basicGeodataIDTypeCode" codeListValue="federal"/>
       </che:basicGeodataIDType>
       <che:geodataType>
-          <che:MD_geodataTypeCode codeList="#MD_geodataTypeCode" codeListValue="ReferenceGeodata"/>
+        <che:MD_geodataTypeCode codeList="#MD_geodataTypeCode" codeListValue="ReferenceGeodata"/>
       </che:geodataType>
     </che:CHE_MD_DataIdentification>
   </gmd:identificationInfo>
@@ -741,12 +764,12 @@
                 <gco:Date>2012-05-10</gco:Date>
               </gmd:date>
               <gmd:dateType>
-                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_DateTypeCode" codeListValue="creation" />
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_DateTypeCode" codeListValue="creation"/>
               </gmd:dateType>
             </gmd:CI_Date>
           </gmd:date>
           <gmd:presentationForm>
-            <gmd:CI_PresentationFormCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_PresentationFormCode" codeListValue="mapDigital" />
+            <gmd:CI_PresentationFormCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_PresentationFormCode" codeListValue="mapDigital"/>
           </gmd:presentationForm>
         </gmd:CI_Citation>
       </gmd:featureCatalogueCitation>
@@ -755,7 +778,7 @@
           <che:name>
             <gco:CharacterString>LISIERES_PRIORITAIRES</gco:CharacterString>
           </che:name>
-          <che:description />
+          <che:description/>
           <che:attribute>
             <che:name>
               <gco:CharacterString>REMARQUE</gco:CharacterString>
@@ -763,7 +786,7 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>Remarque</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
           <che:attribute>
             <che:name>
@@ -772,7 +795,7 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>Longueur en m.</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
           <che:attribute>
             <che:name>
@@ -781,7 +804,7 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>Type de la route route bordant la lisière (si existante)</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
           <che:attribute>
             <che:name>
@@ -790,7 +813,7 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>Importance du corridor à faune (si existant)</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
           <che:attribute>
             <che:name>
@@ -799,7 +822,7 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>Présence / absence de site propice aux reptiles</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
           <che:attribute>
             <che:name>
@@ -808,7 +831,7 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>Présence / absence de prairies et pâturages secs d'importance nationale</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
           <che:attribute>
             <che:name>
@@ -817,7 +840,7 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>Présence / absence de bas-marais d'importance nationale</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
           <che:attribute>
             <che:name>
@@ -826,7 +849,7 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>Présence / absence de haut-marais d'importance nationale</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
           <che:attribute>
             <che:name>
@@ -835,7 +858,7 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>Présence / absence de site marécageux d'importance nationale</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
           <che:attribute>
             <che:name>
@@ -844,7 +867,7 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>Présence / absence de site de reproduction des amphibiens d'importance nationale</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
           <che:attribute>
             <che:name>
@@ -853,7 +876,7 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>Présence / absence de prairie maigre du canton de Fribourg</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
           <che:attribute>
             <che:name>
@@ -862,7 +885,7 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>Présence / absence de haut-marais d'importance cantonale</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
           <che:attribute>
             <che:name>
@@ -871,7 +894,7 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>Présence / absence de prairie et pâturage sec d'importance nationale</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
           <che:attribute>
             <che:name>
@@ -880,7 +903,7 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>Type de priorité 1.Très haute: si les 3 types d'objets d'importance biologique sont attenant à cette lisière / 2.Haute: si 2 types d'objets d'importance biologique sont attenant à cette lisière / 3.Basse: si 1 seul type d'objets d'importance biologique est attenant à cette lisière / 4.Secondaire: si la lisière est proche d'une route de classe 4, d'une gravière ou se situe à plus de 1400m d'altitude et cela indépendamment du nombre d'objets d'importance biologique attenant à cette lisière.</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
           <che:attribute>
             <che:name>
@@ -889,7 +912,7 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>Numéro de l'arrondissement forestier</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
           <che:attribute>
             <che:name>
@@ -898,7 +921,7 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>Présence / absence d'une gravière</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
           <che:attribute>
             <che:name>
@@ -907,7 +930,7 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>&lt; ou &gt; à 1400 m.</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
           <che:attribute>
             <che:name>
@@ -916,12 +939,12 @@
             <che:description xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>Numéro de référence</gco:CharacterString>
             </che:description>
-            <che:namedType />
+            <che:namedType/>
           </che:attribute>
         </che:CHE_MD_Class>
       </che:class>
       <che:modelType>
-        <che:CHE_MD_modelTypeCode codeListValue="FeatureDescription" codeList="#CHE_MD_modelTypeCode" />
+        <che:CHE_MD_modelTypeCode codeListValue="FeatureDescription" codeList="#CHE_MD_modelTypeCode"/>
       </che:modelType>
     </che:CHE_MD_FeatureCatalogueDescription>
   </gmd:contentInfo>
@@ -944,7 +967,7 @@
       <gmd:scope>
         <gmd:DQ_Scope>
           <gmd:level>
-            <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset" />
+            <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset"/>
           </gmd:level>
         </gmd:DQ_Scope>
       </gmd:scope>
@@ -965,28 +988,8 @@
   <gmd:metadataMaintenance xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive" xmlns:xalan="http://xml.apache.org/xalan">
     <che:CHE_MD_MaintenanceInformation gco:isoType="gmd:MD_MaintenanceInformation">
       <gmd:maintenanceAndUpdateFrequency>
-        <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="asNeeded" />
+        <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="asNeeded"/>
       </gmd:maintenanceAndUpdateFrequency>
-      <che:appraisal>
-      <che:CHE_MD_Appraisal_AAP>
-         <che:durationOfConservation>
-            <gco:Integer>3</gco:Integer>
-         </che:durationOfConservation>
-         <che:commentOnDurationOfConservation>
-            <gco:CharacterString>Sample comment on the duration of conservation</gco:CharacterString>
-         </che:commentOnDurationOfConservation>
-         <che:appraisalOfArchivalValue>
-            <che:CHE_AppraisalOfArchivalValueCode codeList="#CHE_AppraisalOfArchivalValueCode" codeListValue="S"/>
-         </che:appraisalOfArchivalValue>
-         <che:reasonForArchivingValue>
-            <che:CHE_ReasonForArchivingValueCode codeList="#CHE_ReasonForArchivingValueCode" codeListValue="definingPowers"/>
-         </che:reasonForArchivingValue>
-         <che:commentOnArchivalValue>
-            <gco:CharacterString>Sample comment on the archival value</gco:CharacterString>
-         </che:commentOnArchivalValue>
-      </che:CHE_MD_Appraisal_AAP>
-    </che:appraisal>
     </che:CHE_MD_MaintenanceInformation>
   </gmd:metadataMaintenance>
 </che:CHE_MD_Metadata>
-

--- a/core/src/test/resources/org/fao/geonet/geocat/kernel/mdaaptest.xml
+++ b/core/src/test/resources/org/fao/geonet/geocat/kernel/mdaaptest.xml
@@ -876,23 +876,23 @@
       <gmd:maintenanceAndUpdateFrequency>
         <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="asNeeded" />
       </gmd:maintenanceAndUpdateFrequency>
-    <che:CHE_Appraisal_AAP>
-      <che:CHE_DurationOfConservation>
-        <gco:integer>2</gco:integer>
-      </che:CHE_DurationOfConservation>
-      <che:CHE_CommentOnDurationOfConservation>
-        <gco:CharacterString>Comment on the duration of conservation</gco:CharacterString>
-      </che:CHE_CommentOnDurationOfConservation>
-      <che:CHE_AppraisalOfArchivalValue>
-        <che:CHE_AppraisalOfArchivalValueCode codeList="#CHE_AppraisalOfArchivalTypeCode" codeListValue="S" />
-      </che:CHE_AppraisalOfArchivalValue>
-      <che:CHE_ReasonForArchivingValue>
-	<che:CHE_ReasonForArchivingValueCode codeList="#CHE_ReasonForArchivingTypeCode" codeListValue="Legal relevance" />
-      </che:CHE_ReasonForArchivingValue>
-      <che:CHE_CommentOnArchivalValue>
-        <gco:CharacterString>A sample comment "on archival value"</gco:CharacterString>
-      </che:CHE_CommentOnArchivalValue>
-    </che:CHE_Appraisal_AAP>
+      <che:CHE_Appraisal_AAP>
+        <che:CHE_durationOfConservation>
+          <gco:Integer>3</gco:Integer>
+        </che:CHE_durationOfConservation>
+        <che:CHE_commentOnDurationOfConservation>
+          <gco:CharacterString>3 years should be sufficient for any MD - sample comment</gco:CharacterString>
+        </che:CHE_commentOnDurationOfConservation>
+        <che:CHE_AppraisalOfArchivalValue>
+          <che:CHE_AppraisalOfArchivalValueCode codeList="#CHE_AppraisalOfArchivalValueCode" codeListValue="S"/>
+        </che:CHE_AppraisalOfArchivalValue>
+        <che:CHE_ReasonForArchivingValue>
+          <che:CHE_ReasonForArchingValueCode codeList="#CHE_ReasonForArchingValueCode" codeListValue="evidenceOfBusinessPractice"/>
+        </che:CHE_ReasonForArchivingValue>
+        <che:CHE_commentOnArchivalValue>
+          <gco:CharacterString>Sample comment on the archival value</gco:CharacterString>
+        </che:CHE_commentOnArchivalValue>
+      </che:CHE_Appraisal_AAP>
     </che:CHE_MD_MaintenanceInformation>
   </gmd:metadataMaintenance>
 </che:CHE_MD_Metadata>

--- a/domain/src/main/java/org/fao/geonet/domain/SchematronCriteriaType.java
+++ b/domain/src/main/java/org/fao/geonet/domain/SchematronCriteriaType.java
@@ -56,6 +56,12 @@ public enum SchematronCriteriaType {
         public boolean accepts(ApplicationContext applicationContext, String value, int metadataId, Element metadata,
                                List<Namespace> metadataNamespaces) {
 
+            // if values is empty, consider the criteria as not accepted.
+            // Since the value is editable in the schematron admin interface
+            // we cannot rely on this user input.
+            if (value == null || value.equals("")) {
+                return false;
+            }
 
             String[] values = value.split(",");
             Integer[] ids = new Integer[values.length];

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/formatter/full_view/view.groovy
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/formatter/full_view/view.groovy
@@ -10,3 +10,5 @@ handlers.add name: 'gmd:topicCategory', select: 'gmd:topicCategory', group: true
     def listItems = elems.findAll{!it.text().isEmpty() && !iso19139TopicCategories.contains(it.text())}.collect {f.codelistValueLabel("MD_TopicCategoryCode", it.text())};
     handlers.fileResult("html/list-entry.html", [label:f.nodeLabel(elems[0]), listItems: listItems])
 }
+
+handlers.skip name: 'skip che:CHE_MD_Appraisal_AAP', select: { it -> it.name() == 'che:CHE_MD_Appraisal_AAP' }, { it.children() }

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/index-fields/default.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/index-fields/default.xsl
@@ -433,7 +433,7 @@
         <!-- === maintenance Info (AAP) === -->
         
         <xsl:choose>
-            <xsl:when test="gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/che:CHE_Appraisal_AAP">
+            <xsl:when test="gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/che:appraisal">
                 <Field name="AAP" string="true" store="true" index="true"/>
             </xsl:when>
             <xsl:otherwise>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/index-fields/default.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/index-fields/default.xsl
@@ -430,18 +430,6 @@
         </xsl:for-each>
 
         <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-        <!-- === maintenance Info (AAP) === -->
-        
-        <xsl:choose>
-          <xsl:when test="gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword/gco:CharacterString[text() = 'AAP-Bund']">
-                <Field name="AAP" string="true" store="true" index="true"/>
-            </xsl:when>
-            <xsl:otherwise>
-                <Field name="AAP" string="false" store="true" index="true"/>
-            </xsl:otherwise>
-        </xsl:choose>
-
-        <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
         <!-- === Service stuff ===  -->
         <!-- Service type           -->
         <xsl:for-each select="gmd:identificationInfo/srv:SV_ServiceIdentification/srv:serviceType/gco:LocalName|

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/index-fields/default.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/index-fields/default.xsl
@@ -429,7 +429,17 @@
             </xsl:for-each>
         </xsl:for-each>
 
-
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <!-- === maintenance Info (AAP) === -->
+        
+        <xsl:choose>
+            <xsl:when test="gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/che:CHE_Appraisal_AAP">
+                <Field name="AAP" string="true" store="true" index="true"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <Field name="AAP" string="false" store="true" index="true"/>
+            </xsl:otherwise>
+        </xsl:choose>
 
         <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
         <!-- === Service stuff ===  -->

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/index-fields/default.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/index-fields/default.xsl
@@ -433,7 +433,7 @@
         <!-- === maintenance Info (AAP) === -->
         
         <xsl:choose>
-            <xsl:when test="gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/che:appraisal">
+          <xsl:when test="gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword/gco:CharacterString[text() = 'AAP-Bund']">
                 <Field name="AAP" string="true" store="true" index="true"/>
             </xsl:when>
             <xsl:otherwise>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/index-fields/language-default.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/index-fields/language-default.xsl
@@ -257,6 +257,18 @@
 					<Field name="keywordType" string="{string(.)}" store="true" index="true"/>
 				</xsl:for-each>
 			</xsl:for-each>
+
+            <!-- === maintenance Info (AAP) ===             -->
+            <xsl:choose>
+                <xsl:when
+                    test="*/gmd:MD_Keywords/gmd:keyword/gco:CharacterString[text()='AAP-Bund']|
+                    */gmd:MD_Keywords/gmd:keyword/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[text()='AAP-Bund']">
+                    <Field name="AAP" string="true" store="true" index="true" />
+                </xsl:when>
+                <xsl:otherwise>
+                    <Field name="AAP" string="false" store="true" index="true" />
+                </xsl:otherwise>
+            </xsl:choose>
 	
 			<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->		
     

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/index-fields/language-default.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/index-fields/language-default.xsl
@@ -261,8 +261,8 @@
             <!-- === maintenance Info (AAP) ===             -->
             <xsl:choose>
                 <xsl:when
-                    test="*/gmd:MD_Keywords/gmd:keyword/gco:CharacterString[text()='AAP-Bund']|
-                    */gmd:MD_Keywords/gmd:keyword/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[text()='AAP-Bund']">
+                    test="*/gmd:MD_Keywords/gmd:keyword/gco:CharacterString[text()='Aufbewahrungs- und Archivierungsplanung AAP']|
+                    */gmd:MD_Keywords/gmd:keyword/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[text()='Aufbewahrungs- und Archivierungsplanung AAP']">
                     <Field name="AAP" string="true" store="true" index="true" />
                 </xsl:when>
                 <xsl:otherwise>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
@@ -352,9 +352,9 @@
         <for name="gmd:topicCategory"/>
         <for name="gmd:transferOptions"/>
         <for name="gmd:date"/>
-        <for name="che:appraisal"/>
-        <!--<for name="che:commentOnDurationOfConservation"/>
-        <for name="che:commentOnArchivalValue"/>-->
+         <!--<for name="che:appraisal"/>
+         <for name="che:commentOnDurationOfConservation"/>
+         <for name="che:commentOnArchivalValue"/>-->
         <for name="che:attribute"/>
       </flatModeExceptions>
 

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
@@ -281,6 +281,7 @@
       <name ancestor="gmd:contactInfo">gmd:country</name>
       <name ancestor="gmd:DQ_DomainConsistency">gmd:explanation</name>
       <name>che:code</name>
+      <name>che:durationOfConservation</name>
     </exclude>
   </multilingualFields>
 

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
@@ -281,7 +281,7 @@
       <name ancestor="gmd:contactInfo">gmd:country</name>
       <name ancestor="gmd:DQ_DomainConsistency">gmd:explanation</name>
       <name>che:code</name>
-      <name>che:CHE_durationOfConservation</name>
+      <name>che:CHE_DurationOfConservation</name>
     </exclude>
   </multilingualFields>
 

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
@@ -166,6 +166,7 @@
     <name>gmd:geographicBox</name>
     <name>gmd:EX_TemporalExtent</name>
     <name>gmd:MD_Distributor</name>
+    <name>che:appraisal</name>
     <name>srv:containsOperations</name>
     <name>srv:SV_CoupledResource</name>
     <name>gmd:metadataConstraints</name>
@@ -281,7 +282,7 @@
       <name ancestor="gmd:contactInfo">gmd:country</name>
       <name ancestor="gmd:DQ_DomainConsistency">gmd:explanation</name>
       <name>che:code</name>
-      <name>che:CHE_DurationOfConservation</name>
+      <name>che:durationOfConservation</name>
     </exclude>
   </multilingualFields>
 
@@ -351,6 +352,9 @@
         <for name="gmd:topicCategory"/>
         <for name="gmd:transferOptions"/>
         <for name="gmd:date"/>
+        <for name="che:appraisal"/>
+        <!--<for name="che:commentOnDurationOfConservation"/>
+        <for name="che:commentOnArchivalValue"/>-->
         <for name="che:attribute"/>
       </flatModeExceptions>
 

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
@@ -281,7 +281,7 @@
       <name ancestor="gmd:contactInfo">gmd:country</name>
       <name ancestor="gmd:DQ_DomainConsistency">gmd:explanation</name>
       <name>che:code</name>
-      <name>che:durationOfConservation</name>
+      <name>che:CHE_durationOfConservation</name>
     </exclude>
   </multilingualFields>
 

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/codelists.xml
@@ -568,5 +568,68 @@
             <description>Specialist authority</description>
         </entry>
     </codelist>
-    
+    <codelist name="che:CHE_MD_ArchivalValueCode">
+        <entry>
+            <code>A</code>
+            <label>of archival value</label>
+            <description>of archival value</description>
+        </entry>
+        <entry>
+            <code>N</code>
+            <label>no archival value</label>
+            <description>no archival value</description>
+        </entry>
+        <entry>
+            <code>S</code>
+            <label>Sampling / Selection</label>
+            <description>Sampling / Selection</description>
+        </entry>
+    </codelist>
+    <codelist name="che:CHE_MD_ArchivalReasonCode">
+        <entry>
+            <code>legalRelevance</code>
+            <label>Legal relevance</label>
+            <description>Legal relevance</description>
+        </entry>
+        <entry>
+            <code>guaranteeOfLegalCertainty</code>
+            <label>Guarantee of legal certainty</label>
+            <description>Guarantee of legal certainty</description>
+        </entry>
+        <entry>
+            <code>evidenceOfBusinessPractice</code>
+            <label>Evidence of business practice</label>
+            <description>Evidence of business practice</description>
+        </entry>
+        <entry>
+            <code>benefitsForResearch</code>
+            <label>Benefits for research</label>
+            <description>Benefits for research</description>
+        </entry>
+        <entry>
+            <code>contemporaryInterest</code>
+            <label>Contemporary interest</label>
+            <description>Contemporary interest</description>
+        </entry>
+        <entry>
+            <code>sensitivity</code>
+            <label>Sensitivity</label>
+            <description>Sensitivity</description>
+        </entry>
+        <entry>
+            <code>developmentsProgression</code>
+            <label>Developments / Progression</label>
+            <description>Developments / Progression</description>
+        </entry>
+        <entry>
+            <code>definingPowers</code>
+            <label>Defining powers</label>
+            <description>Defining powers</description>
+        </entry>
+        <entry>
+            <code>empty</code>
+            <label>empty</label>
+            <description>empty</description>
+        </entry>
+    </codelist>
 </codelists>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/codelists.xml
@@ -581,8 +581,8 @@
         </entry>
         <entry>
             <code>S</code>
-            <label>Sampling / Selection</label>
-            <description>Sampling / Selection</description>
+            <label>sampling / selection</label>
+            <description>sampling / selection</description>
         </entry>
     </codelist>
     <codelist name="che:CHE_ReasonForArchivingValueCode">

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/codelists.xml
@@ -585,7 +585,7 @@
             <description>Sampling / Selection</description>
         </entry>
     </codelist>
-    <codelist name="che:CHE_ReasonForArchingValueCode">
+    <codelist name="che:CHE_ReasonForArchivingValueCode">
         <entry>
             <code>legalRelevance</code>
             <label>Legal relevance</label>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/codelists.xml
@@ -475,7 +475,98 @@
       <label>WMS Services</label>
       <description></description>
     </entry>
-
-  </codelist>
-
+    </codelist>
+    <!-- Geocat override: asked on behalf of SB-422 -->
+    <codelist name="gmd:CI_RoleCode">
+        <entry>
+            <code>resourceProvider</code>
+            <label>Resource provider</label>
+            <description>Party that supplies the resource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>custodian</code>
+            <label>Custodian</label>
+            <description>Party that accepts accountability and
+                responsability for the data and ensures
+                appropriate care
+                and maintenance of the resource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>owner</code>
+            <label>Owner</label>
+            <description>Party that owns the resource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>user</code>
+            <label>User</label>
+            <description>Party who uses the resource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>distributor</code>
+            <label>Distributor</label>
+            <description>Party who distributes the resource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>originator</code>
+            <label>Originator</label>
+            <description>Party who created the resource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>pointOfContact</code>
+            <label>Point of contact</label>
+            <description>Party who can be contacted for acquiring
+                knowledge about or acquisition of the
+                resource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>principalInvestigator</code>
+            <label>Principal investigator</label>
+            <description>Key party responsible for gathering information
+                and conducting
+                research</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>processor</code>
+            <label>Processor</label>
+            <description>Party wha has processed the data in a manner
+                such that the resource has been
+                modified</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>publisher</code>
+            <label>Publisher</label>
+            <description>Party who published the resource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>author</code>
+            <label>Author</label>
+            <description>Party who authored the resource</description>
+        </entry>
+        <entry>
+            <code>editor</code>
+            <label>Editor</label>
+            <description></description>
+        </entry>
+        <entry>
+            <code>partner</code>
+            <label>Partner</label>
+            <description></description>
+        </entry>
+        <entry>
+            <code>specialistAuthority</code>
+            <label>Specialist authority</label>
+            <description>Specialist authority</description>
+        </entry>
+    </codelist>
+    
 </codelists>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/codelists.xml
@@ -626,10 +626,5 @@
             <label>Defining powers</label>
             <description>Defining powers</description>
         </entry>
-        <entry>
-            <code>empty</code>
-            <label>empty</label>
-            <description>empty</description>
-        </entry>
     </codelist>
 </codelists>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/codelists.xml
@@ -568,7 +568,7 @@
             <description>Specialist authority</description>
         </entry>
     </codelist>
-    <codelist name="che:CHE_MD_ArchivalValueCode">
+    <codelist name="che:CHE_AppraisalOfArchivalValueCode">
         <entry>
             <code>A</code>
             <label>of archival value</label>
@@ -585,7 +585,7 @@
             <description>Sampling / Selection</description>
         </entry>
     </codelist>
-    <codelist name="che:CHE_MD_ArchivalReasonCode">
+    <codelist name="che:CHE_ReasonForArchingValueCode">
         <entry>
             <code>legalRelevance</code>
             <label>Legal relevance</label>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/labels.xml
@@ -564,6 +564,10 @@
         <help>Classification of the dataset in a larger group of similar datasets with the help of the enclosed codelist</help>
     </element>
     <!-- SB-422: AAP -->
+    <element name="che:CHE_Appraisal_AAP">
+        <label>Appraisal AAP</label>
+        <description>Appraisal AAP</description>    
+    </element>
     <element name="che:CHE_durationOfConservation">
         <label>Duration of conservation</label>
         <description>Duration of conservation</description>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/labels.xml
@@ -580,10 +580,18 @@
         <label>Appraisal of archival value</label>
         <description>Appraisal of archival value</description>
     </element>
+    <element name="che:CHE_AppraisalOfArchivalValueCode">
+        <label>Appraisal of archival value</label>
+        <description>Appraisal of archival value</description>
+    </element>    
     <element name="che:reasonForArchivingValue">
         <label>Reason for archiving value</label>
         <description>Reason for archiving value</description>
     </element>
+    <element name="che:CHE_ReasonForArchivingValueCode">
+        <label>Reason for archiving value</label>
+        <description>Reason for archiving value</description>
+    </element>    
     <element name="che:commentOnArchivalValue">
         <label>Comment on archival value</label>
         <description>Comment on archival value</description>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/labels.xml
@@ -563,4 +563,26 @@
         <description>Characterization of a Dataset</description>
         <help>Classification of the dataset in a larger group of similar datasets with the help of the enclosed codelist</help>
     </element>
+    <!-- SB-422: AAP -->
+    <element name="che:CHE_durationOfConservation">
+        <label>Duration of conservation</label>
+        <description>Duration of conservation</description>
+    </element>
+    <element name="che:CHE_commentOnDurationOfConservation">
+        <label>Comment on duration of conservation</label>
+        <description>Comment on duration of conservation</description>
+    </element>
+    <element name="che:CHE_AppraisalOfArchivalValue">
+        <label>Appraisal of archival value</label>
+        <description>Appraisal of archival value</description>
+    </element>
+    <element name="che:CHE_ReasonForArchivingValue">
+        <label>Reason for archiving value</label>
+        <description>Reason for archiving value</description>
+    </element>
+    <element name="che:CHE_commentOnArchivalValue">
+        <label>Comment on archival value</label>
+        <description>Comment on archival value</description>
+    </element>
+
 </labels>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/labels.xml
@@ -564,27 +564,27 @@
         <help>Classification of the dataset in a larger group of similar datasets with the help of the enclosed codelist</help>
     </element>
     <!-- SB-422: AAP -->
-    <element name="che:CHE_Appraisal_AAP">
+    <element name="che:appraisal">
         <label>Appraisal AAP</label>
         <description>Appraisal AAP</description>    
     </element>
-    <element name="che:CHE_DurationOfConservation">
+    <element name="che:durationOfConservation">
         <label>Duration of conservation</label>
         <description>Duration of conservation</description>
     </element>
-    <element name="che:CHE_CommentOnDurationOfConservation">
+    <element name="che:commentOnDurationOfConservation">
         <label>Comment on duration of conservation</label>
         <description>Comment on duration of conservation</description>
     </element>
-    <element name="che:CHE_AppraisalOfArchivalValue">
+    <element name="che:appraisalOfArchivalValue">
         <label>Appraisal of archival value</label>
         <description>Appraisal of archival value</description>
     </element>
-    <element name="che:CHE_ReasonForArchivingValue">
+    <element name="che:reasonForArchivingValue">
         <label>Reason for archiving value</label>
         <description>Reason for archiving value</description>
     </element>
-    <element name="che:CHE_CommentOnArchivalValue">
+    <element name="che:commentOnArchivalValue">
         <label>Comment on archival value</label>
         <description>Comment on archival value</description>
     </element>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/labels.xml
@@ -568,11 +568,11 @@
         <label>Appraisal AAP</label>
         <description>Appraisal AAP</description>    
     </element>
-    <element name="che:CHE_durationOfConservation">
+    <element name="che:CHE_DurationOfConservation">
         <label>Duration of conservation</label>
         <description>Duration of conservation</description>
     </element>
-    <element name="che:CHE_commentOnDurationOfConservation">
+    <element name="che:CHE_CommentOnDurationOfConservation">
         <label>Comment on duration of conservation</label>
         <description>Comment on duration of conservation</description>
     </element>
@@ -584,7 +584,7 @@
         <label>Reason for archiving value</label>
         <description>Reason for archiving value</description>
     </element>
-    <element name="che:CHE_commentOnArchivalValue">
+    <element name="che:CHE_CommentOnArchivalValue">
         <label>Comment on archival value</label>
         <description>Comment on archival value</description>
     </element>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/schematron-rules-aap.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/schematron-rules-aap.xml
@@ -1,0 +1,11 @@
+<strings>
+  <mandatoryFields>Check mandatory fields</mandatoryFields>
+  <durationOfConservationRequired>durationOfConservation is required (integer)</durationOfConservationRequired>
+  <durationOfConservationReport>duration of conservation: </durationOfConservationReport>
+  
+  <appraisalOfArchivalValueRequired>appraisalOfArchivalValue is required (codelist)</appraisalOfArchivalValueRequired>
+  <appraisalOfArchivalValueReport>appraisal of archival value: </appraisalOfArchivalValueReport>
+  
+  <reasonForArchivingRequired>reasonForArchivingValue is required (codelist)</reasonForArchivingRequired>
+  <reasonForArchivingReport>reason for archiving: </reasonForArchivingReport>
+</strings>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/schematron-rules-aap.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/eng/schematron-rules-aap.xml
@@ -1,11 +1,15 @@
 <strings>
   <mandatoryFields>Check mandatory fields</mandatoryFields>
+
   <durationOfConservationRequired>durationOfConservation is required (integer)</durationOfConservationRequired>
   <durationOfConservationReport>duration of conservation: </durationOfConservationReport>
   
   <appraisalOfArchivalValueRequired>appraisalOfArchivalValue is required (codelist)</appraisalOfArchivalValueRequired>
   <appraisalOfArchivalValueReport>appraisal of archival value: </appraisalOfArchivalValueReport>
-  
-  <reasonForArchivingRequired>reasonForArchivingValue is required (codelist)</reasonForArchivingRequired>
-  <reasonForArchivingReport>reason for archiving: </reasonForArchivingReport>
+
+  <reasonForArchivalValuePresence>Test presence or absence of reasonForArchivalValue field</reasonForArchivalValuePresence>
+  <reasonForArchivalValuePresenceReport>reasonForArchivalValue: </reasonForArchivalValuePresenceReport>
+  <reasonForArchivalValuePresent>Field is present</reasonForArchivalValuePresent>
+  <reasonForArchivalValueAbsent>Field is absent</reasonForArchivalValueAbsent>
+
 </strings>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/codelists.xml
@@ -452,8 +452,91 @@ une interface externe du service internet pour le processus ou la chaîne de ser
       <label>Services WMS</label>
       <description></description>
     </entry>
-
   </codelist>
+  
+    <!-- Geocat override: asked on behalf of SB-422 -->
+  	<codelist name="gmd:CI_RoleCode">
+		<entry>
+			<code>resourceProvider</code>
+			<label>Fournisseur</label>
+			<description>Organisme qui fournit la ressource. Acteur qui délivre physiquement la ressource, soit de manière directe au destinataire, soit par l’intermédiaire d’un diffuseur</description>
+		</entry>
+		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+		<entry>
+			<code>custodian</code>
+			<label>Gestionnaire</label>
+			<description>Acteur responsable de la gestion et de la mise à jour de la ressource</description>
+		</entry>
+		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+		<entry>
+			<code>owner</code>
+			<label>Propriétaire</label>
+			<description>Organisme qui est propriétaire de la ressource / Acteur qui détient les droits patrimoniaux de la ressource</description>
+		</entry>
+		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+		<entry>
+			<code>user</code>
+			<label>Utilisateur</label>
+			<description>Organisme qui utilise ou a utilisé la ressource</description>
+		</entry>
+		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+		<entry>
+			<code>distributor</code>
+			<label>Distributeur</label>
+			<description>Organisme qui distribue la ressource. Diffuseur de second niveau de la ressource</description>
+		</entry>
+		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+		<entry>
+			<code>originator</code>
+			<label>A l’origine de</label>
+			<description>Organisme qui  a commandé la ressource. Acteur qui a été habilité à créer la ressource et qui a mis en place les moyens pour la constituer</description>
+		</entry>
+		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+		<entry>
+			<code>pointOfContact</code>
+			<label>Point de contact</label>
+			<description>Organisme que l’on peut contacter pour avoir des renseignements détaillés sur la ressource. Acteur à contacter en premier lieu pour obtenir des informations relatives à la ressource</description>
+		</entry>
+		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+		<entry>
+			<code>principalInvestigator</code>
+			<label>Point de recherche</label>
+			<description>Personne clé pour obtenir des informations sur la ressource et les recherches conduites autour de la ressource&#xA;Acteur qui a assuré la réalisation de la ressource,éventuellement en faisant appel à des co-traitants ou des sous traitants</description>
+		</entry>
+		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+		<entry>
+			<code>processor</code>
+			<label>Exécutant</label>
+			<description>Organisme qui a réalisé des traitements sur la ressource. Acteur qui est intervenu lors de la réalisation de la ressource</description>
+		</entry>
+		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+		<entry>
+			<code>publisher</code>
+			<label>Editeur (publication)</label>
+			<description>Organisme qui assure la publication de la ressource.</description>
+		</entry>
+		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+		<entry>
+			<code>author</code>
+			<label>Auteur</label>
+			<description>Organisme  ou personne qui est auteur. Acteur qui dispose des droits moraux relatifs à la ressource</description>
+		</entry>
+		<entry>
+			<code>editor</code>
+			<label>Editeur</label>
+			<description></description>
+		</entry>
+		<entry>
+			<code>partner</code>
+			<label>Partenaire</label>
+			<description></description>
+		</entry>
+		<entry>
+			<code>specialistAuthority</code>
+			<label>Service spécialisé de la Confédération</label>
+			<description>Service spécialisé de la Confédération</description>
+		</entry>		
+	</codelist>
 
 </codelists>
 

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/codelists.xml
@@ -537,6 +537,69 @@ une interface externe du service internet pour le processus ou la chaîne de ser
 			<description>Service spécialisé de la Confédération</description>
 		</entry>		
 	</codelist>
-
+    <codelist name="che:CHE_MD_ArchivalValueCode">
+        <entry>
+            <code>A</code>
+            <label>(de) valeur archivistique</label>
+            <description>(de) valeur archivistique</description>
+        </entry>
+        <entry>
+            <code>N</code>
+            <label>pas de valeur archivistique</label>
+            <description>pas de valeur archivistique</description>
+        </entry>
+        <entry>
+            <code>S</code>
+            <label>sampling / sélection</label>
+            <description>sampling / sélection</description>
+        </entry>
+    </codelist>
+    <codelist name="che:CHE_MD_ArchivalReasonCode">
+        <entry>
+            <code>legalRelevance</code>
+            <label>Pertinence juridique</label>
+            <description>Pertinence juridique</description>
+        </entry>
+        <entry>
+            <code>guaranteeOfLegalCertainty</code>
+            <label>Garantie de la sécurité juridique</label>
+            <description>Garantie de la sécurité juridique</description>
+        </entry>
+        <entry>
+            <code>evidenceOfBusinessPractice</code>
+            <label>Preuve de la pratique courante</label>
+            <description>Preuve de la pratique courante</description>
+        </entry>
+        <entry>
+            <code>benefitsForResearch</code>
+            <label>Utilité pour la recherche</label>
+            <description>Utilité pour la recherche</description>
+        </entry>
+        <entry>
+            <code>contemporaryInterest</code>
+            <label>Valeur d'actualité</label>
+            <description>Valeur d'actualité</description>
+        </entry>
+        <entry>
+            <code>sensitivity</code>
+            <label>Sujets explosifs</label>
+            <description>Sujets explosifs</description>
+        </entry>
+        <entry>
+            <code>developmentsProgression</code>
+            <label>Evolution / déroulement</label>
+            <description>Evolution / déroulement</description>
+        </entry>
+        <entry>
+            <code>definingPowers</code>
+            <label>Pouvoir d'influence</label>
+            <description>Pouvoir d'influence</description>
+        </entry>
+        <entry>
+            <code>empty</code>
+            <label>vide</label>
+            <description>vide</description>
+        </entry>
+    </codelist>
 </codelists>
 

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/codelists.xml
@@ -595,11 +595,6 @@ une interface externe du service internet pour le processus ou la chaîne de ser
             <label>Pouvoir d'influence</label>
             <description>Pouvoir d'influence</description>
         </entry>
-        <entry>
-            <code>empty</code>
-            <label>vide</label>
-            <description>vide</description>
-        </entry>
     </codelist>
 </codelists>
 

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/codelists.xml
@@ -554,7 +554,7 @@ une interface externe du service internet pour le processus ou la chaîne de ser
             <description>sampling / sélection</description>
         </entry>
     </codelist>
-    <codelist name="che:CHE_ReasonForArchingValueCode">
+    <codelist name="che:CHE_ReasonForArchivingValueCode">
         <entry>
             <code>legalRelevance</code>
             <label>Pertinence juridique</label>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/codelists.xml
@@ -537,7 +537,7 @@ une interface externe du service internet pour le processus ou la chaîne de ser
 			<description>Service spécialisé de la Confédération</description>
 		</entry>		
 	</codelist>
-    <codelist name="che:CHE_MD_ArchivalValueCode">
+    <codelist name="che:CHE_AppraisalOfArchivalValueCode">
         <entry>
             <code>A</code>
             <label>(de) valeur archivistique</label>
@@ -554,7 +554,7 @@ une interface externe du service internet pour le processus ou la chaîne de ser
             <description>sampling / sélection</description>
         </entry>
     </codelist>
-    <codelist name="che:CHE_MD_ArchivalReasonCode">
+    <codelist name="che:CHE_ReasonForArchingValueCode">
         <entry>
             <code>legalRelevance</code>
             <label>Pertinence juridique</label>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/labels.xml
@@ -733,11 +733,11 @@ ce qui concerne les métadonnées"</description>
         <label>Évaluation AAP</label>
         <description>Évaluation AAP</description>    
     </element>
-    <element name="che:CHE_durationOfConservation">
+    <element name="che:CHE_DurationOfConservation">
         <label>durée de conservation DAD (années)</label>
         <description>durée de conservation DAD (années)</description>
     </element>
-    <element name="che:CHE_commentOnDurationOfConservation">
+    <element name="che:CHE_CommentOnDurationOfConservation">
         <label>Remarques concernant la durée de conservation</label>
         <description>Remarques concernant la durée de conservation</description>
     </element>
@@ -749,7 +749,7 @@ ce qui concerne les métadonnées"</description>
         <label>justification quant à la valeur archivistique</label>
         <description>justification quant à la valeur archivistique</description>
     </element>
-    <element name="che:CHE_commentOnArchivalValue">
+    <element name="che:CHE_CommentOnArchivalValue">
         <label>Remarques concernant la valeur archivistique</label>
         <description>Remarques concernant la valeur archivistique</description>
     </element>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/labels.xml
@@ -729,27 +729,27 @@ ce qui concerne les métadonnées"</description>
  </element>
 
     <!-- SB-422: AAP -->
-    <element name="che:CHE_Appraisal_AAP">
+    <element name="che:appraisal">
         <label>Évaluation AAP</label>
         <description>Évaluation AAP</description>    
     </element>
-    <element name="che:CHE_DurationOfConservation">
+    <element name="che:durationOfConservation">
         <label>durée de conservation DAD (années)</label>
         <description>durée de conservation DAD (années)</description>
     </element>
-    <element name="che:CHE_CommentOnDurationOfConservation">
+    <element name="che:commentOnDurationOfConservation">
         <label>Remarques concernant la durée de conservation</label>
         <description>Remarques concernant la durée de conservation</description>
     </element>
-    <element name="che:CHE_AppraisalOfArchivalValue">
+    <element name="che:appraisalOfArchivalValue">
         <label>évaluation de la valeur archivistique</label>
         <description>évaluation de la valeur archivistique</description>
     </element>
-    <element name="che:CHE_ReasonForArchivingValue">
+    <element name="che:reasonForArchivingValue">
         <label>justification quant à la valeur archivistique</label>
         <description>justification quant à la valeur archivistique</description>
     </element>
-    <element name="che:CHE_CommentOnArchivalValue">
+    <element name="che:commentOnArchivalValue">
         <label>Remarques concernant la valeur archivistique</label>
         <description>Remarques concernant la valeur archivistique</description>
     </element>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/labels.xml
@@ -727,4 +727,26 @@ ce qui concerne les métadonnées"</description>
   <description>Characterization of a Dataset</description>
   <help>Classification of the dataset in a larger group of similar datasets with the help of the enclosed codelist</help>
  </element>
+
+    <!-- SB-422: AAP -->
+    <element name="che:CHE_durationOfConservation">
+        <label>durée de conservation DAD (années)</label>
+        <description>durée de conservation DAD (années)</description>
+    </element>
+    <element name="che:CHE_commentOnDurationOfConservation">
+        <label>Remarques concernant la durée de conservation</label>
+        <description>Remarques concernant la durée de conservation</description>
+    </element>
+    <element name="che:CHE_AppraisalOfArchivalValue">
+        <label>évaluation de la valeur archivistique</label>
+        <description>évaluation de la valeur archivistique</description>
+    </element>
+    <element name="che:CHE_ReasonForArchivingValue">
+        <label>justification quant à la valeur archivistique</label>
+        <description>justification quant à la valeur archivistique</description>
+    </element>
+    <element name="che:CHE_commentOnArchivalValue">
+        <label>Remarques concernant la valeur archivistique</label>
+        <description>Remarques concernant la valeur archivistique</description>
+    </element>
 </labels>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/labels.xml
@@ -729,6 +729,10 @@ ce qui concerne les métadonnées"</description>
  </element>
 
     <!-- SB-422: AAP -->
+    <element name="che:CHE_Appraisal_AAP">
+        <label>Évaluation AAP</label>
+        <description>Évaluation AAP</description>    
+    </element>
     <element name="che:CHE_durationOfConservation">
         <label>durée de conservation DAD (années)</label>
         <description>durée de conservation DAD (années)</description>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/fre/labels.xml
@@ -745,7 +745,15 @@ ce qui concerne les métadonnées"</description>
         <label>évaluation de la valeur archivistique</label>
         <description>évaluation de la valeur archivistique</description>
     </element>
+    <element name="che:CHE_AppraisalOfArchivalValueCode">
+        <label>évaluation de la valeur archivistique</label>
+        <description>évaluation de la valeur archivistique</description>
+    </element>    
     <element name="che:reasonForArchivingValue">
+        <label>justification quant à la valeur archivistique</label>
+        <description>justification quant à la valeur archivistique</description>
+    </element>
+    <element name="che:CHE_ReasonForArchivingValueCode">
         <label>justification quant à la valeur archivistique</label>
         <description>justification quant à la valeur archivistique</description>
     </element>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/codelists.xml
@@ -592,7 +592,7 @@
             <description>Sampling / Selektion</description>
         </entry>
     </codelist>
-    <codelist name="che:CHE_ReasonForArchingValueCode">
+    <codelist name="che:CHE_ReasonForArchivingValueCode">
         <entry>
             <code>legalRelevance</code>
             <label>Rechtliche Relevanz</label>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/codelists.xml
@@ -575,7 +575,7 @@
             <description>Fachstelle des Bundes</description>
         </entry>
     </codelist>
-    <codelist name="che:CHE_MD_ArchivalValueCode">
+    <codelist name="che:CHE_AppraisalOfArchivalValueCode">
         <entry>
             <code>A</code>
             <label>archivwürdig</label>
@@ -592,7 +592,7 @@
             <description>Sampling / Selektion</description>
         </entry>
     </codelist>
-    <codelist name="che:CHE_MD_ArchivalReasonCode">
+    <codelist name="che:CHE_ReasonForArchingValueCode">
         <entry>
             <code>legalRelevance</code>
             <label>Rechtliche Relevanz</label>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/codelists.xml
@@ -588,8 +588,8 @@
         </entry>
         <entry>
             <code>S</code>
-            <label>Sampling / Selektion</label>
-            <description>Sampling / Selektion</description>
+            <label>sampling / selektion</label>
+            <description>sampling / selektion</description>
         </entry>
     </codelist>
     <codelist name="che:CHE_ReasonForArchivingValueCode">

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/codelists.xml
@@ -574,5 +574,69 @@
             <label>Fachstelle des Bundes</label>
             <description>Fachstelle des Bundes</description>
         </entry>
-    </codelist>    
+    </codelist>
+    <codelist name="che:CHE_MD_ArchivalValueCode">
+        <entry>
+            <code>A</code>
+            <label>archivwürdig</label>
+            <description>archivwürdig</description>
+        </entry>
+        <entry>
+            <code>N</code>
+            <label>nicht archivwürdig</label>
+            <description>nicht archivwürdig</description>
+        </entry>
+        <entry>
+            <code>S</code>
+            <label>Sampling / Selektion</label>
+            <description>Sampling / Selektion</description>
+        </entry>
+    </codelist>
+    <codelist name="che:CHE_MD_ArchivalReasonCode">
+        <entry>
+            <code>legalRelevance</code>
+            <label>Rechtliche Relevanz</label>
+            <description>Rechtliche Relevanz</description>
+        </entry>
+        <entry>
+            <code>guaranteeOfLegalCertainty</code>
+            <label>Gewährleistung der Rechtssicherheit</label>
+            <description>Gewährleistung der Rechtssicherheit</description>
+        </entry>
+        <entry>
+            <code>evidenceOfBusinessPractice</code>
+            <label>Nachweis der Geschäftspraxis</label>
+            <description>Nachweis der Geschäftspraxis</description>
+        </entry>
+        <entry>
+            <code>benefitsForResearch</code>
+            <label>Nutzen für die Forschung</label>
+            <description>Nutzen für die Forschung</description>
+        </entry>
+        <entry>
+            <code>contemporaryInterest</code>
+            <label>Zeitgenössisches Interesse</label>
+            <description>Zeitgenössisches Interesse</description>
+        </entry>
+        <entry>
+            <code>sensitivity</code>
+            <label>Brisanz</label>
+            <description>Brisanz</description>
+        </entry>
+        <entry>
+            <code>developmentsProgression</code>
+            <label>Entwicklungen / Verlauf</label>
+            <description>Entwicklungen / Verlauf</description>
+        </entry>
+        <entry>
+            <code>definingPowers</code>
+            <label>Definitionsmacht</label>
+            <description>Definitionsmacht</description>
+        </entry>
+        <entry>
+            <code>empty</code>
+            <label>leer</label>
+            <description>leer</description>
+        </entry>
+    </codelist>
 </codelists>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/codelists.xml
@@ -483,4 +483,96 @@
 			<label>Reference Geodata</label>
 		</entry>
 	</codelist>
+    <!-- Geocat override: asked on behalf of SB-422 -->
+    <codelist name="gmd:CI_RoleCode">
+        <entry>
+            <code>resourceProvider</code>
+            <label>Anbieter</label>
+            <description>Anbieter der Ressource</description>
+
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>custodian</code>
+            <label>Verwalter</label>
+            <description>Person oder Stelle, welche die Zuständigkeit und Verantwortlichkeit für einen Datensatz übernommen hat und seine sachgerechte Pflege und Wartung sichert</description>
+        </entry>
+
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>owner</code>
+            <label>Eigentümer / Datenherr</label>
+            <description>Eigentümer/Datenherr der Ressource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+        <entry>
+            <code>user</code>
+            <label>Nutzer</label>
+            <description>Nutzer der Ressource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+
+            <code>distributor</code>
+            <label>Vertrieb</label>
+            <description>Person oder Stelle, die für den Vertrieb zuständig ist</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>originator</code>
+
+            <label>Urheber</label>
+            <description>Erzeuger der Ressource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>pointOfContact</code>
+            <label>Ansprechpartner</label>
+
+            <description>Kontakt für Informationen zur Ressource oder deren Bezugsmöglichkeiten</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>principalInvestigator</code>
+            <label>Projektleitung</label>
+            <description>Person oder Stelle, die verantwortlich für die Erhebung der Daten, Untersuchung ist</description>
+
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>processor</code>
+            <label>Bearbeiter</label>
+            <description>Person oder Stelle, die die Resource in einem Arbeitsschritt verändert hat</description>
+        </entry>
+
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>publisher</code>
+            <label>Herausgeber</label>
+            <description>Person oder Stelle, welche die Ressource veröffentlicht</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+        <entry>
+            <code>author</code>
+            <label>Autor</label>
+            <description>Verfasser der Ressource</description>
+        </entry>
+        <entry>
+            <code>editor</code>
+            <label>Editor</label>
+            <description>Verleger einer Publikation</description>
+        </entry>
+        <entry>
+            <code>partner</code>
+            <label>Partner</label>
+            <description>Beiteiligter bei der Erstellung der Ressource</description>
+        </entry>
+        <entry>
+            <code>specialistAuthority</code>
+            <label>Fachstelle des Bundes</label>
+            <description>Fachstelle des Bundes</description>
+        </entry>
+    </codelist>    
 </codelists>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/codelists.xml
@@ -633,10 +633,5 @@
             <label>Definitionsmacht</label>
             <description>Definitionsmacht</description>
         </entry>
-        <entry>
-            <code>empty</code>
-            <label>leer</label>
-            <description>leer</description>
-        </entry>
     </codelist>
 </codelists>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/labels.xml
@@ -655,4 +655,27 @@
         <description>Characterization of a Dataset</description>
         <help>Classification of the dataset in a larger group of similar datasets with the help of the enclosed codelist</help>
     </element>
+
+    <!-- SB-422: AAP -->
+    <element name="che:CHE_durationOfConservation">
+        <label>Aufbewahrungsdauer NV in Jahren</label>
+        <description>Aufbewahrungsdauer NV in Jahren</description>
+    </element>
+    <element name="che:CHE_commentOnDurationOfConservation">
+        <label>Bemerkung zur Aufbewahrungsdauer</label>
+        <description>Bemerkung zur Aufbewahrungsdauer</description>
+    </element>
+    <element name="che:CHE_AppraisalOfArchivalValue">
+        <label>Bewertung Archivwürdigkeit</label>
+        <description>Bewertung Archivwürdigkeit</description>
+    </element>
+    <element name="che:CHE_ReasonForArchivingValue">
+        <label>Begründung Archivwürdigkeit</label>
+        <description>Begründung Archivwürdigkeit</description>
+    </element>
+    <element name="che:CHE_commentOnArchivalValue">
+        <label>Bemerkung zur Archivwürdigkeit</label>
+        <description>Bemerkung zur Archivwürdigkeit</description>
+    </element>
+    
 </labels>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/labels.xml
@@ -661,11 +661,11 @@
         <label>Bewertung AAP</label>
         <description>Bewertung AAP</description>    
     </element>
-    <element name="che:CHE_durationOfConservation">
+    <element name="che:CHE_DurationOfConservation">
         <label>Aufbewahrungsdauer NV in Jahren</label>
         <description>Aufbewahrungsdauer NV in Jahren</description>
     </element>
-    <element name="che:CHE_commentOnDurationOfConservation">
+    <element name="che:CHE_CommentOnDurationOfConservation">
         <label>Bemerkung zur Aufbewahrungsdauer</label>
         <description>Bemerkung zur Aufbewahrungsdauer</description>
     </element>
@@ -677,7 +677,7 @@
         <label>Begründung Archivwürdigkeit</label>
         <description>Begründung Archivwürdigkeit</description>
     </element>
-    <element name="che:CHE_commentOnArchivalValue">
+    <element name="che:CHE_CommentOnArchivalValue">
         <label>Bemerkung zur Archivwürdigkeit</label>
         <description>Bemerkung zur Archivwürdigkeit</description>
     </element>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/labels.xml
@@ -673,7 +673,15 @@
         <label>Bewertung Archivwürdigkeit</label>
         <description>Bewertung Archivwürdigkeit</description>
     </element>
+    <element name="che:CHE_AppraisalOfArchivalValueCode">
+        <label>Bewertung Archivwürdigkeit</label>
+        <description>Bewertung Archivwürdigkeit</description>
+    </element>    
     <element name="che:reasonForArchivingValue">
+        <label>Begründung Archivwürdigkeit</label>
+        <description>Begründung Archivwürdigkeit</description>
+    </element>
+    <element name="che:CHE_ReasonForArchivingValueCode">
         <label>Begründung Archivwürdigkeit</label>
         <description>Begründung Archivwürdigkeit</description>
     </element>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/labels.xml
@@ -657,27 +657,27 @@
     </element>
 
     <!-- SB-422: AAP -->
-    <element name="che:CHE_Appraisal_AAP">
+    <element name="che:appraisal">
         <label>Bewertung AAP</label>
         <description>Bewertung AAP</description>    
     </element>
-    <element name="che:CHE_DurationOfConservation">
+    <element name="che:durationOfConservation">
         <label>Aufbewahrungsdauer NV in Jahren</label>
         <description>Aufbewahrungsdauer NV in Jahren</description>
     </element>
-    <element name="che:CHE_CommentOnDurationOfConservation">
+    <element name="che:commentOnDurationOfConservation">
         <label>Bemerkung zur Aufbewahrungsdauer</label>
         <description>Bemerkung zur Aufbewahrungsdauer</description>
     </element>
-    <element name="che:CHE_AppraisalOfArchivalValue">
+    <element name="che:appraisalOfArchivalValue">
         <label>Bewertung Archivwürdigkeit</label>
         <description>Bewertung Archivwürdigkeit</description>
     </element>
-    <element name="che:CHE_ReasonForArchivingValue">
+    <element name="che:reasonForArchivingValue">
         <label>Begründung Archivwürdigkeit</label>
         <description>Begründung Archivwürdigkeit</description>
     </element>
-    <element name="che:CHE_CommentOnArchivalValue">
+    <element name="che:commentOnArchivalValue">
         <label>Bemerkung zur Archivwürdigkeit</label>
         <description>Bemerkung zur Archivwürdigkeit</description>
     </element>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ger/labels.xml
@@ -657,6 +657,10 @@
     </element>
 
     <!-- SB-422: AAP -->
+    <element name="che:CHE_Appraisal_AAP">
+        <label>Bewertung AAP</label>
+        <description>Bewertung AAP</description>    
+    </element>
     <element name="che:CHE_durationOfConservation">
         <label>Aufbewahrungsdauer NV in Jahren</label>
         <description>Aufbewahrungsdauer NV in Jahren</description>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ita/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ita/codelists.xml
@@ -726,8 +726,8 @@
         </entry>
         <entry>
             <code>S</code>
-            <label>Sampling / Selection</label>
-            <description>Sampling / Selection</description>
+            <label>sampling / selection</label>
+            <description>sampling / selection</description>
         </entry>
     </codelist>
     <codelist name="che:CHE_ReasonForArchivingValueCode">

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ita/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ita/codelists.xml
@@ -730,7 +730,7 @@
             <description>Sampling / Selection</description>
         </entry>
     </codelist>
-    <codelist name="che:CHE_ReasonForArchingValueCode">
+    <codelist name="che:CHE_ReasonForArchivingValueCode">
         <entry>
             <code>legalRelevance</code>
             <label>Legal relevance</label>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ita/codelists.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ita/codelists.xml
@@ -621,4 +621,156 @@
 
   </codelist>
 
+    <!-- Geocat override: asked on behalf of SB-422 -->
+    <codelist name="gmd:CI_RoleCode">
+        <entry>
+            <code>resourceProvider</code>
+            <label>Resource provider</label>
+            <description>Party that supplies the resource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>custodian</code>
+            <label>Custodian</label>
+            <description>Party that accepts accountability and
+                responsability for the data and ensures
+                appropriate care
+                and maintenance of the resource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>owner</code>
+            <label>Owner</label>
+            <description>Party that owns the resource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>user</code>
+            <label>User</label>
+            <description>Party who uses the resource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>distributor</code>
+            <label>Distributor</label>
+            <description>Party who distributes the resource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>originator</code>
+            <label>Originator</label>
+            <description>Party who created the resource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>pointOfContact</code>
+            <label>Point of contact</label>
+            <description>Party who can be contacted for acquiring
+                knowledge about or acquisition of the
+                resource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>principalInvestigator</code>
+            <label>Principal investigator</label>
+            <description>Key party responsible for gathering information
+                and conducting
+                research</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>processor</code>
+            <label>Processor</label>
+            <description>Party wha has processed the data in a manner
+                such that the resource has been
+                modified</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>publisher</code>
+            <label>Publisher</label>
+            <description>Party who published the resource</description>
+        </entry>
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <entry>
+            <code>author</code>
+            <label>Author</label>
+            <description>Party who authored the resource</description>
+        </entry>
+        <entry>
+            <code>editor</code>
+            <label>Editor</label>
+            <description></description>
+        </entry>
+        <entry>
+            <code>partner</code>
+            <label>Partner</label>
+            <description></description>
+        </entry>
+        <entry>
+            <code>specialistAuthority</code>
+            <label>Specialist authority</label>
+            <description>Specialist authority</description>
+        </entry>
+    </codelist>
+    <codelist name="che:CHE_AppraisalOfArchivalValueCode">
+        <entry>
+            <code>A</code>
+            <label>of archival value</label>
+            <description>of archival value</description>
+        </entry>
+        <entry>
+            <code>N</code>
+            <label>no archival value</label>
+            <description>no archival value</description>
+        </entry>
+        <entry>
+            <code>S</code>
+            <label>Sampling / Selection</label>
+            <description>Sampling / Selection</description>
+        </entry>
+    </codelist>
+    <codelist name="che:CHE_ReasonForArchingValueCode">
+        <entry>
+            <code>legalRelevance</code>
+            <label>Legal relevance</label>
+            <description>Legal relevance</description>
+        </entry>
+        <entry>
+            <code>guaranteeOfLegalCertainty</code>
+            <label>Guarantee of legal certainty</label>
+            <description>Guarantee of legal certainty</description>
+        </entry>
+        <entry>
+            <code>evidenceOfBusinessPractice</code>
+            <label>Evidence of business practice</label>
+            <description>Evidence of business practice</description>
+        </entry>
+        <entry>
+            <code>benefitsForResearch</code>
+            <label>Benefits for research</label>
+            <description>Benefits for research</description>
+        </entry>
+        <entry>
+            <code>contemporaryInterest</code>
+            <label>Contemporary interest</label>
+            <description>Contemporary interest</description>
+        </entry>
+        <entry>
+            <code>sensitivity</code>
+            <label>Sensitivity</label>
+            <description>Sensitivity</description>
+        </entry>
+        <entry>
+            <code>developmentsProgression</code>
+            <label>Developments / Progression</label>
+            <description>Developments / Progression</description>
+        </entry>
+        <entry>
+            <code>definingPowers</code>
+            <label>Defining powers</label>
+            <description>Defining powers</description>
+        </entry>
+    </codelist>  
+
 </codelists>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ita/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ita/labels.xml
@@ -653,27 +653,27 @@
     </element>
     
     <!-- SB-422: AAP -->
-    <element name="che:CHE_Appraisal_AAP">
+    <element name="che:appraisal">
         <label>Appraisal AAP</label>
         <description>Appraisal AAP</description>    
     </element>
-    <element name="che:CHE_DurationOfConservation">
+    <element name="che:durationOfConservation">
         <label>Duration of conservation</label>
         <description>Duration of conservation</description>
     </element>
-    <element name="che:CHE_CommentOnDurationOfConservation">
+    <element name="che:commentOnDurationOfConservation">
         <label>Comment on duration of conservation</label>
         <description>Comment on duration of conservation</description>
     </element>
-    <element name="che:CHE_AppraisalOfArchivalValue">
+    <element name="che:appraisalOfArchivalValue">
         <label>Appraisal of archival value</label>
         <description>Appraisal of archival value</description>
     </element>
-    <element name="che:CHE_ReasonForArchivingValue">
+    <element name="che:reasonForArchivingValue">
         <label>Reason for archiving value</label>
         <description>Reason for archiving value</description>
     </element>
-    <element name="che:CHE_CommentOnArchivalValue">
+    <element name="che:commentOnArchivalValue">
         <label>Comment on archival value</label>
         <description>Comment on archival value</description>
     </element>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ita/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ita/labels.xml
@@ -657,11 +657,11 @@
         <label>Appraisal AAP</label>
         <description>Appraisal AAP</description>    
     </element>
-    <element name="che:CHE_durationOfConservation">
+    <element name="che:CHE_DurationOfConservation">
         <label>Duration of conservation</label>
         <description>Duration of conservation</description>
     </element>
-    <element name="che:CHE_commentOnDurationOfConservation">
+    <element name="che:CHE_CommentOnDurationOfConservation">
         <label>Comment on duration of conservation</label>
         <description>Comment on duration of conservation</description>
     </element>
@@ -673,7 +673,7 @@
         <label>Reason for archiving value</label>
         <description>Reason for archiving value</description>
     </element>
-    <element name="che:CHE_commentOnArchivalValue">
+    <element name="che:CHE_CommentOnArchivalValue">
         <label>Comment on archival value</label>
         <description>Comment on archival value</description>
     </element>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ita/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ita/labels.xml
@@ -669,7 +669,15 @@
         <label>Appraisal of archival value</label>
         <description>Appraisal of archival value</description>
     </element>
+    <element name="che:CHE_AppraisalOfArchivalValueCode">
+        <label>Appraisal of archival value</label>
+        <description>Appraisal of archival value</description>
+    </element>
     <element name="che:reasonForArchivingValue">
+        <label>Reason for archiving value</label>
+        <description>Reason for archiving value</description>
+    </element>
+    <element name="che:CHE_ReasonForArchivingValueCode">
         <label>Reason for archiving value</label>
         <description>Reason for archiving value</description>
     </element>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ita/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ita/labels.xml
@@ -653,6 +653,10 @@
     </element>
     
     <!-- SB-422: AAP -->
+    <element name="che:CHE_Appraisal_AAP">
+        <label>Appraisal AAP</label>
+        <description>Appraisal AAP</description>    
+    </element>
     <element name="che:CHE_durationOfConservation">
         <label>Duration of conservation</label>
         <description>Duration of conservation</description>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ita/labels.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/loc/ita/labels.xml
@@ -651,4 +651,26 @@
         <description>Characterization of a Dataset</description>
         <help>Classification of the dataset in a larger group of similar datasets with the help of the enclosed codelist</help>
     </element>
+    
+    <!-- SB-422: AAP -->
+    <element name="che:CHE_durationOfConservation">
+        <label>Duration of conservation</label>
+        <description>Duration of conservation</description>
+    </element>
+    <element name="che:CHE_commentOnDurationOfConservation">
+        <label>Comment on duration of conservation</label>
+        <description>Comment on duration of conservation</description>
+    </element>
+    <element name="che:CHE_AppraisalOfArchivalValue">
+        <label>Appraisal of archival value</label>
+        <description>Appraisal of archival value</description>
+    </element>
+    <element name="che:CHE_ReasonForArchivingValue">
+        <label>Reason for archiving value</label>
+        <description>Reason for archiving value</description>
+    </element>
+    <element name="che:CHE_commentOnArchivalValue">
+        <label>Comment on archival value</label>
+        <description>Comment on archival value</description>
+    </element>
 </labels>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
@@ -238,16 +238,16 @@
 	</xs:complexType>
 
     <!-- AAP -->
-    <xs:element name="CHE_MD_ArchivalValueCode"  type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString" />
-    <xs:element name="CHE_MD_ArchivalReasonCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString" />
-    <xs:complexType name="CHE_MD_ArchivalValue_Type">
+    <xs:element name="CHE_AppraisalOfArchivalValueCode"  type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString" />
+    <xs:element name="CHE_ReasonForArchingValueCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString" />
+    <xs:complexType name="CHE_AppraisalOfArchivalValue_Type">
         <xs:sequence minOccurs="1" maxOccurs="1">
-            <xs:element ref="che:CHE_MD_ArchivalValueCode" />
+            <xs:element ref="che:CHE_AppraisalOfArchivalValueCode" />
         </xs:sequence>
     </xs:complexType>
-    <xs:complexType name="CHE_MD_ArchivalReason_Type">
+    <xs:complexType name="CHE_ReasonForArchivingValue_Type">
         <xs:sequence minOccurs="1" maxOccurs="1">
-            <xs:element ref="che:CHE_MD_ArchivalReasonCode" />
+            <xs:element ref="che:CHE_ReasonForArchingValueCode" />
         </xs:sequence>
     </xs:complexType>
 	<!-- CHE_MD_Appraisal_AAP_Type -->
@@ -256,13 +256,13 @@
 			<xs:documentation>AAP</xs:documentation>
 		</xs:annotation>
         <xs:sequence minOccurs="0" maxOccurs="1">
-                <xs:sequence minOccurs="0" maxOccurs="1">
-                    <xs:element name="durationOfConservation" type="gco:Integer_PropertyType" minOccurs="0" />
+                <xs:sequence minOccurs="1" maxOccurs="1">
+                    <xs:element name="CHE_durationOfConservation" type="gco:Integer_PropertyType" minOccurs="1" maxOccurs="1" />
                 </xs:sequence>
-                <xs:element name="commentOnDurationOfConservation" type="gco:CharacterString_PropertyType"  minOccurs="0" maxOccurs="unbounded" />
-                <xs:element name="CHE_MD_ArchivalValue" type="che:CHE_MD_ArchivalValue_Type" />
-                <xs:element name="CHE_MD_ArchivalReason" type="che:CHE_MD_ArchivalReason_Type" minOccurs="0" maxOccurs="unbounded" />                    
-			    <xs:element name="commentOnArchivalValue" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="CHE_commentOnDurationOfConservation" type="gco:CharacterString_PropertyType"  minOccurs="0" maxOccurs="1" />
+                <xs:element name="CHE_AppraisalOfArchivalValue" type="che:CHE_AppraisalOfArchivalValue_Type" minOccurs="1" maxOccurs="1" />
+                <xs:element name="CHE_ReasonForArchivingValue" type="che:CHE_ReasonForArchivingValue_Type" minOccurs="1" maxOccurs="1" />
+                <xs:element name="CHE_commentOnArchivalValue" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="1"/>
 		</xs:sequence>
 	</xs:complexType>
 	<!-- MD_AbstractClass -->

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
@@ -262,7 +262,7 @@
 					<xs:element name="appraisalOfArchivalValue" type="che:CHE_AppraisalOfArchivalValue_Type"
 						minOccurs="1" maxOccurs="1" />
 					<xs:element name="reasonForArchivingValue" type="che:CHE_ReasonForArchivingValue_Type"
-						minOccurs="1" maxOccurs="1" />
+						minOccurs="0" maxOccurs="1" />
 					<xs:element name="commentOnArchivalValue" type="gco:CharacterString_PropertyType"
 						minOccurs="0" maxOccurs="1"/>
 				</xs:sequence>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
@@ -191,6 +191,7 @@
 					<xs:element name="dateOfMonitoringState" type="gco:Date_PropertyType" minOccurs="0"/>
 					<xs:element name="historyConcept" type="che:CHE_MD_HistoryConcept_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element name="archiveConcept" type="che:CHE_MD_ArchiveConcept_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="appraisalAap"   type="che:CHE_MD_Appraisal_AAP_Type" minOccurs="0" maxOccurs="1" />
 				</xs:sequence>
 				<xs:attribute ref="gco:isoType" use="required" fixed="gmd:MD_MaintenanceInformation"/>
 			</xs:extension>
@@ -234,6 +235,29 @@
 		</xs:sequence>
 		<xs:attributeGroup ref="gco:ObjectReference"/>
 		<xs:attribute ref="gco:nilReason"/>
+	</xs:complexType>
+	<xs:element name="MD_ArchivalValueCode"  type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
+	<xs:element name="MD_ArchivalReasonCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
+	<!-- CHE_MD_Appraisal_AAP_Type -->
+	<xs:complexType name="CHE_MD_Appraisal_AAP_Type">
+		<xs:annotation>
+			<xs:documentation>AAP</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="gco:AbstractObject_Type">
+				<xs:sequence>
+					<xs:element name="durationOfConservation" type="gco:Integer_PropertyType" minOccurs="0" maxOccurs="1" />
+					<xs:element name="commentOnDurationOfConservation" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="unbounded" />
+					<xs:sequence minOccurs="1" maxOccurs="1">
+						<xs:element ref="MD_ArchivalValueCode" />
+					</xs:sequence>
+					<xs:sequence>
+						<xs:element ref="MD_ArchivalReasonCode" />
+					</xs:sequence>
+					<xs:element name="commentOnArchivalValue" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
 	</xs:complexType>
 	<!-- MD_AbstractClass -->
 	<xs:complexType name="CHE_MD_AbstractClass_Type" abstract="true">

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
@@ -239,7 +239,7 @@
 
     <!-- AAP -->
     <xs:element name="CHE_AppraisalOfArchivalValueCode"  type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString" />
-    <xs:element name="CHE_ReasonForArchingValueCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString" />
+    <xs:element name="CHE_ReasonForArchivingValueCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString" />
     <xs:complexType name="CHE_AppraisalOfArchivalValue_Type">
         <xs:sequence minOccurs="1" maxOccurs="1">
             <xs:element ref="che:CHE_AppraisalOfArchivalValueCode" />
@@ -247,7 +247,7 @@
     </xs:complexType>
     <xs:complexType name="CHE_ReasonForArchivingValue_Type">
         <xs:sequence minOccurs="1" maxOccurs="1">
-            <xs:element ref="che:CHE_ReasonForArchingValueCode" />
+            <xs:element ref="che:CHE_ReasonForArchivingValueCode" />
         </xs:sequence>
     </xs:complexType>
 	<!-- CHE_MD_Appraisal_AAP_Type -->

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
@@ -241,17 +241,13 @@
     <xs:element name="CHE_MD_ArchivalValueCode"  type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString" />
     <xs:element name="CHE_MD_ArchivalReasonCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString" />
     <xs:complexType name="CHE_MD_ArchivalValue_Type">
-        <xs:complexContent>
-            <xs:extension base="gco:AbstractObject_Type">
-                <xs:sequence>
-                    <xs:element ref="che:CHE_MD_ArchivalValueCode" minOccurs="1" maxOccurs="1" />
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
+        <xs:sequence minOccurs="1" maxOccurs="1">
+            <xs:element ref="che:CHE_MD_ArchivalValueCode" />
+        </xs:sequence>
     </xs:complexType>
     <xs:complexType name="CHE_MD_ArchivalReason_Type">
-        <xs:sequence>
-            <xs:element ref="che:CHE_MD_ArchivalReasonCode" minOccurs="1" maxOccurs="1" />
+        <xs:sequence minOccurs="1" maxOccurs="1">
+            <xs:element ref="che:CHE_MD_ArchivalReasonCode" />
         </xs:sequence>
     </xs:complexType>
 	<!-- CHE_MD_Appraisal_AAP_Type -->
@@ -259,25 +255,15 @@
 		<xs:annotation>
 			<xs:documentation>AAP</xs:documentation>
 		</xs:annotation>
-		<xs:complexContent>
-			<xs:extension base="gco:AbstractObject_Type">
-				<xs:sequence>
-                    <xs:sequence minOccurs="0" maxOccurs="1">
-                        <xs:element name="durationOfConservation" type="gco:Integer_PropertyType" />
-                    </xs:sequence>
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:element name="commentOnDurationOfConservation" type="gco:CharacterString_PropertyType" />
-                    </xs:sequence>
-					<xs:sequence minOccurs="1" maxOccurs="1">
-                        <xs:element name="CHE_MD_ArchivalValue" type="che:CHE_MD_ArchivalValue_Type" />
-                    </xs:sequence>
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:element name="CHE_MD_ArchivalReason" type="che:CHE_MD_ArchivalReason_Type" />                    
-                    </xs:sequence>
-					<xs:element name="commentOnArchivalValue" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
+        <xs:sequence minOccurs="0" maxOccurs="1">
+                <xs:sequence minOccurs="0" maxOccurs="1">
+                    <xs:element name="durationOfConservation" type="gco:Integer_PropertyType" minOccurs="0" />
+                </xs:sequence>
+                <xs:element name="commentOnDurationOfConservation" type="gco:CharacterString_PropertyType"  minOccurs="0" maxOccurs="unbounded" />
+                <xs:element name="CHE_MD_ArchivalValue" type="che:CHE_MD_ArchivalValue_Type" />
+                <xs:element name="CHE_MD_ArchivalReason" type="che:CHE_MD_ArchivalReason_Type" minOccurs="0" maxOccurs="unbounded" />                    
+			    <xs:element name="commentOnArchivalValue" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
 	</xs:complexType>
 	<!-- MD_AbstractClass -->
 	<xs:complexType name="CHE_MD_AbstractClass_Type" abstract="true">

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
@@ -236,8 +236,8 @@
 		<xs:attributeGroup ref="gco:ObjectReference"/>
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
-	<xs:element name="MD_ArchivalValueCode"  type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
-	<xs:element name="MD_ArchivalReasonCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
+	<xs:element name="CHE_MD_ArchivalValueCode"  type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
+	<xs:element name="CHE_MD_ArchivalReasonCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
 	<!-- CHE_MD_Appraisal_AAP_Type -->
 	<xs:complexType name="CHE_MD_Appraisal_AAP_Type">
 		<xs:annotation>
@@ -249,10 +249,10 @@
 					<xs:element name="durationOfConservation" type="gco:Integer_PropertyType" minOccurs="0" maxOccurs="1" />
 					<xs:element name="commentOnDurationOfConservation" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="unbounded" />
 					<xs:sequence minOccurs="1" maxOccurs="1">
-						<xs:element ref="MD_ArchivalValueCode" />
+						<xs:element ref="CHE_MD_ArchivalValueCode" />
 					</xs:sequence>
 					<xs:sequence>
-						<xs:element ref="MD_ArchivalReasonCode" />
+						<xs:element ref="CHE_MD_ArchivalReasonCode" />
 					</xs:sequence>
 					<xs:element name="commentOnArchivalValue" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
@@ -191,7 +191,7 @@
 					<xs:element name="dateOfMonitoringState" type="gco:Date_PropertyType" minOccurs="0"/>
 					<xs:element name="historyConcept" type="che:CHE_MD_HistoryConcept_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element name="archiveConcept" type="che:CHE_MD_ArchiveConcept_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="CHE_Appraisal_AAP" type="che:CHE_MD_Appraisal_AAP_Type" minOccurs="0" maxOccurs="1" />
+					<xs:element name="appraisal" type="che:CHE_MD_Appraisal_AAP_PropertyType" minOccurs="0" maxOccurs="1" />
 				</xs:sequence>
 				<xs:attribute ref="gco:isoType" use="required" fixed="gmd:MD_MaintenanceInformation"/>
 			</xs:extension>
@@ -238,7 +238,35 @@
 	</xs:complexType>
 
     <!-- AAP -->
-    <xs:element name="CHE_AppraisalOfArchivalValueCode"  type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString" />
+	<xs:complexType name="CHE_MD_Appraisal_AAP_PropertyType">
+		<xs:sequence minOccurs="0">
+			<xs:element ref="che:CHE_MD_Appraisal_AAP"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="gco:ObjectReference"/>
+		<xs:attribute ref="gco:nilReason"/>
+	</xs:complexType>
+
+	<xs:element name="CHE_MD_Appraisal_AAP" type="che:CHE_MD_Appraisal_AAP_Type" substitutionGroup="gco:AbstractObject"/>
+
+	<xs:complexType name="CHE_MD_Appraisal_AAP_Type">
+		<xs:annotation>
+			<xs:documentation>AAP</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="durationOfConservation" type="gco:Integer_PropertyType"
+						minOccurs="1" maxOccurs="1" />
+			<xs:element name="commentOnDurationOfConservation" type="gco:CharacterString_PropertyType"
+						minOccurs="0" maxOccurs="1" />
+			<xs:element name="appraisalOfArchivalValue" type="che:CHE_AppraisalOfArchivalValue_Type"
+						minOccurs="1" maxOccurs="1" />
+			<xs:element name="reasonForArchivingValue" type="che:CHE_ReasonForArchivingValue_Type"
+						minOccurs="1" maxOccurs="1" />
+			<xs:element name="commentOnArchivalValue" type="gco:CharacterString_PropertyType"
+						minOccurs="0" maxOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="CHE_AppraisalOfArchivalValueCode"  type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString" />
     <xs:element name="CHE_ReasonForArchivingValueCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString" />
     <xs:complexType name="CHE_AppraisalOfArchivalValue_Type">
         <xs:sequence minOccurs="1" maxOccurs="1">
@@ -250,21 +278,7 @@
             <xs:element ref="che:CHE_ReasonForArchivingValueCode" />
         </xs:sequence>
     </xs:complexType>
-	<!-- CHE_MD_Appraisal_AAP_Type -->
-	<xs:complexType name="CHE_MD_Appraisal_AAP_Type">
-		<xs:annotation>
-			<xs:documentation>AAP</xs:documentation>
-		</xs:annotation>
-        <xs:sequence minOccurs="0" maxOccurs="1">
-                <xs:sequence minOccurs="1" maxOccurs="1">
-                    <xs:element name="CHE_DurationOfConservation" type="gco:Integer_PropertyType" minOccurs="1" maxOccurs="1" />
-                </xs:sequence>
-                <xs:element name="CHE_CommentOnDurationOfConservation" type="gco:CharacterString_PropertyType"  minOccurs="0" maxOccurs="1" />
-                <xs:element name="CHE_AppraisalOfArchivalValue" type="che:CHE_AppraisalOfArchivalValue_Type" minOccurs="1" maxOccurs="1" />
-                <xs:element name="CHE_ReasonForArchivingValue" type="che:CHE_ReasonForArchivingValue_Type" minOccurs="1" maxOccurs="1" />
-                <xs:element name="CHE_CommentOnArchivalValue" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="1"/>
-		</xs:sequence>
-	</xs:complexType>
+
 	<!-- MD_AbstractClass -->
 	<xs:complexType name="CHE_MD_AbstractClass_Type" abstract="true">
 		<xs:complexContent>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
@@ -191,7 +191,7 @@
 					<xs:element name="dateOfMonitoringState" type="gco:Date_PropertyType" minOccurs="0"/>
 					<xs:element name="historyConcept" type="che:CHE_MD_HistoryConcept_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element name="archiveConcept" type="che:CHE_MD_ArchiveConcept_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="appraisalAap"   type="che:CHE_MD_Appraisal_AAP_Type" minOccurs="0" maxOccurs="1" />
+					<xs:element name="CHE_Appraisal_AAP" type="che:CHE_MD_Appraisal_AAP_Type" minOccurs="0" maxOccurs="1" />
 				</xs:sequence>
 				<xs:attribute ref="gco:isoType" use="required" fixed="gmd:MD_MaintenanceInformation"/>
 			</xs:extension>
@@ -236,8 +236,24 @@
 		<xs:attributeGroup ref="gco:ObjectReference"/>
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
-	<xs:element name="CHE_MD_ArchivalValueCode"  type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
-	<xs:element name="CHE_MD_ArchivalReasonCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
+
+    <!-- AAP -->
+    <xs:element name="CHE_MD_ArchivalValueCode"  type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString" />
+    <xs:element name="CHE_MD_ArchivalReasonCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString" />
+    <xs:complexType name="CHE_MD_ArchivalValue_Type">
+        <xs:complexContent>
+            <xs:extension base="gco:AbstractObject_Type">
+                <xs:sequence>
+                    <xs:element ref="che:CHE_MD_ArchivalValueCode" minOccurs="1" maxOccurs="1" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="CHE_MD_ArchivalReason_Type">
+        <xs:sequence>
+            <xs:element ref="che:CHE_MD_ArchivalReasonCode" minOccurs="1" maxOccurs="1" />
+        </xs:sequence>
+    </xs:complexType>
 	<!-- CHE_MD_Appraisal_AAP_Type -->
 	<xs:complexType name="CHE_MD_Appraisal_AAP_Type">
 		<xs:annotation>
@@ -246,14 +262,18 @@
 		<xs:complexContent>
 			<xs:extension base="gco:AbstractObject_Type">
 				<xs:sequence>
-					<xs:element name="durationOfConservation" type="gco:Integer_PropertyType" minOccurs="0" maxOccurs="1" />
-					<xs:element name="commentOnDurationOfConservation" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="unbounded" />
+                    <xs:sequence minOccurs="0" maxOccurs="1">
+                        <xs:element name="durationOfConservation" type="gco:Integer_PropertyType" />
+                    </xs:sequence>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="commentOnDurationOfConservation" type="gco:CharacterString_PropertyType" />
+                    </xs:sequence>
 					<xs:sequence minOccurs="1" maxOccurs="1">
-						<xs:element ref="CHE_MD_ArchivalValueCode" />
-					</xs:sequence>
-					<xs:sequence>
-						<xs:element ref="CHE_MD_ArchivalReasonCode" />
-					</xs:sequence>
+                        <xs:element name="CHE_MD_ArchivalValue" type="che:CHE_MD_ArchivalValue_Type" />
+                    </xs:sequence>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="CHE_MD_ArchivalReason" type="che:CHE_MD_ArchivalReason_Type" />                    
+                    </xs:sequence>
 					<xs:element name="commentOnArchivalValue" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
 			</xs:extension>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
@@ -257,12 +257,12 @@
 		</xs:annotation>
         <xs:sequence minOccurs="0" maxOccurs="1">
                 <xs:sequence minOccurs="1" maxOccurs="1">
-                    <xs:element name="CHE_durationOfConservation" type="gco:Integer_PropertyType" minOccurs="1" maxOccurs="1" />
+                    <xs:element name="CHE_DurationOfConservation" type="gco:Integer_PropertyType" minOccurs="1" maxOccurs="1" />
                 </xs:sequence>
-                <xs:element name="CHE_commentOnDurationOfConservation" type="gco:CharacterString_PropertyType"  minOccurs="0" maxOccurs="1" />
+                <xs:element name="CHE_CommentOnDurationOfConservation" type="gco:CharacterString_PropertyType"  minOccurs="0" maxOccurs="1" />
                 <xs:element name="CHE_AppraisalOfArchivalValue" type="che:CHE_AppraisalOfArchivalValue_Type" minOccurs="1" maxOccurs="1" />
                 <xs:element name="CHE_ReasonForArchivingValue" type="che:CHE_ReasonForArchivingValue_Type" minOccurs="1" maxOccurs="1" />
-                <xs:element name="CHE_commentOnArchivalValue" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="CHE_CommentOnArchivalValue" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="1"/>
 		</xs:sequence>
 	</xs:complexType>
 	<!-- MD_AbstractClass -->

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/che/che.xsd
@@ -249,21 +249,25 @@
 	<xs:element name="CHE_MD_Appraisal_AAP" type="che:CHE_MD_Appraisal_AAP_Type" substitutionGroup="gco:AbstractObject"/>
 
 	<xs:complexType name="CHE_MD_Appraisal_AAP_Type">
-		<xs:annotation>
-			<xs:documentation>AAP</xs:documentation>
-		</xs:annotation>
-		<xs:sequence>
-			<xs:element name="durationOfConservation" type="gco:Integer_PropertyType"
+		<xs:complexContent>
+			<xs:extension base="gco:AbstractObject_Type">
+				<xs:annotation>
+					<xs:documentation>AAP</xs:documentation>
+				</xs:annotation>
+				<xs:sequence>
+					<xs:element name="durationOfConservation" type="gco:Integer_PropertyType"
 						minOccurs="1" maxOccurs="1" />
-			<xs:element name="commentOnDurationOfConservation" type="gco:CharacterString_PropertyType"
+					<xs:element name="commentOnDurationOfConservation" type="gco:CharacterString_PropertyType"
 						minOccurs="0" maxOccurs="1" />
-			<xs:element name="appraisalOfArchivalValue" type="che:CHE_AppraisalOfArchivalValue_Type"
+					<xs:element name="appraisalOfArchivalValue" type="che:CHE_AppraisalOfArchivalValue_Type"
 						minOccurs="1" maxOccurs="1" />
-			<xs:element name="reasonForArchivingValue" type="che:CHE_ReasonForArchivingValue_Type"
+					<xs:element name="reasonForArchivingValue" type="che:CHE_ReasonForArchivingValue_Type"
 						minOccurs="1" maxOccurs="1" />
-			<xs:element name="commentOnArchivalValue" type="gco:CharacterString_PropertyType"
+					<xs:element name="commentOnArchivalValue" type="gco:CharacterString_PropertyType"
 						minOccurs="0" maxOccurs="1"/>
-		</xs:sequence>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
 	</xs:complexType>
 
 	<xs:element name="CHE_AppraisalOfArchivalValueCode"  type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString" />

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/gmd/maintenance.xsd
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/gmd/maintenance.xsd
@@ -29,6 +29,24 @@
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
+
+    <xs:complexType name="MD_Appraisal_AAP_Type">
+        <xs:annotation>
+            <xs:documentation>AAP</xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="gco:AbstractObject_Type">
+                <xs:sequence>
+                    <xs:element name="durationOfConservation" type="gco:Integer_PropertyType" />
+                    <xs:element name="commentOnDurationOfConservation" type="gco:CharacterString_PropertyType" />
+                    <xs:element name="appraisalOfArchivalValue" type="gco:CodeListValue_Type" />
+                    <xs:element name="reasonForArchivingValue" type="gco:CodeListValue_Type" />
+                    <xs:element name="commentOnArchivalValue" type="gco:CharacterString_PropertyType" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    
 	<!-- ........................................................................ -->
 	<xs:element name="MD_MaintenanceInformation" type="gmd:MD_MaintenanceInformation_Type"/>
 	<!-- ........................................................................ -->

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/gmd/maintenance.xsd
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/schema/gmd/maintenance.xsd
@@ -29,23 +29,6 @@
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
-
-    <xs:complexType name="MD_Appraisal_AAP_Type">
-        <xs:annotation>
-            <xs:documentation>AAP</xs:documentation>
-        </xs:annotation>
-        <xs:complexContent>
-            <xs:extension base="gco:AbstractObject_Type">
-                <xs:sequence>
-                    <xs:element name="durationOfConservation" type="gco:Integer_PropertyType" />
-                    <xs:element name="commentOnDurationOfConservation" type="gco:CharacterString_PropertyType" />
-                    <xs:element name="appraisalOfArchivalValue" type="gco:CodeListValue_Type" />
-                    <xs:element name="reasonForArchivingValue" type="gco:CodeListValue_Type" />
-                    <xs:element name="commentOnArchivalValue" type="gco:CharacterString_PropertyType" />
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
     
 	<!-- ........................................................................ -->
 	<xs:element name="MD_MaintenanceInformation" type="gmd:MD_MaintenanceInformation_Type"/>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/schematron/schematron-rules-aap.sch
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/schematron/schematron-rules-aap.sch
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+queryBinding="xslt2">
+<sch:title xmlns="http://www.w3.org/2001/XMLSchema">AAP</sch:title>
+<sch:ns prefix="gml" uri="http://www.opengis.net/gml"/>
+<sch:ns prefix="gmd" uri="http://www.isotc211.org/2005/gmd"/>
+<sch:ns prefix="gmx" uri="http://www.isotc211.org/2005/gmx"/>
+<sch:ns prefix="srv" uri="http://www.isotc211.org/2005/srv"/>
+<sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
+<sch:ns prefix="che" uri="http://www.geocat.ch/2008/che"/>
+<sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
+<sch:ns prefix="skos" uri="http://www.w3.org/2004/02/skos/core#"/>
+<sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+
+<sch:pattern>
+    <sch:title>$loc/strings/mandatoryFields</sch:title>
+    <sch:rule context="/che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/che:appraisal/che:CHE_MD_Appraisal_AAP">
+
+        <sch:let name="durationOfConservation" value="che:durationOfConservation/gco:Integer/text()"/>
+	<sch:let name="appraisalOfArchivalValue" value="che:appraisalOfArchivalValue/che:CHE_AppraisalOfArchivalValueCode/@codeListValue" />
+	<sch:let name="reasonForArchiving" value="che:reasonForArchivingValue/che:CHE_ReasonForArchivingValueCode/@codeListValue" />
+
+	<!-- duration of conservation -->
+        <sch:assert test="string-length($durationOfConservation) &gt; 0">
+            <sch:value-of select="$loc/strings/durationOfConservationRequired"/>
+        </sch:assert>
+        <sch:report test="string-length($durationOfConservation) &gt; 0">
+            <sch:value-of select="$loc/strings/durationOfConservationReport"/>
+            <sch:value-of select="floor($durationOfConservation)"/>
+        </sch:report>
+
+	<!-- appraisal of archival value (codelist) -->
+        <sch:assert test="string-length($appraisalOfArchivalValue) &gt; 0">
+            <sch:value-of select="$loc/strings/appraisalOfArchivalValueRequired"/>
+        </sch:assert>
+        <sch:report test="string-length($appraisalOfArchivalValue) &gt; 0">
+            <sch:value-of select="$loc/strings/appraisalOfArchivalValueReport"/>
+            <sch:value-of select="normalize-space($appraisalOfArchivalValue)"/>
+        </sch:report>
+
+	<!-- reason for archiving value (codelist) -->
+        <sch:assert test="string-length($reasonForArchiving) &gt; 0">
+            <sch:value-of select="$loc/strings/reasonForArchivingRequired"/>
+        </sch:assert>
+        <sch:report test="string-length($reasonForArchiving) &gt; 0">
+            <sch:value-of select="$loc/strings/reasonForArchivingReport"/>
+            <sch:value-of select="normalize-space($reasonForArchiving)"/>
+        </sch:report>
+
+    </sch:rule>
+</sch:pattern>
+
+</sch:schema>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/schematron/schematron-rules-aap.sch
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/schematron/schematron-rules-aap.sch
@@ -1,54 +1,66 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-queryBinding="xslt2">
-<sch:title xmlns="http://www.w3.org/2001/XMLSchema">AAP</sch:title>
-<sch:ns prefix="gml" uri="http://www.opengis.net/gml"/>
-<sch:ns prefix="gmd" uri="http://www.isotc211.org/2005/gmd"/>
-<sch:ns prefix="gmx" uri="http://www.isotc211.org/2005/gmx"/>
-<sch:ns prefix="srv" uri="http://www.isotc211.org/2005/srv"/>
-<sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
-<sch:ns prefix="che" uri="http://www.geocat.ch/2008/che"/>
-<sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
-<sch:ns prefix="skos" uri="http://www.w3.org/2004/02/skos/core#"/>
-<sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
 
-<sch:pattern>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  queryBinding="xslt2">
+  <sch:title xmlns="http://www.w3.org/2001/XMLSchema">AAP</sch:title>
+  <sch:ns prefix="gml" uri="http://www.opengis.net/gml"/>
+  <sch:ns prefix="gmd" uri="http://www.isotc211.org/2005/gmd"/>
+  <sch:ns prefix="gmx" uri="http://www.isotc211.org/2005/gmx"/>
+  <sch:ns prefix="srv" uri="http://www.isotc211.org/2005/srv"/>
+  <sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
+  <sch:ns prefix="che" uri="http://www.geocat.ch/2008/che"/>
+  <sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
+  <sch:ns prefix="skos" uri="http://www.w3.org/2004/02/skos/core#"/>
+  <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+
+  <sch:pattern>
     <sch:title>$loc/strings/mandatoryFields</sch:title>
     <sch:rule context="/che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/che:appraisal/che:CHE_MD_Appraisal_AAP">
 
-        <sch:let name="durationOfConservation" value="che:durationOfConservation/gco:Integer/text()"/>
-	<sch:let name="appraisalOfArchivalValue" value="che:appraisalOfArchivalValue/che:CHE_AppraisalOfArchivalValueCode/@codeListValue" />
-	<sch:let name="reasonForArchiving" value="che:reasonForArchivingValue/che:CHE_ReasonForArchivingValueCode/@codeListValue" />
+      <sch:let name="durationOfConservation" value="che:durationOfConservation/gco:Integer/text()"/>
+      <sch:let name="appraisalOfArchivalValue" value="che:appraisalOfArchivalValue/che:CHE_AppraisalOfArchivalValueCode/@codeListValue" />
+      <sch:let name="reasonForArchiving" value="che:reasonForArchivingValue/che:CHE_ReasonForArchivingValueCode/@codeListValue" />
 
-	<!-- duration of conservation -->
-        <sch:assert test="string-length($durationOfConservation) &gt; 0">
-            <sch:value-of select="$loc/strings/durationOfConservationRequired"/>
-        </sch:assert>
-        <sch:report test="string-length($durationOfConservation) &gt; 0">
-            <sch:value-of select="$loc/strings/durationOfConservationReport"/>
-            <sch:value-of select="floor($durationOfConservation)"/>
-        </sch:report>
+      <!-- duration of conservation -->
+      <sch:assert test="string-length($durationOfConservation) &gt; 0">
+        <sch:value-of select="$loc/strings/durationOfConservationRequired"/>
+      </sch:assert>
+      <sch:report test="string-length($durationOfConservation) &gt; 0">
+        <sch:value-of select="$loc/strings/durationOfConservationReport"/>
+        <sch:value-of select="floor($durationOfConservation)"/>
+      </sch:report>
 
-	<!-- appraisal of archival value (codelist) -->
-        <sch:assert test="string-length($appraisalOfArchivalValue) &gt; 0">
-            <sch:value-of select="$loc/strings/appraisalOfArchivalValueRequired"/>
-        </sch:assert>
-        <sch:report test="string-length($appraisalOfArchivalValue) &gt; 0">
-            <sch:value-of select="$loc/strings/appraisalOfArchivalValueReport"/>
-            <sch:value-of select="normalize-space($appraisalOfArchivalValue)"/>
-        </sch:report>
-
-	<!-- reason for archiving value (codelist) -->
-        <sch:assert test="string-length($reasonForArchiving) &gt; 0">
-            <sch:value-of select="$loc/strings/reasonForArchivingRequired"/>
-        </sch:assert>
-        <sch:report test="string-length($reasonForArchiving) &gt; 0">
-            <sch:value-of select="$loc/strings/reasonForArchivingReport"/>
-            <sch:value-of select="normalize-space($reasonForArchiving)"/>
-        </sch:report>
+      <!-- appraisal of archival value (codelist) -->
+      <sch:assert test="string-length($appraisalOfArchivalValue) &gt; 0">
+        <sch:value-of select="$loc/strings/appraisalOfArchivalValueRequired"/>
+      </sch:assert>
+      <sch:report test="string-length($appraisalOfArchivalValue) &gt; 0">
+        <sch:value-of select="$loc/strings/appraisalOfArchivalValueReport"/>
+        <sch:value-of select="normalize-space($appraisalOfArchivalValue)"/>
+      </sch:report>
 
     </sch:rule>
-</sch:pattern>
+  </sch:pattern>
+
+  <sch:pattern>
+    <sch:title>$loc/strings/reasonForArchivalValuePresence</sch:title>
+    <sch:rule context="/che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/che:appraisal/che:CHE_MD_Appraisal_AAP">
+      <sch:let name="appraisalOfArchivalValue" value="che:appraisalOfArchivalValue/che:CHE_AppraisalOfArchivalValueCode/@codeListValue" />
+      <sch:let name="archWurdigOrSampling" value="$appraisalOfArchivalValue = 'S' or $appraisalOfArchivalValue = 'A'" />
+      <sch:let name="reasonForArchiving" value="che:reasonForArchivingValue/che:CHE_ReasonForArchivingValueCode/@codeListValue" />
+      <sch:let name="reasonPresent" value="string-length($reasonForArchiving) &gt; 0" />
+      <sch:let name="reasonReport" value="if ($reasonPresent) then $loc/strings/reasonForArchivalValuePresent else $loc/strings/reasonForArchivalValueAbsent" />
+
+      <sch:assert test="($archWurdigOrSampling and $reasonPresent) or (not($archWurdigOrSampling) and not($reasonPresent))">
+        <sch:value-of select="$reasonReport" />
+      </sch:assert>
+      <sch:report test="($archWurdigOrSampling and $reasonPresent) or (not($archWurdigOrSampling) and not($reasonPresent))">
+        <sch:value-of select="$loc/strings/reasonForArchivalValuePresenceReport" />
+        <sch:value-of select="$reasonReport" />
+      </sch:report>
+
+    </sch:rule>
+  </sch:pattern>
 
 </sch:schema>

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -65,6 +65,21 @@
              }
            }
          };
+         // When adding a new element and the cardinality is 0-1,
+         // then hide the add control.
+         // When an element is removed and the cardinality is 0-1,
+         // then display the add control
+         var checkAddControls = function(element, isRemoved) {
+           var addElement = $(element).next();
+           if (addElement !== undefined) {
+             var addBlock = addElement.get(0);
+             if ($(addBlock).hasClass('gn-add-field') &&
+                 $(addBlock).attr('data-gn-cardinality') === '0-1') {
+               $(addBlock).toggleClass('hidden', isRemoved ? false : true);
+             }
+           }
+         };
+
          // When adding a new element, the down control
          // of the previous element must be enabled and
          // the up control enabled only if the previous
@@ -316,7 +331,8 @@
                  target[position || 'after'](snippet); // Insert
                  snippet.slideDown(duration, function() {});   // Slide
 
-                 // Adapt the move element
+                 // Adapt the add & move element
+                 checkAddControls(snippet);
                  checkMoveControls(snippet);
                }
                $compile(snippet)(gnCurrentEdit.formScope);
@@ -347,7 +363,7 @@
                target[position || 'before'](snippet); // Insert
                snippet.slideDown(duration, function() {});   // Slide
 
-               // Adapt the move element
+               checkAddControls(snippet);
                checkMoveControls(snippet);
 
                $compile(snippet)(gnCurrentEdit.formScope);
@@ -410,7 +426,7 @@
                  }
                };
 
-               // Adapt the move element
+               checkAddControls(target.get(0), true);
                checkMoveControls(target.get(0));
 
                target.slideUp(duration, function() { $(this).remove();});

--- a/web-ui/src/main/resources/catalog/templates/admin/geocat.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/geocat.html
@@ -12,10 +12,10 @@
       <i class="fa fa-file-code-o fa-4x"></i>
       <p data-translate="">Unpublished Metadata Report HTML</p>
     </a>
-    <!--  SB 451 -->
-    <a href="aap.report.html" class="btn btn-lg btn-block btn-success gn-btn-admin">
+    <!--  SB 451: AAP report -->
+    <a href="aap.report.csv" class="btn btn-lg btn-block btn-success gn-btn-admin">
       <i class="fa fa-file-code-o fa-4x"></i>
-      <p data-translate="">AAP Metadata Report HTML</p>
+      <p data-translate="">AAP Metadata Report CSV</p>
     </a>    
     <a href="admin.shared.objects" class="btn btn-lg btn-block btn-info gn-btn-admin">
       <i class="fa fa-tags fa-4x"></i>

--- a/web-ui/src/main/resources/catalog/templates/admin/geocat.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/geocat.html
@@ -12,6 +12,11 @@
       <i class="fa fa-file-code-o fa-4x"></i>
       <p data-translate="">Unpublished Metadata Report HTML</p>
     </a>
+    <!--  SB 451 -->
+    <a href="aap.report.html" class="btn btn-lg btn-block btn-success gn-btn-admin">
+      <i class="fa fa-file-code-o fa-4x"></i>
+      <p data-translate="">AAP Metadata Report HTML</p>
+    </a>    
     <a href="admin.shared.objects" class="btn btn-lg btn-block btn-info gn-btn-admin">
       <i class="fa fa-tags fa-4x"></i>
       <p data-translate="">Shared Objects</p>

--- a/web/src/main/webapp/WEB-INF/config-geocat.xml
+++ b/web/src/main/webapp/WEB-INF/config-geocat.xml
@@ -251,6 +251,12 @@
 			<output sheet="unpublish-report-html.xsl" contentType="text/html; charset=UTF-8"/>
         </service>
 
+        <service name="aap.report.csb">
+            <class name=".geocat.kernel.AapMetadataReport"/>
+            <output sheet="aap-report-csv.xsl" contentType="text/html; charset=UTF-8"/>
+        </service>
+        
+
         <service name="keywords.duplicate">
             <class name=".geocat.services.thesaurus.Duplicate"/>
 

--- a/web/src/main/webapp/WEB-INF/config-geocat.xml
+++ b/web/src/main/webapp/WEB-INF/config-geocat.xml
@@ -251,7 +251,7 @@
 			<output sheet="unpublish-report-html.xsl" contentType="text/html; charset=UTF-8"/>
         </service>
 
-        <service name="aap.report.csb">
+        <service name="aap.report.csv">
             <class name=".geocat.kernel.AapMetadataReport"/>
             <output sheet="aap-report-csv.xsl" contentType="text/html; charset=UTF-8"/>
         </service>

--- a/web/src/main/webapp/WEB-INF/config-geocat.xml
+++ b/web/src/main/webapp/WEB-INF/config-geocat.xml
@@ -253,7 +253,7 @@
 
         <service name="aap.report.csv">
             <class name=".geocat.kernel.AapMetadataReport"/>
-            <output sheet="aap-report-csv.xsl" contentType="text/html; charset=UTF-8"/>
+            <output sheet="aap-report-csv.xsl" contentType="text/csv; charset=UTF-8"/>
         </service>
         
 

--- a/web/src/main/webapp/WEB-INF/overrides-config-security-geocat.xml
+++ b/web/src/main/webapp/WEB-INF/overrides-config-security-geocat.xml
@@ -25,6 +25,9 @@
         <addInterceptUrl  pattern="/srv/\w\w\w/unpublish.report.csv!?.*" access="hasRole('Administrator')"/>
         <addInterceptUrl  pattern="/srv/\w\w\w/unpublish.report.html!?.*" access="hasRole('Administrator')"/>
 
+        <!--  AAP report -->
+        <addInterceptUrl  pattern="/srv/\w\w\w/aap.report.csv!?.*" access="hasRole('Administrator')"/>
+
         <!-- Extent facilities -->
         <addInterceptUrl  pattern="/srv/\w\w\w/xml.extent.add!?.*" access="hasRole('Editor')"/>
         <addInterceptUrl  pattern="/srv/\w\w\w/xml.extent.delete!?.*" access="hasRole('Administrator')"/>

--- a/web/src/main/webapp/xsl/aap-report-csv.xsl
+++ b/web/src/main/webapp/xsl/aap-report-csv.xsl
@@ -5,9 +5,9 @@
 
   <xsl:template match="/">
     <xsl:text>"owner";"Title";"Identifier";"UUID";"geodata type";"Point of contact";"maintenance &amp; update frequency";"duration of conservation";"comment on duration of conservation";;;;;;"comment on archival value";"appraisal of archival value";"reason for archiving value";;;;;;;;;;;;</xsl:text>
-    <xsl:apply-templates select="/root/report/allElements/record"/>
+    <xsl:apply-templates select="/root/records"/>
   </xsl:template>
   <xsl:template match="record">
-    "<xsl:value-of select="uuid"/>";"<xsl:value-of select="entity"/>";"<xsl:value-of select="validated"/>";"<xsl:value-of select="published"/>";"<xsl:value-of select="changedate"/>";"<xsl:value-of select="changetime"/>";"<xsl:value-of select="failurerule"/>";"<xsl:value-of select="replace(failurereasons, '&quot;', '`')"/>"</xsl:template>
+"<xsl:value-of select="uuid"/>";"<xsl:value-of select="entity"/>";"<xsl:value-of select="validated"/>";"<xsl:value-of select="published"/>";"<xsl:value-of select="changedate"/>";"<xsl:value-of select="changetime"/>";"<xsl:value-of select="failurerule"/>";"<xsl:value-of select="replace(failurereasons, '&quot;', '`')"/>"</xsl:template>
 
 </xsl:stylesheet>

--- a/web/src/main/webapp/xsl/aap-report-csv.xsl
+++ b/web/src/main/webapp/xsl/aap-report-csv.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:output method="text" indent="no" media-type="text/csv"></xsl:output>
+
+  <xsl:template match="/">
+    <xsl:text>"owner";"Title";"Identifier";"UUID";"geodata type";"Point of contact";"maintenance &amp; update frequency";"duration of conservation";"comment on duration of conservation";;;;;;"comment on archival value";"appraisal of archival value";"reason for archiving value";;;;;;;;;;;;</xsl:text>
+    <xsl:apply-templates select="/root/report/allElements/record"/>
+  </xsl:template>
+  <xsl:template match="record">
+    "<xsl:value-of select="uuid"/>";"<xsl:value-of select="entity"/>";"<xsl:value-of select="validated"/>";"<xsl:value-of select="published"/>";"<xsl:value-of select="changedate"/>";"<xsl:value-of select="changetime"/>";"<xsl:value-of select="failurerule"/>";"<xsl:value-of select="replace(failurereasons, '&quot;', '`')"/>"</xsl:template>
+
+</xsl:stylesheet>

--- a/web/src/main/webapp/xsl/aap-report-csv.xsl
+++ b/web/src/main/webapp/xsl/aap-report-csv.xsl
@@ -4,10 +4,10 @@
   <xsl:output method="text" indent="no" media-type="text/csv"></xsl:output>
 
   <xsl:template match="/">
-    <xsl:text>"owner";"Title";"Identifier";"UUID";"geodata type";"Point of contact";"maintenance &amp; update frequency";"duration of conservation";"comment on duration of conservation";;;;;;"comment on archival value";"appraisal of archival value";"reason for archiving value";;;;;;;;;;;;</xsl:text>
+    <xsl:text>"owner";"Title";"Identifier";"UUID";"geodata type";"Point of contact";"maintenance &amp; update frequency";"duration of conservation";"comment on duration of conservation";"";"";"";"";"";"comment on archival value";"appraisal of archival value";"reason for archiving value";"";"";"";"";"";"";"";"";"";"";"";""</xsl:text>
     <xsl:apply-templates select="/root/records"/>
   </xsl:template>
   <xsl:template match="record">
-"<xsl:value-of select="uuid"/>";"<xsl:value-of select="entity"/>";"<xsl:value-of select="validated"/>";"<xsl:value-of select="published"/>";"<xsl:value-of select="changedate"/>";"<xsl:value-of select="changetime"/>";"<xsl:value-of select="failurerule"/>";"<xsl:value-of select="replace(failurereasons, '&quot;', '`')"/>"</xsl:template>
+"<xsl:value-of select="owner"/>";"<xsl:value-of select="title"/>";"<xsl:value-of select="identifier"/>";"<xsl:value-of select="uuid"/>";"<xsl:value-of select="geodatatype"/>";"<xsl:value-of select="specialistAuthority"/>";"<xsl:value-of select="updateFrequency"/>";"<xsl:value-of select="durationOfConservation"/>";"<xsl:value-of select="commentOnDuration"/>";"";"";"";"";"";"<xsl:value-of select="commentOnArchival"/>";"<xsl:value-of select="appraisalOfArchival"/>";"<xsl:value-of select="reasonForArchiving"/>";"";"";"";"";"";"";"";"";"";"";""</xsl:template>
 
 </xsl:stylesheet>

--- a/web/src/main/webapp/xslt/ui-metadata/edit/edit.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/edit/edit.xsl
@@ -10,7 +10,7 @@
   extension-element-prefixes="saxon" exclude-result-prefixes="#all">
 
   <!-- The editor form.
-  
+
   The form is built from the processing of the metadocument. The metadocument
   is composed of the source metadata record and the schema information.
   

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -219,6 +219,23 @@
       </xsl:otherwise>
     </xsl:choose>
 
+    <!-- When building the form with an element having cardinality 0..1,
+    add a hidden add action in case the element is removed. If removed,
+    the client app take care of displaying this control. -->
+    <xsl:if test="$service = 'md.edit' and $parentEditInfo/@min = 0 and $parentEditInfo/@max = 1">
+      <xsl:variable name="directive" select="gn-fn-metadata:getFieldAddDirective($editorConfig, name())"/>
+
+      <xsl:call-template name="render-element-to-add">
+        <xsl:with-param name="label"
+                        select="gn-fn-metadata:getLabel($schema, name(.), $labels, name(..), '', '')/label"/>
+        <xsl:with-param name="directive" select="$directive"/>
+        <xsl:with-param name="childEditInfo" select="$parentEditInfo"/>
+        <xsl:with-param name="parentEditInfo" select="../gn:element"/>
+        <xsl:with-param name="isFirst" select="false()"/>
+        <xsl:with-param name="isHidden" select="true()"/>
+        <xsl:with-param name="name" select="name()"/>
+      </xsl:call-template>
+    </xsl:if>
   </xsl:template>
 
 
@@ -624,6 +641,9 @@
     <!-- Hide add element if child of an XLink section. -->
     <xsl:param name="isDisabled" select="ancestor::node()[@xlink:href]"/>
     <xsl:param name="isFirst" required="no" as="xs:boolean" select="true()"/>
+    <xsl:param name="isHidden" required="no" as="xs:boolean" select="false()"/>
+    <xsl:param name="name" required="no" as="xs:string" select="''"/>
+
     <xsl:variable name="isCitedResponsiblePartySimpleView"
       select="$currTab = 'default' and name() = 'geonet:child' and @name='citedResponsibleParty'"/>
     <xsl:if test="not($isDisabled) and not($isCitedResponsiblePartySimpleView)">
@@ -633,8 +653,9 @@
 
       <!-- This element is replaced by the content received when clicking add -->
       <!-- GEOCAT -->
-      <div class="form-group gn-field {concat('gn-', substring-after($qualifiedName, ':'))} {if ($isRequired) then 'gn-required' else ''} gn-add-field"
+      <div class="form-group gn-field {concat('gn-', substring-after($qualifiedName, ':'))} {if ($isRequired) then 'gn-required' else ''} gn-add-field {if ($isHidden) then 'hidden' else ''}"
            id="gn-el-{$id}"
+           data-gn-cardinality="{$childEditInfo/@min}-{$childEditInfo/@max}"
            data-gn-field-highlight="">
         <label class="col-sm-2 control-label"
           data-gn-field-tooltip="{$schema}|{$qualifiedName}|{name(..)}|">
@@ -717,7 +738,7 @@
                 </xsl:when>
                 <xsl:otherwise>
                   <a class="btn btn-default"
-                     data-gn-click-and-spin="add({$parentEditInfo/@ref}, '{concat(@prefix, ':', @name)}', '{$id}', 'before');">
+                     data-gn-click-and-spin="add({$parentEditInfo/@ref}, '{if ($name != '') then $name else concat(@prefix, ':', @name)}', '{$id}', 'before');">
                     <i class="fa fa-plus gn-add"/>
                   </a>
                 </xsl:otherwise>

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -222,7 +222,7 @@
     <!-- When building the form with an element having cardinality 0..1,
     add a hidden add action in case the element is removed. If removed,
     the client app take care of displaying this control. -->
-    <xsl:if test="$service = 'md.edit' and $parentEditInfo/@min = 0 and $parentEditInfo/@max = 1">
+    <xsl:if test="$service = 'md.edit' and $parentEditInfo and $parentEditInfo/@min = 0 and $parentEditInfo/@max = 1">
       <xsl:variable name="directive" select="gn-fn-metadata:getFieldAddDirective($editorConfig, name())"/>
 
       <xsl:call-template name="render-element-to-add">


### PR DESCRIPTION
This PR is a bit long, but addresses several issues related to MD archival (AAP).

- SB-422: iso19139.che modifications (see https://jira.swisstopo.ch/browse/GEOCAT_SB-422)

- SB-451: AAP-related MD CSV export: Based on the previous issue, the requirement is to be able for the admins, to export as CSV the set of MD concerned by AAP. To implement this, a new field has been added on the lucene index, so that we can filter the corresponding MD easily. The new menu item has been added in the Geocat menu of the admin interface (red cross).

- SB-453: Adding new schematron rules for AAP. See in the admin / MD / schematron interface, as well as in the validation menu the implementation rules. For now 3 rules have been requested. The validity against the schema is already processed by the XSD validation, the 3 rules mainly check the coherence of the AAP field values.

Tests: runtime ok, customer currently testing this work (already deployed on tc-geocat.dev)
Some u-tests added when relevant.

