### PR TITLE
Backport 1753

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/SchematronCriteria.java
+++ b/domain/src/main/java/org/fao/geonet/domain/SchematronCriteria.java
@@ -11,22 +11,22 @@ import java.util.List;
 /**
  * An entity representing a schematron criteria. This is for the extended
  * validation framework ({@link Schematron}).
- * 
+ *
  * @author delawen
  */
 @Entity
 @Table(name = "SchematronCriteria")
 @Cacheable
 @Access(AccessType.PROPERTY)
-@SequenceGenerator(name= SchematronCriteria.ID_SEQ_NAME, initialValue=100, allocationSize=1)
+@SequenceGenerator(name = SchematronCriteria.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class SchematronCriteria extends GeonetEntity {
     static final String ID_SEQ_NAME = "schematron_criteria_id_seq";
     static final String EL_UI_TYPE = "uitype";
     static final String EL_UI_VALUE = "uivalue";
 
     private int id;
-	private SchematronCriteriaType type;
-	private String value;
+    private SchematronCriteriaType type;
+    private String value;
     private String uiType;
     private String uiValue;
     private SchematronCriteriaGroup group;
@@ -34,58 +34,56 @@ public class SchematronCriteria extends GeonetEntity {
     /**
      * Get the unique id for the schematron criteria object
      */
-	@Id
-	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = ID_SEQ_NAME)
-	public int getId() {
-		return id;
-	}
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = ID_SEQ_NAME)
+    public int getId() {
+        return id;
+    }
 
     /**
      * Set the unique id for the schematron criteria object
      */
-	public SchematronCriteria setId(int id) {
-		this.id = id;
-		return this;
-	}
+    public SchematronCriteria setId(int id) {
+        this.id = id;
+        return this;
+    }
 
-	@Override
-	public String toString() {
-		return "SchematronCriteria [id=" + id + ", type=" + type
-				+ ", value=" + value + "]";
-	}
+    @Override
+    public String toString() {
+        return "SchematronCriteria [id=" + id + ", type=" + type
+                + ", value=" + value + "]";
+    }
 
     /**
-	 * @return the type
-	 */
-	@Column(nullable = false, name = "type")
+     * @return the type
+     */
+    @Column(nullable = false, name = "type")
     @Enumerated(EnumType.STRING)
-	public SchematronCriteriaType getType() {
-		return type;
-	}
+    public SchematronCriteriaType getType() {
+        return type;
+    }
 
-	/**
-	 * @param type
-	 *            the type to set
-	 */
-	public void setType(SchematronCriteriaType type) {
-		this.type = type;
-	}
+    /**
+     * @param type the type to set
+     */
+    public void setType(SchematronCriteriaType type) {
+        this.type = type;
+    }
 
-	/**
-	 * @return the value
-	 */
-	@Column(nullable = false, name = "value")
-	public String getValue() {
-		return value;
-	}
+    /**
+     * @return the value
+     */
+    @Column(nullable = false, name = "value")
+    public String getValue() {
+        return value;
+    }
 
-	/**
-	 * @param value
-	 *            the value to set
-	 */
-	public void setValue(String value) {
-		this.value = value;
-	}
+    /**
+     * @param value the value to set
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
 
     /**
      * Get the <em>UI Type</em>.  The type of the criteria as reported in the UI.  This tends to be more descriptive and useful for a
@@ -101,15 +99,15 @@ public class SchematronCriteria extends GeonetEntity {
     /**
      * Set the <em>UI Type</em>.  The type of the criteria as reported in the UI.  This tends to be more descriptive and useful for a
      * user.
+     *
      * @param uiType the <em>UI Type</em>.  The type of the criteria as reported in the UI.  This tends to be more descriptive and useful for a
-     * user.
+     *               user.
      */
     public void setUiType(String uiType) {
         this.uiType = uiType;
     }
 
     /**
-     *
      * @return
      */
     public String getUiValue() {
@@ -165,6 +163,7 @@ public class SchematronCriteria extends GeonetEntity {
 
     /**
      * Create a copy of the c
+     *
      * @return
      */
     public SchematronCriteria copy() {

--- a/web-ui/src/main/resources/catalog/components/admin/schematron/SchematronEditCriteriaDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/schematron/SchematronEditCriteriaDirective.js
@@ -145,7 +145,24 @@
                scope.confirmationDialog.showDialog();
              };
              scope.saveEdit = function() {
+               var criteriaType, rawValue, value, isTypeahead;
+               isTypeahead = false;
                if (scope.isDirty()) {
+                 var input = findValueInput();
+                 // it we are not using an autocompleter replace the value with valueUi
+                 input.each(function(index, ele) {
+                   isTypeahead = isTypeahead || $(ele).data("ttTypeahead");
+                 });
+                 if (!isTypeahead) {
+                   criteriaType = scope.criteriaTypes[scope.criteria.uitype];
+                   rawValue = scope.criteria.uivalue;
+                   if (criteriaType.value) {
+                     // Check because ALWAYS_ACCEPT has not value.
+                     value = criteriaType.value.replace(/@@value@@/g, rawValue);
+                     scope.criteria.value = value;
+                   }
+                 }
+
                  if (scope.criteria.id) {
                    // it is an updated
                    gnSchematronAdminService.criteria.

--- a/web-ui/src/main/resources/catalog/components/admin/schematron/partials/criteria-viewer.html
+++ b/web-ui/src/main/resources/catalog/components/admin/schematron/partials/criteria-viewer.html
@@ -31,7 +31,6 @@
                     <input type="text"
                            class="form-control"
                            data-ng-disabled="(criteria.uitype | uppercase) === 'ALWAYS_ACCEPT' || (criteria.uitype | uppercase) === 'NEW'"
-                           placeholder="{{'criteriaValue' | translate}}"
                            data-ng-model="criteria.uivalue"
                             />
                 </div>

--- a/web-ui/src/main/resources/catalog/components/admin/schematron/partials/criteria-viewer.html
+++ b/web-ui/src/main/resources/catalog/components/admin/schematron/partials/criteria-viewer.html
@@ -1,8 +1,9 @@
-<div>
-    <a class="gn-action list-group-item" data-ng-hide="editing" data-ng-click="startEditing()">
+<div class="list-group-item">
+    <a class="gn-action" data-ng-hide="editing" data-ng-click="startEditing()">
         <div class="row">
             <i class="fa fa-edit" data-ng-class="calculateClassOnDirty('col-sm-1', null)" data-ng-show="isDirty()"/>
-            <div data-ng-class="calculateClassOnDirty('col-sm-10', 'col-sm-11')">{{describeCriteria()}}</div>
+            <div data-ng-if="(original.uitype | uppercase) !== 'NEW'" data-ng-class="calculateClassOnDirty('col-sm-10', 'col-sm-11')">{{describeCriteria()}}</div>
+            <button data-ng-if="(original.uitype | uppercase) === 'NEW'" class="btn btn-primary" data-ng-class="calculateClassOnDirty('col-sm-10', 'col-sm-11')">{{describeCriteria()}}</button>
 
             <div class="col-sm-1">
                 <i class="fa gn-action"
@@ -15,10 +16,10 @@
             </div>
         </div>
     </a>
-    <div class="row">
-        <form class="form-inline" role="form" data-ng-show="editing"
+    <div class="row" data-ng-show="editing">
+        <form class="" role="form"
               data-ng-keyup="handleKeyUp($event.keyCode)">
-                <div class="form-group col-sm-3">
+                <div class="form-group col-sm-4">
                     <select
                             class="form-control"
                             data-ng-change="updateType(); updateTypeAhead(); updateValueField()"
@@ -29,7 +30,7 @@
                 <div class="form-group col-sm-6">
                     <input type="text"
                            class="form-control"
-                           data-ng-disabled="criteria.uitype === 'ALWAYS_ACCEPT' || criteria.uitype === 'NEW'"
+                           data-ng-disabled="(criteria.uitype | uppercase) === 'ALWAYS_ACCEPT' || (criteria.uitype | uppercase) === 'NEW'"
                            placeholder="{{'criteriaValue' | translate}}"
                            data-ng-model="criteria.uivalue"
                             />

--- a/web-ui/src/main/resources/catalog/js/admin/SchematronAdminController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SchematronAdminController.js
@@ -234,10 +234,12 @@
           updateGroupCount(group, 1);
           var i, criteria = group.criteria;
           group.criteria = [];
-          for (i = 0; i < criteria.length; i++) {
-            var template = angular.copy(criteria[i]);
-            gnSchematronAdminService.criteria.add(criteria[i],
-                group.criteria[i], group);
+          if (criteria) {
+            for (i = 0; i < criteria.length; i++) {
+              var template = angular.copy(criteria[i]);
+              gnSchematronAdminService.criteria.add(criteria[i],
+                  group.criteria[i], group);
+            }
           }
         });
       };

--- a/web-ui/src/main/resources/catalog/style/gn_admin.less
+++ b/web-ui/src/main/resources/catalog/style/gn_admin.less
@@ -76,6 +76,11 @@ fieldset.cswCriteriaInfo, ul.list-group {
   max-height: 40em;
 }
 
+fieldset.cswCriteriaInfo, ul.criteria-list-group {
+  padding-right: 1em;
+  overflow-x: hidden;
+}
+
 .gn-virtual-csw .radio-inline {
   width: 24%;
 }

--- a/web-ui/src/main/resources/catalog/templates/admin/metadata/schematron.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/metadata/schematron.html
@@ -11,8 +11,10 @@
                         <p>{{confirmationDialog.message}}</p>
                     </div>
                     <div class="modal-footer">
-                        <button data-dismiss="modal" data-ng-click="confirmationDialog.deleteConfirmed()">{{'confirm' | translate}}</button>
-                        <button data-dismiss="modal">{{'cancel' | translate}}</button>
+                        <button data-dismiss="modal" data-ng-click="confirmationDialog.deleteConfirmed()"
+                                class="btn btn-warning">{{'confirm' | translate}}
+                        </button>
+                        <button data-dismiss="modal" class="btn btn-default">{{'cancel' | translate}}</button>
                     </div>
                 </div>
             </div>
@@ -28,7 +30,8 @@
                         <h5><strong>{{schema.name}}</strong></h5>
 
                         <div class="list-group">
-                            <a class="list-group-item" data-ng-repeat="schematron in schema.schematron | filter:schematronSearch"
+                            <a class="list-group-item"
+                               data-ng-repeat="schematron in schema.schematron | filter:schematronSearch"
                                data-ng-click="selectSchematron(schema, schematron)"
                                data-ng-class="{active: selection.schematron === schematron}">
                                 <i class="fa"
@@ -47,10 +50,10 @@
                 <div class="panel panel-default">
                     <div class="panel-heading"><span data-translate="">schematronApplicationCriteria</span>
                         <i id="schematronCriteriaGroupsQuestion" class="fa fa-question-circle"
-                             data-ng-mouseover="isShowSchematronGroupHelp = true"
-                             data-ng-mouseleave="isShowSchematronGroupHelp = false"></i>
+                           data-ng-mouseover="isShowSchematronGroupHelp = true"
+                           data-ng-mouseleave="isShowSchematronGroupHelp = false"></i>
                         <div style="padding-left: 2em; padding-top: 1em" data-ng-show="isShowSchematronGroupHelp">
-                           {{'schematronInfo' | translate}}
+                            {{'schematronInfo' | translate}}
                         </div>
                     </div>
                     <div class="panel-body">
@@ -65,7 +68,7 @@
                                                data-ng-blur="cancelGroupEdit()"
                                                data-ng-model="editGroup.updatedGroup.id.name"
                                                data-ng-keyup="handleGroupEditKeyPress($event.keyCode)"
-                                               id="{{group.id.name}}_NameInput"type="text" value="{{group.id.name}}" />
+                                               id="{{group.id.name}}_NameInput" type="text" value="{{group.id.name}}"/>
                                         <i class="fa gn-action"
                                            title="{{'schematronCopy' | translate}}"
                                            data-ng-class="hoverDup"
@@ -83,7 +86,7 @@
                                     </a>
                                 </li>
                                 <li data-ng-class="{active: !selection.group}"
-                                        data-ng-click="createSchematronGroup()">
+                                    data-ng-click="createSchematronGroup()">
                                     <a class="fa fa-plus"></a>
                                 </li>
                             </ul>
@@ -96,11 +99,12 @@
                                     <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
                                         <li role="presentation" data-ng-repeat="requirement in requirements"
                                             data-ng-hide="selection.group.requirement === requirement">
-                                            <a role="menuitem" data-ng-click="setRequirement(requirement)" tabindex="-1">{{'requirement'+requirement | translate}}</a></li>
+                                            <a role="menuitem" data-ng-click="setRequirement(requirement)"
+                                               tabindex="-1">{{'requirement'+requirement | translate}}</a></li>
                                     </ul>
                                 </div>
                             </div>
-                            <ul class="list-group" data-ng-if="selection.group">
+                            <ul class="criteria-list-group" data-ng-if="selection.group">
                                 <gn-criteria-editor
                                         criteria="criteria"
                                         schema="selection.schema"


### PR DESCRIPTION
See https://github.com/geonetwork/core-geonetwork/pull/1753 and https://jira.swisstopo.ch/browse/GEOCAT_SB-366?focusedCommentId=18861&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-18861 for the details.

This is a backport of the upstream PR, since both tree do not exactly match, some aspects of the previous PR could not be ported. The modification onto CheckUserName.java for instance, since the file does not exist in GeoCat. The rest of the modifications seemed coherent to me, even if I'm not a client-side expert on the modified parts.

Tests: untested yet, it would at least deserve a runtime one.