### PR TITLE
Add multilingual support for URL in online resources

### DIFF
--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/process/onlinesrc-add.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/process/onlinesrc-add.xsl
@@ -323,8 +323,6 @@ Insert is made in first transferOptions found.
           <!-- ... the name is simply added in the newly
           created online element. -->
 
-          <xsl:message>###############
-          <xsl:value-of select="$name"></xsl:value-of> </xsl:message>
           <gmd:onLine>
             <xsl:if test="$uuidref">
               <xsl:attribute name="uuidref" select="$uuidref"/>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/process/onlinesrc-add.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/process/onlinesrc-add.xsl
@@ -1,261 +1,547 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Stylesheet used to update metadata for a service and
-attached it to the metadata for data.
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<!--
+Processing to insert or update an online resource element.
+Insert is made in first transferOptions found.
 -->
-<xsl:stylesheet xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<xsl:stylesheet xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:che="http://www.geocat.ch/2008/che"
-                xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:mime="java:org.fao.geonet.util.MimeTypeFinder"
-                version="2.0">
+                version="2.0" xmlns:che="http://www.geocat.ch/2008/che">
 
-  <!-- ============================================================================= -->
-
-  <xsl:param name="uuidref"/>
-  <xsl:param name="extra_metadata_uuid"/>
+  <!-- Main properties for the link.
+  Name and description may be multilingual eg. ENG#English name|FRE#Le français
+  Name and description may be a list of layer/feature type names and titles comma separated. -->
   <xsl:param name="protocol" select="'WWW:LINK-1.0-http--link'"/>
   <xsl:param name="url"/>
   <xsl:param name="name"/>
   <xsl:param name="desc"/>
+  <xsl:param name="function"/>
+  <xsl:param name="applicationProfile"/>
 
-  <!-- ============================================================================= -->
+  <!-- Add an optional uuidref attribute to the onLine element created. -->
+  <xsl:param name="uuidref"/>
 
-  <xsl:template match="/gmd:MD_Metadata|*[@gco:isoType='gmd:MD_Metadata']">
+  <!-- In this case an external metadata is available under the
+  extra element and all online resource from this records are added
+  in this one. -->
+  <xsl:param name="extra_metadata_uuid"/>
+
+  <!-- Target element to update. The key is based on the concatenation
+  of URL+Protocol+Name -->
+  <xsl:param name="updateKey"/>
+
+
+  <xsl:variable name="mainLang">
+    <xsl:value-of
+            select="(gmd:MD_Metadata|*[@gco:isoType='gmd:MD_Metadata'])/gmd:language/gmd:LanguageCode/@codeListValue"/>
+  </xsl:variable>
+
+  <xsl:template match="gmd:MD_Metadata|*[@gco:isoType='gmd:MD_Metadata']">
     <xsl:copy>
-      <xsl:copy-of select="@*"/>
-      <xsl:copy-of
-        select="gmd:fileIdentifier|
-		    gmd:language|
-		    gmd:characterSet|
-		    gmd:parentIdentifier|
-		    gmd:hierarchyLevel|
-		    gmd:hierarchyLevelName|
-		    gmd:contact|
-		    gmd:dateStamp|
-		    gmd:metadataStandardName|
-		    gmd:metadataStandardVersion|
-		    gmd:dataSetURI|
-		    gmd:locale|
-		    gmd:spatialRepresentationInfo|
-		    gmd:referenceSystemInfo|
-		    gmd:metadataExtensionInfo|
-		    gmd:identificationInfo|
-		    gmd:contentInfo"/>
+      <xsl:apply-templates select="@*"/>
+      <xsl:apply-templates
+              select="gmd:fileIdentifier|
+                gmd:language|
+                gmd:characterSet|
+                gmd:parentIdentifier|
+                gmd:hierarchyLevel|
+                gmd:hierarchyLevelName|
+                gmd:contact|
+                gmd:dateStamp|
+                gmd:metadataStandardName|
+                gmd:metadataStandardVersion|
+                gmd:dataSetURI|
+                gmd:locale|
+                gmd:spatialRepresentationInfo|
+                gmd:referenceSystemInfo|
+                gmd:metadataExtensionInfo|
+                gmd:identificationInfo|
+                gmd:contentInfo"/>
 
       <gmd:distributionInfo>
         <gmd:MD_Distribution>
-          <xsl:copy-of
-            select="gmd:distributionInfo/gmd:MD_Distribution/gmd:distributionFormat"/>
-          <xsl:copy-of
-            select="gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor"/>
+          <xsl:apply-templates
+                  select="gmd:distributionInfo/gmd:MD_Distribution/gmd:distributionFormat"/>
+          <xsl:apply-templates
+                  select="gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor"/>
           <gmd:transferOptions>
             <gmd:MD_DigitalTransferOptions>
-              <xsl:copy-of
-                select="gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:unitsOfDistribution"/>
-              <xsl:copy-of
-                select="gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:transferSize"/>
-              <xsl:copy-of
-                select="gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:onLine"/>
+              <xsl:apply-templates
+                      select="gmd:distributionInfo/gmd:MD_Distribution/
+                          gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:unitsOfDistribution"/>
+              <xsl:apply-templates
+                      select="gmd:distributionInfo/gmd:MD_Distribution/
+                          gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:transferSize"/>
+              <xsl:apply-templates
+                      select="gmd:distributionInfo/gmd:MD_Distribution/
+                          gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:onLine"/>
 
 
-              <!-- Add all online source from the target metadata to the
-              current one -->
-              <xsl:if test="//extra">
-                <xsl:for-each select="//extra//gmd:onLine">
-                  <gmd:onLine>
-                    <xsl:if test="$extra_metadata_uuid">
-                      <xsl:attribute name="uuidref" select="$extra_metadata_uuid"/>
-                    </xsl:if>
-                    <xsl:copy-of select="*"/>
-                  </gmd:onLine>
-                </xsl:for-each>
+              <xsl:if test="$updateKey = ''">
+                <xsl:call-template name="createOnlineSrc"/>
               </xsl:if>
-              <xsl:if test="$url">
 
-                <xsl:variable name="separator" select="'\|'"/>
-
-                <!-- In case the protocol is an OGC protocol
-                the name parameter may contains a list of layers
-                separated by comma.
-                In that case on one online element is added per
-                layer/featureType.
-                -->
-                <xsl:choose>
-                  <xsl:when test="starts-with($protocol, 'OGC:')">
-
-                    <xsl:for-each select="tokenize($name, ',')">
-                      <xsl:variable name="pos" select="position()"/>
-                      <gmd:onLine>
-                        <xsl:if test="$uuidref">
-                          <xsl:attribute name="uuidref" select="$uuidref"/>
-                        </xsl:if>
-                        <gmd:CI_OnlineResource>
-                          <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
-                            <xsl:choose>
-                              <xsl:when test="contains($url, '#')">
-                                <che:PT_FreeURL>
-                                  <xsl:for-each select="tokenize($url, $separator)">
-                                    <xsl:variable name="nameLang" select="substring-before(., '#')"></xsl:variable>
-                                    <xsl:variable name="nameValue" select="substring-after(., '#')"></xsl:variable>
-                                    <che:URLGroup>
-                                      <che:LocalisedURL locale="{concat('#', $nameLang)}">
-                                        <xsl:value-of select="$nameValue"/>
-                                      </che:LocalisedURL>
-                                    </che:URLGroup>
-                                  </xsl:for-each>
-                                </che:PT_FreeURL>
-                              </xsl:when>
-                              <xsl:otherwise>
-                                <gmd:URL>
-                                  <xsl:value-of select="$url"/>
-                                </gmd:URL>
-                              </xsl:otherwise>
-                            </xsl:choose>
-                          </gmd:linkage>
-                          <gmd:protocol>
-                            <gco:CharacterString>
-                              <xsl:value-of select="$protocol"/>
-                            </gco:CharacterString>
-                          </gmd:protocol>
-
-                          <xsl:if test=". != ''">
-                            <gmd:name>
-                              <gco:CharacterString>
-                                <xsl:value-of select="."/>
-                              </gco:CharacterString>
-                            </gmd:name>
-                          </xsl:if>
-
-                          <xsl:if test="tokenize($desc, ',')[position() = $pos] != ''">
-                            <gmd:description>
-                              <gco:CharacterString>
-                                <xsl:value-of select="tokenize($desc, ',')[position() = $pos]"/>
-                              </gco:CharacterString>
-                            </gmd:description>
-                          </xsl:if>
-                        </gmd:CI_OnlineResource>
-                      </gmd:onLine>
-                    </xsl:for-each>
-                  </xsl:when>
-                  <xsl:otherwise>
-                    <!-- ... the name is simply added in the newly
-                    created online element. -->
-
-                    <gmd:onLine>
-                      <xsl:if test="$uuidref">
-                        <xsl:attribute name="uuidref" select="$uuidref"/>
-                      </xsl:if>
-                      <gmd:CI_OnlineResource>
-                        <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
-                          <che:PT_FreeURL>
-                            <xsl:for-each select="tokenize($url, $separator)">
-                              <xsl:variable name="nameLang" select="substring-before(., '#')"></xsl:variable>
-                              <xsl:variable name="nameValue" select="substring-after(., '#')"></xsl:variable>
-                              <che:URLGroup>
-                                <che:LocalisedURL locale="{concat('#', $nameLang)}">
-                                  <xsl:value-of select="$nameValue"/>
-                                </che:LocalisedURL>
-                              </che:URLGroup>
-                            </xsl:for-each>
-                          </che:PT_FreeURL>
-                        </gmd:linkage>
-
-                        <xsl:if test="$protocol != ''">
-                          <gmd:protocol>
-                            <gco:CharacterString>
-                              <xsl:value-of select="$protocol"/>
-                            </gco:CharacterString>
-                          </gmd:protocol>
-                        </xsl:if>
-
-                        <xsl:if test="$name != ''">
-                          <xsl:choose>
-                            <xsl:when test="contains($name, '#')">
-                              <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
-                                <gmd:PT_FreeText>
-                                  <xsl:for-each select="tokenize($name, $separator)">
-                                    <xsl:variable name="nameLang" select="substring-before(., '#')"></xsl:variable>
-                                    <xsl:variable name="nameValue" select="substring-after(., '#')"></xsl:variable>
-                                    <gmd:textGroup>
-                                      <gmd:LocalisedCharacterString locale="{concat('#', $nameLang)}">
-                                        <xsl:value-of select="$nameValue"/>
-                                      </gmd:LocalisedCharacterString>
-                                    </gmd:textGroup>
-                                  </xsl:for-each>
-                                </gmd:PT_FreeText>
-                              </gmd:name>
-                            </xsl:when>
-                            <xsl:otherwise>
-                              <xsl:variable name="mimeType" select="mime:detectMimeTypeFile(/root/env/datadir,$name)"/>
-                              <gmd:name>
-                                <gmx:MimeFileType type="{$mimeType}">
-                                  <xsl:value-of select="$name"/>
-                                </gmx:MimeFileType>
-                              </gmd:name>
-                            </xsl:otherwise>
-                          </xsl:choose>
-                        </xsl:if>
-
-                        <xsl:if test="$desc != ''">
-                          <xsl:choose>
-                            <xsl:when test="contains($desc, '#')">
-                              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
-                                <gmd:PT_FreeText>
-                                  <xsl:for-each select="tokenize($desc, $separator)">
-                                    <xsl:variable name="descLang" select="substring-before(., '#')"></xsl:variable>
-                                    <xsl:variable name="descValue" select="substring-after(., '#')"></xsl:variable>
-                                    <gmd:textGroup>
-                                      <gmd:LocalisedCharacterString locale="{concat('#', $descLang)}">
-                                        <xsl:value-of select="$descValue"/>
-                                      </gmd:LocalisedCharacterString>
-                                    </gmd:textGroup>
-                                  </xsl:for-each>
-                                </gmd:PT_FreeText>
-                              </gmd:description>
-                            </xsl:when>
-                            <xsl:otherwise>
-                              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
-                                <gco:CharacterString>
-                                  <xsl:value-of select="$desc"/>
-                                </gco:CharacterString>
-                              </gmd:description>
-                            </xsl:otherwise>
-                          </xsl:choose>
-                        </xsl:if>
-                        <!-- TODO may be relevant to add the function -->
-                      </gmd:CI_OnlineResource>
-                    </gmd:onLine>
-                  </xsl:otherwise>
-                </xsl:choose>
-
-
-              </xsl:if>
-              <xsl:copy-of
-                select="gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:offLine"
-              />
+              <xsl:apply-templates
+                      select="gmd:distributionInfo/gmd:MD_Distribution/
+                          gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:offLine"/>
             </gmd:MD_DigitalTransferOptions>
           </gmd:transferOptions>
-          <xsl:copy-of
-            select="gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions[position() > 1]"
-          />
-        </gmd:MD_Distribution>
 
+
+          <xsl:apply-templates
+                  select="gmd:distributionInfo/gmd:MD_Distribution/
+                      gmd:transferOptions[position() > 1]"/>
+
+        </gmd:MD_Distribution>
       </gmd:distributionInfo>
 
-      <xsl:copy-of
-        select="gmd:dataQualityInfo|
-			gmd:portrayalCatalogueInfo|
-			gmd:metadataConstraints|
-			gmd:applicationSchemaInfo|
-			gmd:metadataMaintenance|
-			gmd:series|
-			gmd:describes|
-			gmd:propertyType|
-			gmd:featureType|
-			gmd:featureAttribute|
-			legislationInformation"/>
+      <xsl:apply-templates
+              select="gmd:dataQualityInfo|
+                gmd:portrayalCatalogueInfo|
+                gmd:metadataConstraints|
+                gmd:applicationSchemaInfo|
+                gmd:metadataMaintenance|
+                gmd:series|
+                gmd:describes|
+                gmd:propertyType|
+                gmd:featureType|
+                gmd:featureAttribute"/>
+    </xsl:copy>
+  </xsl:template>
 
+
+  <!-- Updating the link matching the update key. -->
+  <xsl:template match="gmd:onLine[
+                        normalize-space($updateKey) = concat(
+                        gmd:CI_OnlineResource/gmd:linkage/gmd:URL,
+                        gmd:CI_OnlineResource/gmd:linkage/che:PT_FreeURL/che:URLGroup/che:LocalisedURL[@locale = '#DE'],
+                        gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString,
+                        gmd:CI_OnlineResource/gmd:name/gco:CharacterString,
+                        gmd:CI_OnlineResource/gmd:name/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE'])
+                       ]">
+    <xsl:call-template name="createOnlineSrc"/>
+  </xsl:template>
+<!-- TMP TO REMOVE when gco:characterString is added in multilingual elements
+  <xsl:template match="gmd:onLine[
+                        normalize-space($updateKey) = concat(
+                        gmd:CI_OnlineResource/gmd:linkage/che:PT_FreeURL/che:URLGroup/che:LocalisedURL[@locale = '#DE'],
+                        gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString,
+                        gmd:CI_OnlineResource/gmd:name/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE')
+                        ]">
+    <xsl:call-template name="createOnlineSrc"/>
+  </xsl:template>
+-->
+
+
+  <xsl:template name="createOnlineSrc">
+    <!-- Add all online source from the target metadata to the
+    current one -->
+    <xsl:if test="//extra">
+      <xsl:for-each select="//extra//gmd:onLine">
+        <gmd:onLine>
+          <xsl:if test="$extra_metadata_uuid">
+            <xsl:attribute name="uuidref" select="$extra_metadata_uuid"/>
+          </xsl:if>
+          <xsl:apply-templates select="*"/>
+        </gmd:onLine>
+      </xsl:for-each>
+    </xsl:if>
+
+    <xsl:variable name="separator" select="'\|'"/>
+    <xsl:variable name="useOnlyPTFreeText">
+      <xsl:value-of
+              select="count(//*[gmd:PT_FreeText and not(gco:CharacterString)]) > 0"/>
+    </xsl:variable>
+
+
+    <xsl:if test="$url">
+      <!-- In case the protocol is an OGC protocol
+      the name parameter may contains a list of layers
+      separated by comma.
+      In that case on one online element is added per
+      layer/featureType.
+      -->
+      <xsl:choose>
+        <xsl:when test="starts-with($protocol, 'OGC:') and $name != ''">
+          <xsl:for-each select="tokenize($name, ',')">
+            <xsl:variable name="pos" select="position()"/>
+            <gmd:onLine>
+              <xsl:if test="$uuidref">
+                <xsl:attribute name="uuidref" select="$uuidref"/>
+              </xsl:if>
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+
+                  <xsl:choose>
+
+                    <!--Multilingual-->
+                    <xsl:when test="contains($url, '#')">
+                      <xsl:for-each select="tokenize($url, $separator)">
+                        <xsl:variable name="urlLang"
+                                      select="substring-before(., '#')"></xsl:variable>
+                        <xsl:variable name="urlValue"
+                                      select="substring-after(., '#')"></xsl:variable>
+                        <xsl:if
+                                test="$useOnlyPTFreeText = 'false' and $urlLang = $mainLang">
+                          <gmd:URL>
+                            <xsl:value-of select="$urlValue"/>
+                          </gmd:URL>
+                        </xsl:if>
+                      </xsl:for-each>
+
+                      <che:PT_FreeURL>
+                        <xsl:for-each select="tokenize($url, $separator)">
+                          <xsl:variable name="urlLang"
+                                        select="substring-before(., '#')"></xsl:variable>
+                          <xsl:variable name="urlValue"
+                                        select="substring-after(., '#')"></xsl:variable>
+
+                          <xsl:if
+                                  test="$useOnlyPTFreeText = 'true' or $urlLang != $mainLang">
+                            <che:URLGroup>
+                              <che:LocalisedURL
+                                      locale="{concat('#', $urlLang)}">
+                                <xsl:value-of select="$urlValue"/>
+                              </che:LocalisedURL>
+                            </che:URLGroup>
+                          </xsl:if>
+
+                        </xsl:for-each>
+                      </che:PT_FreeURL>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <gmd:URL>
+                        <xsl:value-of select="$url"/>
+                      </gmd:URL>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString>
+                    <xsl:value-of select="$protocol"/>
+                  </gco:CharacterString>
+                </gmd:protocol>
+
+                <xsl:if test="$applicationProfile != ''">
+                  <gmd:applicationProfile>
+                    <xsl:choose>
+                      <xsl:when test="contains($applicationProfile, '#')">
+                        <xsl:for-each select="tokenize($applicationProfile, $separator)">
+                          <xsl:variable name="nameLang"
+                                        select="substring-before(., '#')"></xsl:variable>
+                          <xsl:variable name="nameValue"
+                                        select="substring-after(., '#')"></xsl:variable>
+                          <xsl:if
+                                  test="$useOnlyPTFreeText = 'false' and $nameLang = $mainLang">
+                            <gco:CharacterString>
+                              <xsl:value-of select="$nameValue"/>
+                            </gco:CharacterString>
+                          </xsl:if>
+                        </xsl:for-each>
+
+                        <gmd:PT_FreeText>
+                          <xsl:for-each select="tokenize($applicationProfile, $separator)">
+                            <xsl:variable name="nameLang"
+                                          select="substring-before(., '#')"></xsl:variable>
+                            <xsl:variable name="nameValue"
+                                          select="substring-after(., '#')"></xsl:variable>
+
+                            <xsl:if
+                                    test="$useOnlyPTFreeText = 'true' or $nameLang != $mainLang">
+                              <gmd:textGroup>
+                                <gmd:LocalisedCharacterString
+                                        locale="{concat('#', $nameLang)}">
+                                  <xsl:value-of select="$nameValue"/>
+                                </gmd:LocalisedCharacterString>
+                              </gmd:textGroup>
+                            </xsl:if>
+
+                          </xsl:for-each>
+                        </gmd:PT_FreeText>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <gco:CharacterString>
+                          <xsl:value-of select="$applicationProfile"/>
+                        </gco:CharacterString>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  </gmd:applicationProfile>
+                </xsl:if>
+
+                <xsl:if test=". != ''">
+                  <gmd:name>
+                    <gco:CharacterString>
+                      <xsl:value-of select="."/>
+                    </gco:CharacterString>
+                  </gmd:name>
+                </xsl:if>
+
+                <xsl:if test="tokenize($desc, ',')[position() = $pos] != ''">
+                  <gmd:description>
+                    <gco:CharacterString>
+                      <xsl:value-of select="tokenize($desc, ',')[position() = $pos]"/>
+                    </gco:CharacterString>
+                  </gmd:description>
+                </xsl:if>
+
+
+                <xsl:if test="$function != ''">
+                  <gmd:function>
+                    <gmd:CI_OnLineFunctionCode
+                            codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode"
+                            codeListValue="{$function}"/>
+                  </gmd:function>
+                </xsl:if>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+          </xsl:for-each>
+        </xsl:when>
+        <xsl:otherwise>
+          <!-- ... the name is simply added in the newly
+          created online element. -->
+
+          <xsl:message>###############
+          <xsl:value-of select="$name"></xsl:value-of> </xsl:message>
+          <gmd:onLine>
+            <xsl:if test="$uuidref">
+              <xsl:attribute name="uuidref" select="$uuidref"/>
+            </xsl:if>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+
+                <xsl:choose>
+
+                  <!--Multilingual-->
+                  <xsl:when test="contains($url, '#')">
+                    <xsl:for-each select="tokenize($url, $separator)">
+                      <xsl:variable name="urlLang"
+                                    select="substring-before(., '#')"></xsl:variable>
+                      <xsl:variable name="urlValue"
+                                    select="substring-after(., '#')"></xsl:variable>
+                      <xsl:if
+                              test="$useOnlyPTFreeText = 'false' and $urlLang = $mainLang">
+                        <gmd:URL>
+                          <xsl:value-of select="$urlValue"/>
+                        </gmd:URL>
+                      </xsl:if>
+                    </xsl:for-each>
+
+                    <che:PT_FreeURL>
+                      <xsl:for-each select="tokenize($url, $separator)">
+                        <xsl:variable name="urlLang"
+                                      select="substring-before(., '#')"></xsl:variable>
+                        <xsl:variable name="urlValue"
+                                      select="substring-after(., '#')"></xsl:variable>
+
+                        <xsl:if
+                                test="$useOnlyPTFreeText = 'true' or $urlLang != $mainLang">
+                          <che:URLGroup>
+                            <che:LocalisedURL
+                                    locale="{concat('#', $urlLang)}">
+                              <xsl:value-of select="$urlValue"/>
+                            </che:LocalisedURL>
+                          </che:URLGroup>
+                        </xsl:if>
+
+                      </xsl:for-each>
+                    </che:PT_FreeURL>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <gmd:URL>
+                      <xsl:value-of select="$url"/>
+                    </gmd:URL>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </gmd:linkage>
+
+              <xsl:if test="$protocol != ''">
+                <gmd:protocol>
+                  <gco:CharacterString>
+                    <xsl:value-of select="$protocol"/>
+                  </gco:CharacterString>
+                </gmd:protocol>
+              </xsl:if>
+
+              <xsl:if test="$applicationProfile != ''">
+                <gmd:applicationProfile>
+                  <xsl:choose>
+                    <xsl:when test="contains($applicationProfile, '#')">
+                      <xsl:for-each select="tokenize($applicationProfile, $separator)">
+                        <xsl:variable name="nameLang"
+                                      select="substring-before(., '#')"></xsl:variable>
+                        <xsl:variable name="nameValue"
+                                      select="substring-after(., '#')"></xsl:variable>
+                        <xsl:if
+                                test="$useOnlyPTFreeText = 'false' and $nameLang = $mainLang">
+                          <gco:CharacterString>
+                            <xsl:value-of select="$nameValue"/>
+                          </gco:CharacterString>
+                        </xsl:if>
+                      </xsl:for-each>
+
+                      <gmd:PT_FreeText>
+                        <xsl:for-each select="tokenize($applicationProfile, $separator)">
+                          <xsl:variable name="nameLang"
+                                        select="substring-before(., '#')"></xsl:variable>
+                          <xsl:variable name="nameValue"
+                                        select="substring-after(., '#')"></xsl:variable>
+
+                          <xsl:if
+                                  test="$useOnlyPTFreeText = 'true' or $nameLang != $mainLang">
+                            <gmd:textGroup>
+                              <gmd:LocalisedCharacterString
+                                      locale="{concat('#', $nameLang)}">
+                                <xsl:value-of select="$nameValue"/>
+                              </gmd:LocalisedCharacterString>
+                            </gmd:textGroup>
+                          </xsl:if>
+
+                        </xsl:for-each>
+                      </gmd:PT_FreeText>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <gco:CharacterString>
+                        <xsl:value-of select="$applicationProfile"/>
+                      </gco:CharacterString>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </gmd:applicationProfile>
+              </xsl:if>
+
+              <xsl:if test="$name != ''">
+                <gmd:name>
+                  <xsl:choose>
+
+                    <!--Multilingual-->
+                    <xsl:when test="contains($name, '#')">
+                      <xsl:for-each select="tokenize($name, $separator)">
+                        <xsl:variable name="nameLang"
+                                      select="substring-before(., '#')"></xsl:variable>
+                        <xsl:variable name="nameValue"
+                                      select="substring-after(., '#')"></xsl:variable>
+                        <xsl:if
+                                test="$useOnlyPTFreeText = 'false' and $nameLang = $mainLang">
+                          <gco:CharacterString>
+                            <xsl:value-of select="$nameValue"/>
+                          </gco:CharacterString>
+                        </xsl:if>
+                      </xsl:for-each>
+
+                      <gmd:PT_FreeText>
+                        <xsl:for-each select="tokenize($name, $separator)">
+                          <xsl:variable name="nameLang"
+                                        select="substring-before(., '#')"></xsl:variable>
+                          <xsl:variable name="nameValue"
+                                        select="substring-after(., '#')"></xsl:variable>
+
+                          <xsl:if
+                                  test="$useOnlyPTFreeText = 'true' or $nameLang != $mainLang">
+                            <gmd:textGroup>
+                              <gmd:LocalisedCharacterString
+                                      locale="{concat('#', $nameLang)}">
+                                <xsl:value-of select="$nameValue"/>
+                              </gmd:LocalisedCharacterString>
+                            </gmd:textGroup>
+                          </xsl:if>
+
+                        </xsl:for-each>
+                      </gmd:PT_FreeText>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <gco:CharacterString>
+                        <xsl:value-of select="$name"/>
+                      </gco:CharacterString>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </gmd:name>
+              </xsl:if>
+
+              <xsl:if test="$desc != ''">
+                <gmd:description>
+                  <xsl:choose>
+                    <xsl:when test="contains($desc, '#')">
+                      <xsl:for-each select="tokenize($desc, $separator)">
+                        <xsl:variable name="descLang"
+                                      select="substring-before(., '#')"></xsl:variable>
+                        <xsl:variable name="descValue"
+                                      select="substring-after(., '#')"></xsl:variable>
+                        <xsl:if
+                                test="$useOnlyPTFreeText = 'false' and $descLang = $mainLang">
+                          <gco:CharacterString>
+                            <xsl:value-of select="$descValue"/>
+                          </gco:CharacterString>
+                        </xsl:if>
+                      </xsl:for-each>
+
+                      <gmd:PT_FreeText>
+                        <xsl:for-each select="tokenize($desc, $separator)">
+                          <xsl:variable name="descLang"
+                                        select="substring-before(., '#')"></xsl:variable>
+                          <xsl:variable name="descValue"
+                                        select="substring-after(., '#')"></xsl:variable>
+                          <xsl:if
+                                  test="$useOnlyPTFreeText = 'true' or $descLang != $mainLang">
+                            <gmd:textGroup>
+                              <gmd:LocalisedCharacterString
+                                      locale="{concat('#', $descLang)}">
+                                <xsl:value-of select="$descValue"/>
+                              </gmd:LocalisedCharacterString>
+                            </gmd:textGroup>
+                          </xsl:if>
+                        </xsl:for-each>
+                      </gmd:PT_FreeText>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <gco:CharacterString>
+                        <xsl:value-of select="$desc"/>
+                      </gco:CharacterString>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </gmd:description>
+              </xsl:if>
+
+              <xsl:if test="$function != ''">
+                <gmd:function>
+                  <gmd:CI_OnLineFunctionCode
+                          codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode"
+                          codeListValue="{$function}"/>
+                </gmd:function>
+              </xsl:if>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="extra" priority="2"/>
+
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
     </xsl:copy>
   </xsl:template>
 </xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/extract-relations.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-relations.xsl
@@ -59,14 +59,17 @@
   <!-- Convert an element gco:CharacterString
   to the GN localized string structure -->
   <xsl:template mode="get-iso19139-localized-string" match="*">
+
+    <xsl:variable name="mainLanguage"
+                  select="string(ancestor::metadata/*[@gco:isoType='gmd:MD_Metadata' or name()='gmd:MD_Metadata']/gmd:language/gco:CharacterString)"/>
+
     <xsl:for-each select="gco:CharacterString|
                           gmd:PT_FreeText/*/gmd:LocalisedCharacterString">
       <xsl:variable name="localeId"
                     select="substring-after(@locale, '#')"/>
-      <xsl:variable name="mainLanguage"
-                    select="ancestor::gmd:MD_Metadata/gmd:language/*/@codeListValue"/>
+
       <value lang="{if (@locale)
-                  then ancestor::gmd:MD_Metadata/gmd:locale/*[@id = $localeId]/gmd:languageCode/*/@codeListValue
+                  then ancestor::metadata/*[@gco:isoType='gmd:MD_Metadata' or name()='gmd:MD_Metadata']/gmd:locale/*[@id = $localeId]/gmd:languageCode/*/@codeListValue
                   else if ($mainLanguage) then $mainLanguage else $lang}">
         <xsl:value-of select="."/>
       </value>

--- a/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-add.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-add.xsl
@@ -29,7 +29,7 @@ Insert is made in first transferOptions found.
 <xsl:stylesheet xmlns:gmd="http://www.isotc211.org/2005/gmd"
                 xmlns:gco="http://www.isotc211.org/2005/gco"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="2.0" xmlns:che="http://www.geocat.ch/2008/che">
 
   <!-- Main properties for the link.
   Name and description may be multilingual eg. ENG#English name|FRE#Le français
@@ -137,8 +137,10 @@ Insert is made in first transferOptions found.
   <xsl:template match="gmd:onLine[
                         normalize-space($updateKey) = concat(
                         gmd:CI_OnlineResource/gmd:linkage/gmd:URL,
+                        gmd:CI_OnlineResource/gmd:linkage/che:PT_FreeURL/che:URLGroup/che:LocalisedURL[@locale = '#DE'],
                         gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString,
-                        gmd:CI_OnlineResource/gmd:name/gco:CharacterString)
+                        gmd:CI_OnlineResource/gmd:name/gco:CharacterString,
+                        gmd:CI_OnlineResource/gmd:name/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE'])
                         ]">
     <xsl:call-template name="createOnlineSrc"/>
   </xsl:template>

--- a/services/src/main/java/org/fao/geonet/api/records/model/related/ObjectFactory.java
+++ b/services/src/main/java/org/fao/geonet/api/records/model/related/ObjectFactory.java
@@ -69,10 +69,17 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link org.fao.geonet.api.records.model.related.RelatedItem.Title }
+     * Create an instance of {@link RelatedItem.MultilingualValue }
      */
-    public org.fao.geonet.api.records.model.related.RelatedItem.Title createRelatedItemTitle() {
-        return new org.fao.geonet.api.records.model.related.RelatedItem.Title();
+    public RelatedItem.MultilingualValue createRelatedItemTitle() {
+        return new RelatedItem.MultilingualValue();
+    }
+
+    /**
+     * Create an instance of {@link RelatedItem.MultilingualValue }
+     */
+    public RelatedItem.MultilingualValue createRelatedItemUrl() {
+        return new RelatedItem.MultilingualValue();
     }
 
     /**

--- a/services/src/main/java/org/fao/geonet/api/records/model/related/RelatedItem.java
+++ b/services/src/main/java/org/fao/geonet/api/records/model/related/RelatedItem.java
@@ -57,11 +57,11 @@ import javax.xml.bind.annotation.XmlType;
 public abstract class RelatedItem {
 
     protected String id;
-    protected String url;
+    protected MultilingualValue url;
     protected String type;
 
     @XmlElement(required = true)
-    protected RelatedItem.Title title;
+    protected MultilingualValue title;
 
     /**
      * Gets the value of the id property.
@@ -84,18 +84,18 @@ public abstract class RelatedItem {
     /**
      * Gets the value of the url property.
      *
-     * @return possible object is {@link String }
+     * @return possible object is {@link MultilingualValue }
      */
-    public String getUrl() {
+    public MultilingualValue getUrl() {
         return url;
     }
 
     /**
      * Sets the value of the url property.
      *
-     * @param value allowed object is {@link String }
+     * @param value allowed object is {@link MultilingualValue }
      */
-    public void setUrl(String value) {
+    public void setUrl(MultilingualValue value) {
         this.url = value;
     }
 
@@ -120,18 +120,18 @@ public abstract class RelatedItem {
     /**
      * Gets the value of the title property.
      *
-     * @return possible object is {@link RelatedItem.Title }
+     * @return possible object is {@link MultilingualValue }
      */
-    public RelatedItem.Title getTitle() {
+    public MultilingualValue getTitle() {
         return title;
     }
 
     /**
      * Sets the value of the title property.
      *
-     * @param value allowed object is {@link RelatedItem.Title }
+     * @param value allowed object is {@link MultilingualValue }
      */
-    public void setTitle(RelatedItem.Title value) {
+    public void setTitle(MultilingualValue value) {
         this.title = value;
     }
 
@@ -159,7 +159,7 @@ public abstract class RelatedItem {
         "value"
     })
     @JsonSerialize(using = LocalizedStringSerializer.class)
-    public static class Title implements ILocalizedStringProperty {
+    public static class MultilingualValue implements ILocalizedStringProperty {
         protected List<LocalizedString> value;
 
         /**

--- a/services/src/main/java/org/fao/geonet/api/records/model/related/relatedResponse.xsd
+++ b/services/src/main/java/org/fao/geonet/api/records/model/related/relatedResponse.xsd
@@ -147,7 +147,14 @@
   <xs:complexType name="relatedItem" abstract="true">
     <xs:sequence>
       <xs:element name="id" type="xs:string" minOccurs="0"/>
-      <xs:element name="url" type="xs:string" minOccurs="0"/>
+      <xs:element name="url">
+        <xs:complexType>
+          <xs:sequence>
+            <!--<xs:any processContents="skip" maxOccurs="unbounded" minOccurs="0" />-->
+            <xs:element name="value" type="localizedString" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
       <xs:element name="title">
         <xs:complexType>
           <xs:sequence>

--- a/web-ui/src/main/resources/catalog/components/edit/multilingualfield/MultilingualFieldDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/multilingualfield/MultilingualFieldDirective.js
@@ -48,7 +48,8 @@
             'multilingualfield/partials/multilingualfield.html',
         scope: {
           mainLanguage: '@',
-          expanded: '@'
+          expanded: '@',
+          currentLanguage: '=?'
         },
         link: function(scope, element, attrs) {
           // Only inputs and textarea could be multilingual fields

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -96,6 +96,20 @@
               var loadRelations = function() {
                 gnOnlinesrc.getAllResources()
                     .then(function(data) {
+
+                      // If multilingual, get current lang url to
+                      // diplay the resource in the list (img, link)
+                      // lUrl means localize Url
+                      angular.forEach(data.onlines, function(src) {
+                        src.lUrl = src.url[scope.lang] ||
+                          src.url[gnCurrentEdit.mdLanguage] ||
+                          src.url[Object.keys(src.url)[0]];
+                      });
+                      angular.forEach(data.thumbnails, function(img) {
+                        img.lUrl = img.url[scope.lang] ||
+                          img.url[gnCurrentEdit.mdLanguage] ||
+                          img.url[Object.keys(img.url)[0]];
+                      });
                       scope.relations = data;
                     });
               };
@@ -188,6 +202,8 @@
                 };
                 scope.modelOptions =
                     angular.copy(gnGlobalSettings.modelOptions);
+
+                scope.ctrl = {};
               },
               post: function(scope, element, attrs) {
                 scope.popupid = attrs['gnPopupid'];
@@ -266,7 +282,8 @@
                         'url': {param: 'thumbnail_url'},
                         'name': {param: 'thumbnail_desc'}
                       }
-                    }]
+                    }],
+                    multilingualFields: ['name', 'desc']
                   },
                   'iso19115-3': {
                     display: 'select',
@@ -906,62 +923,68 @@
 
                     // Create a key which will be sent to XSL processing
                     // for finding which element to edit.
-                    var keysuffix = $filter('gnLocalized')(linkToEdit.title);
+                    var keyName = $filter('gnLocalized')(linkToEdit.title);
+                    var keyUrl = $filter('gnLocalized')(linkToEdit.url);
                     if (scope.isMdMultilingual) {
                       // Key in multilingual mode is
                       // the title in the main language
-                      keysuffix =
-                          linkToEdit.title[Object.keys(scope.mdLangs)[0]];
-                      if (angular.isUndefined(keysuffix)) {
+                      keyName = linkToEdit.title[scope.mdLang];
+                      keyUrl = linkToEdit.url[scope.mdLang];
+                      if (!keyName || ! keyUrl) {
                         console.warn(
                             'Failed to compute key for updating the resource.');
                       }
                     }
-                    scope.editingKey = [linkToEdit.url,
-                                        linkToEdit.protocol,
-                                        keysuffix].join('');
+                    scope.editingKey = [keyUrl, linkToEdit.protocol,
+                      keyName].join('');
 
                     scope.OGCProtocol = checkIsOgc(linkToEdit.protocol);
-
-                    var name = $filter('gnLocalized')(linkToEdit.title),
-                        desc = $filter('gnLocalized')(linkToEdit.description);
 
                     // For multilingual record, build
                     // name and desc based on loc IDs
                     // and no iso3letter code.
                     // If OGC, only take into account, the first element
-                    if (scope.isMdMultilingual && scope.OGCProtocol == null) {
-                      name = {};
-                      desc = {};
-                      $.each(scope.mdLangs, function(key, v) {
-                        name[v] =
-                            (linkToEdit.title && linkToEdit.title[key]) || '';
-                      });
-                      $.each(scope.mdLangs, function(key, v) {
-                        desc[v] =
-                            (linkToEdit.description &&
-                             linkToEdit.description[key]) || '';
-                      });
-                    }
+                    var fields = {
+                      name: 'title',
+                      desc: 'description',
+                      url: 'url'
+                    };
+
+                    angular.forEach(fields, function(value, field){
+                      if(scope.isFieldMultilingual(field)) {
+                        var e = {};
+                        $.each(scope.mdLangs, function(key, v) {
+                          e[v] =
+                            (linkToEdit[fields[field]] &&
+                            linkToEdit[fields[field]][key]) || '';
+                        });
+                        fields[field] = e;
+                      }
+                      else {
+                        fields[field] = $filter('gnLocalized')
+                        (linkToEdit[fields[field]]);
+                      }
+                    });
 
                     scope.params = {
                       linkType: getTypeConfig(linkToEdit),
-                      url: linkToEdit.url,
+                      url: fields.url,
                       protocol: linkToEdit.protocol,
-                      name: name,
-                      desc: desc,
+                      name: fields.name,
+                      desc: fields.desc,
                       applicationProfile: linkToEdit.applicationProfile,
                       function: linkToEdit.function,
                       selectedLayers: []
-                      };
-                      } else{
-                      scope.editingKey= null;
-                      scope.params.linkType= scope.config.types[0];
-                      scope.params.protocol= null;
-                      setParameterValue(scope.params.name, '');
-                      setParameterValue(scope.params.desc, '');
-                    }
-                  });
+                    };
+                  } else {
+                    scope.editingKey= null;
+                    scope.params.linkType= scope.config.types[0];
+                    scope.params.protocol= null;
+                    scope.params.name = '';
+                    scope.params.desc = '';
+                    initMultilingualFields();
+                  };
+                });
 
                 // mode can be 'url' or 'thumbnailMaker' to init thumbnail panel
                 scope.mode = 'url';
@@ -992,13 +1015,20 @@
                   scope.layers = [];
                   scope.OGCProtocol = false;
                   if (scope.params && !scope.isEditing) {
-                    scope.params.name = scope.isMdMultilingual ? {} : '';
-                    scope.params.desc = scope.isMdMultilingual ? {} : '';
+                    scope.params.name = '';
+                    scope.params.desc = '';
+                    initMultilingualFields();
                     scope.params.selectedLayers = [];
                     scope.params.layers = [];
                   }
                 };
 
+                var initMultilingualFields = function() {
+                  scope.config.multilingualFields.forEach(function(f) {
+                    scope.params[f] = {};
+                    scope.params[f] = setParameterValue(scope.params[f], '');
+                  });
+                };
 
                 function buildObjectParameter(param) {
                   if (angular.isObject(param)) {
@@ -1019,6 +1049,7 @@
                   } else {
                     param = value;
                   }
+                  return param;
                 }
 
                 /**
@@ -1028,9 +1059,10 @@
                  *  If it is an URL, we just call a $http.get
                  */
                 scope.addOnlinesrc = function() {
-                  scope.params.name = buildObjectParameter(scope.params.name);
-                  scope.params.desc = buildObjectParameter(scope.params.desc);
+                  scope.config.multilingualFields.forEach(function(f) {
+                    scope.params[f] = buildObjectParameter(scope.params[f]);
 
+                  });
 
                   var processParams = {};
                   angular.forEach(scope.params.linkType.fields,
@@ -1070,15 +1102,20 @@
                  * passed to the layers grid directive.
                  */
                 scope.loadCurrentLink = function(reportError) {
-                  if (angular.isUndefined(scope.params.url) ||
-                      scope.params.url == '') {
+
+                  // If multilingual or not
+                  var url = scope.params.url;
+                  if(angular.isObject(url)) {
+                    url = url[scope.ctrl.urlCurLang];
+                  }
+
+                  if (!url) {
                     return;
                   }
                   if (scope.OGCProtocol) {
                     scope.layers = [];
                     if (scope.OGCProtocol == 'WMS') {
-                      return gnOwsCapabilities.getWMSCapabilities(
-                          scope.params.url)
+                      return gnOwsCapabilities.getWMSCapabilities(url)
                           .then(function(capabilities) {
                             scope.layers = [];
                             scope.isUrlOk = true;
@@ -1091,8 +1128,7 @@
                             scope.isUrlOk = error === 200;
                           });
                     } else if (scope.OGCProtocol == 'WFS') {
-                      return gnWfsService.getCapabilities(
-                          scope.params.url)
+                      return gnWfsService.getCapabilities(url)
                           .then(function(capabilities) {
                             scope.layers = [];
                             scope.isUrlOk = true;
@@ -1111,18 +1147,14 @@
                             scope.isUrlOk = error === 200;
                           });
                     }
-                  } else if (scope.params.url.indexOf('http') === 0) {
-                    var useProxy =
-                        scope.params.url.indexOf(location.hostname) === -1;
-                    var url = useProxy ?
-                        gnGlobalSettings.proxyUrl +
-                        encodeURIComponent(scope.params.url) : scope.params.url;
-                    return $http.get(url).then(function(response) {
+                  } else if (url.indexOf('http') === 0) {
+                    return $http.get(url, {
+                      gnNoProxy: false
+                    }).then(function(response) {
                       scope.isUrlOk = response.status === 200;
                     },
                     function(response) {
-                      // Proxy may return 500 when document is not proxyable
-                      scope.isUrlOk = response.status === 200;
+                      scope.isUrlOk = response.status === 500;
                     });
                   } else {
                     scope.isUrlOk = true;
@@ -1130,7 +1162,8 @@
                 };
 
                 function checkIsOgc(protocol) {
-                  if (protocol && protocol.indexOf('OGC:WMS') >= 0) {
+
+                  if(/OGC:WMS-[0-9].[0-9].[0-9]-http-get-map/.exec(protocol)) {
                     return 'WMS';
                   }
                   else if (protocol && protocol.indexOf('OGC:WFS') >= 0) {
@@ -1164,13 +1197,20 @@
                  * On URL change, reload WMS capabilities
                  * if the protocol is WMS
                  */
-                scope.$watch('params.url', function() {
-                  if (!angular.isUndefined(scope.params.url)) {
+                var updateImageTag = function() {
+                  scope.isImage = false;
+                  var urls = scope.params.url;
+                  var curUrl = angular.isObject(urls) ?
+                    urls[scope.ctrl.urlCurLang] : urls;
+
+                  if(curUrl) {
                     scope.loadCurrentLink();
-                    scope.isImage =
-                        scope.params.url.match(/.*.(png|jpg|gif)$/i);
+                    scope.isImage = curUrl.match(/.*.(png|jpg|gif)$/i);
                   }
-                });
+
+                };
+                scope.$watch('params.url', updateImageTag, true);
+                scope.$watch('ctrl.urlCurLang', updateImageTag, true);
 
                 /**
                  * Concat layer names and title in params names
@@ -1190,10 +1230,18 @@
                           names.push(layer.Name || layer.name);
                           descs.push(layer.Title || layer.title);
                         });
-                    angular.extend(scope.params, {
-                      name: names.join(','),
-                      desc: descs.join(',')
-                    });
+
+                    if(scope.isMdMultilingual) {
+                      var langCode = scope.mdLangs[scope.mdLang];
+                      scope.params.name[langCode] = names.join(',');
+                      scope.params.desc[langCode] = descs.join(',');
+                    }
+                    else {
+                      angular.extend(scope.params, {
+                        name: names.join(','),
+                        desc: descs.join(',')
+                      });
+                    }
                   }
                 });
 
@@ -1262,6 +1310,11 @@
                         }
                       }
                     });
+
+                scope.isFieldMultilingual = function(field) {
+                  return scope.isMdMultilingual &&
+                    scope.config.multilingualFields.indexOf(field) >= 0
+                }
               }
             }
           };

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1029,10 +1029,19 @@
                 var initMultilingualFields = function() {
                   scope.config.multilingualFields.forEach(function(f) {
                     scope.params[f] = {};
-                    scope.params[f] = setParameterValue(scope.params[f], '');
+                    setParameterValue(f, '');
                   });
                 };
 
+
+                /**
+                 * Build the multingual structure if need for the onlinesrc
+                 * param (name, desc, url).
+                 * Struct like {'ger':'', 'eng': ''}
+                 *
+                 * @param param
+                 * @returns {*}
+                 */
                 function buildObjectParameter(param) {
                   if (angular.isObject(param)) {
                     var name = [];
@@ -1044,15 +1053,22 @@
                   return param;
                 }
 
-                function setParameterValue(param, value) {
-                  if (scope.isMdMultilingual) {
+                /**
+                 * Set a vlue to a onlinesrc parameter (url, desc, name).
+                 * Value as string if monolingual, else set to each lang.
+                 *
+                 * @param {String} pName name of attribute in `scope.params`
+                 * @param {string} value of the attribute
+                 */
+                function setParameterValue(pName, value) {
+                  var p = scope.params;
+                  if (scope.isFieldMultilingual(pName)) {
                     $.each(scope.mdLangs, function(key, v) {
-                      param[v] = value;
+                      p[pName][v] = value;
                     });
                   } else {
-                    param = value;
+                    p[pName] = value;
                   }
-                  return param;
                 }
 
                 /**
@@ -1284,15 +1300,27 @@
                 });
 
                 scope.resource = null;
-                scope.$watch('resource', function() {
-                  if (scope.resource && scope.resource.url) {
-                    scope.params.url = '';
-                    setParameterValue(scope.params.name, '');
-                    $timeout(function() {
-                      scope.params.url = scope.resource.url;
-                      setParameterValue(scope.params.name,
-                          scope.resource.id.split('/').splice(2).join('/'));
-                    }, 100);
+
+                /**
+                 * Update url and name from uploaded resource.
+                 * Triggered on file store selection change.
+                 */
+                scope.$watch('resource', function(rsrc) {
+
+                  if (rsrc && rsrc.url) {
+                    var o = {
+                      name: rsrc.id.split('/').splice(2).join('/'),
+                      url: rsrc.url
+                    };
+                    ['url', 'name'].forEach(function(pName) {
+                      var value = o[pName];
+                      if(scope.isFieldMultilingual(pName)) {
+                        scope.params[pName][scope.ctrl.urlCurLang] = value;
+                      }
+                      else {
+                        scope.params[pName] = value;
+                      }
+                    });
                   }
                 });
 

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -881,6 +881,9 @@
                       scope.schema.indexOf('iso19139') === 0) {
                     scope.config = schemaConfig['iso19139'];
                   }
+                  // Specific geocat
+                  scope.config.multilingualFields.push('url');
+                  // End Specific geocat
 
                   if (gnCurrentEdit.mdOtherLanguages) {
 

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -514,7 +514,7 @@
           return runProcess(this,
               setParams('onlinesrc-remove', {
                 id: gnCurrentEdit.id,
-                url: onlinesrc.url,
+                url: onlinesrc.lUrl || onlinesrc.url,
                 name: $filter('gnLocalized')(onlinesrc.title)
               }));
         },

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -72,11 +72,25 @@
 
           <!-- URL text field -->
           <div class="form-group gn-required"
-               data-ng-class="gnAddLink.url.$valid ? '' : 'has-error'">
+               data-ng-class="{'has-error' : !isFieldMultilingual('url') ? !gnAddLink.url.$valid : false}">
             <label for="onlinesrcUrl"
                    class="col-sm-2 control-label"
                    data-translate="">url</label>
-            <div class="col-sm-10">
+
+            <div class="col-sm-10"
+                 data-ng-if="isFieldMultilingual('url')"
+                 gn-multilingual-field="{{mdOtherLanguages}}"
+                 current-language="ctrl.urlCurLang"
+                 data-main-language="{{mdLang}}"
+                 expanded="false">
+              <input data-ng-repeat="(key, val) in mdLangs"
+                     class="form-control input-sm"
+                     lang="{{val}}"
+                     ng-model-options="{debounce: 500}"
+                     data-ng-model="params.url[val]">
+            </div>
+
+            <div class="col-sm-10" data-ng-if="!isFieldMultilingual('url')">
               <div data-ng-class="{'input-group': OGCProtocol != null}">
                 <input data-ng-model="params.url"
                        data-ng-model-options="{debounce: 500}"
@@ -104,11 +118,11 @@
 
 
           <div class="form-group"
-               data-ng-show="isImage">
+               data-ng-if="isImage">
             <label class="col-sm-2 control-label"
                    data-translate="">overview</label>
             <div class="col-sm-10">
-              <img ng-src="{{params.url}}"
+              <img ng-src="{{isFieldMultilingual('url') ? params.url[ctrl.urlCurLang] : params.url}}"
                    class="img-thumbnail">
             </div>
           </div>
@@ -125,12 +139,12 @@
           <!-- Name text Field -->
           <div class="form-group"
                data-ng-show="params.linkType.fields.name &&
-                             !params.linkType.fields.name.hidden">
+                             !params.linkType.fields.name.hidden && !(OGCProtocol && !isEditing)">
             <label for="onlinesrcName"
                    class="col-sm-2 control-label"
                    data-translate="">onlineResourceName</label>
             <div class="col-sm-10"
-                 data-ng-if="!isMdMultilingual || (isMdMultilingual && OGCProtocol != null)">
+                 data-ng-if="!isFieldMultilingual('name')">
               <input ng-model="params.name"
                      name="name"
                      type="text"
@@ -138,7 +152,7 @@
                      placeholder="Name">
             </div>
             <div class="col-sm-10"
-                 data-ng-if="isMdMultilingual && OGCProtocol == null"
+                 data-ng-if="isFieldMultilingual('name')"
                  data-gn-multilingual-field="{{mdOtherLanguages}}"
                  data-main-language="{{mdLang}}"
                  expanded="false">
@@ -152,12 +166,12 @@
           <!-- Description Text area -->
           <div class="form-group"
                data-ng-show="params.linkType.fields.desc &&
-                             !params.linkType.fields.desc.hidden">
+                             !params.linkType.fields.desc.hidden && !(OGCProtocol && !isEditing)">
             <label for="onlinesrcDescr"
                    class="col-sm-2 control-label"
                    data-translate="">Description</label>
             <div class="col-sm-10"
-                 data-ng-if="!isMdMultilingual || (isMdMultilingual && OGCProtocol != null)">
+                 data-ng-if="!isFieldMultilingual('desc')">
               <textarea rows="3"
                         data-gn-autogrow=""
                         data-ng-model="params.desc"
@@ -167,7 +181,7 @@
                         name="description"/>
             </div>
             <div class="col-sm-10"
-                 data-ng-if="isMdMultilingual && OGCProtocol == null"
+                 data-ng-if="isFieldMultilingual('desc')"
                  gn-multilingual-field="{{mdOtherLanguages}}"
                  data-main-language="{{mdLang}}"
                  expanded="false">
@@ -323,9 +337,9 @@
       <span data-translate="">areYouSureToAddALinkWithError</span>
       <a class="btn btn-link"
          target="_blank"
-         data-ng-href="{{params.url}}"
+         data-ng-href="params.url[ctrl.urlCurLang]"
          data-ng-show="gnAddLink.$valid && !isUrlOk">
-        {{params.url}}
+        {{params.url[ctrl.urlCurLang]}}
       </a>
     </div>
   </div>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
@@ -88,7 +88,7 @@
           <img class="thumb-small"
                title="{{thumb.title | gnLocalized: lang}}"
                data-gn-img-modal="thumb"
-               data-ng-src="{{thumb.id}}"/>
+               data-ng-src="{{thumb.lUrl || thumb.id}}"/>
 
           <a href="" class="onlinesrc-remove"
              data-ng-if="gnCurrentEdit.schemaConfig.related.readonly !== true"
@@ -118,19 +118,20 @@
         <li class="list-group-item" href=""
             data-ng-repeat="resource in relations.onlines | orderBy:sortLinks">
           <div class="row">
+            <!--Specific geocat: use lUrl instead of url-->
             <div class="col-md-11"
                  title="{{resource.description | gnLocalized: lang}}">
-              <a data-ng-href="{{resource.url}}"
-                 data-ng-if="resource.url.match('^http|ftp') !== null"
+              <a data-ng-href="{{resource.lUrl}}"
+                 data-ng-if="resource.lUrl.match('^http|ftp') !== null"
                  target="_blank">
                 <i class="fa fa-fw"
                    data-ng-class="onlinesrcService.getIconByProtocol(resource)"/>
-                {{(resource.title | gnLocalized: lang) || resource.url}}
+                {{(resource.title | gnLocalized: lang) || resource.lUrl}}
               </a>
-              <span data-ng-if="resource.url.match('^http|ftp') === null">
+              <span data-ng-if="resource.lUrl.match('^http|ftp') === null">
                 <i class="fa fa-fw"
                    data-ng-class="onlinesrcService.getIconByProtocol(resource)"/>
-                {{(resource.title | gnLocalized: lang) || resource.url}}
+                {{(resource.title | gnLocalized: lang) || resource.lUrl}}
               </span>
             </div>
             <div class="col-md-1">


### PR DESCRIPTION
Fix oneline resources in multilingual mode.
Add support of localized url in the UI.

- url can be multilingual or only one input
- OCGProtocol set to WMS if contains get-map
- add config in schema to tell if a field is multilingual or not
- hide name and description if adding multiple WMS
- manage url checker for both cases
- manage image display for both cases
- display proper url or name in onlinesrc list