### PR TITLE
MEF import - groupOwner is ignored (SB-531)

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
@@ -301,7 +301,7 @@ public class Importer {
 
                     categs = info.getChild("categories");
                     privileges = info.getChild("privileges");
-
+                    groupId = Util.getParam(params, Params.GROUP);
                     Element general = info.getChild("general");
 
                     uuid = general.getChildText("uuid");


### PR DESCRIPTION
Tests:

* testsuite is broken (and will need an update of the java libasm, because it is unable to parse Java Bytecode 52 format, but this would also require an update of springframework ...), no unit tests related to the mef import have been found though.

* Tests OK at runtime: importing a ZIP file containing 1 MD: the privileges publish & notify are correctly set after import.

Note:

Might deserve an upstream PR since the group is also ignored in 3.2.x:
https://github.com/geonetwork/core-geonetwork/blob/develop/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java#L349-L379