### PR TITLE
Fix Loading of graphicoverview with '&'

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/groovy/iso19139/Handlers.groovy
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/groovy/iso19139/Handlers.groovy
@@ -306,7 +306,7 @@ public class Handlers {
             def img = graphic.'gmd:fileName'.text()
             String thumbnailUrl;
             if (img.startsWith("http://") || img.startsWith("https://")) {
-                thumbnailUrl = img;
+                thumbnailUrl = img.replace("&fname", "&amp;fname");
             } else if (!isSmallImage(img) || !hasLargeGraphic) {
                 thumbnailUrl = env.getLocalizedUrl() + "resources.get?fname=" + img + "&amp;access=public&amp;id=" + env.getMetadataId();
             }

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/groovy/iso19139/Handlers.groovy
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/groovy/iso19139/Handlers.groovy
@@ -1,5 +1,6 @@
 package iso19139
 
+import org.apache.commons.lang.StringEscapeUtils
 import org.fao.geonet.services.metadata.format.groovy.Environment
 import org.fao.geonet.services.metadata.format.groovy.MapConfig
 
@@ -306,7 +307,7 @@ public class Handlers {
             def img = graphic.'gmd:fileName'.text()
             String thumbnailUrl;
             if (img.startsWith("http://") || img.startsWith("https://")) {
-                thumbnailUrl = img.replace("&fname", "&amp;fname");
+                thumbnailUrl = StringEscapeUtils.escapeXml(img);
             } else if (!isSmallImage(img) || !hasLargeGraphic) {
                 thumbnailUrl = env.getLocalizedUrl() + "resources.get?fname=" + img + "&amp;access=public&amp;id=" + env.getMetadataId();
             }


### PR DESCRIPTION
This commit will escape `&` to `&amp;`

See https://github.com/geonetwork/core-geonetwork/commit/22a8117d48e946c4a4dddddc3032da8579f77149