### PR TITLE
C2c ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,12 +6,11 @@
 dockerBuild {
   stage('Docker pull the maven image') {
     sh 'docker pull maven:3-jdk-8'
-      sh 'docker pull pmauduit/google-drive-publisher'
   }
   withDockerContainer(image: 'maven:3-jdk-8') {
     stage('Getting the sources') {
-      git url: 'https://github.com/geoadmin/geocat.git', branch: "geocat_3.4.x"
-        sh 'git submodule update --init --recursive'
+      git url: 'https://github.com/geoadmin/geocat.git', branch: env.BRANCH_NAME
+      sh 'git submodule update --init --recursive'
     }
     stage('First build without test') {
       sh '''mvn clean install -B -Dmaven.repo.local=./.m2_repo -DskipTests'''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,9 @@
 
 @Library('c2c-pipeline-library') import static com.camptocamp.utils.*
 
+selectNodes {
+    (it.memorysize_mb as Float) > 12000
+}
 
 dockerBuild {
   stage('Docker pull the maven image') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ dockerBuild {
       sh "mvn clean install ${mavenOpts} -fn"
     }
     stage('calculating coverage') {
-      sh "mvn cobertura:cobertura ${mavenOpts} -fn"
+      sh "mvn cobertura:cobertura ${mavenOpts} -fn -Dcobertura.report.format=xml"
       step([$class: 'CoberturaPublisher',
             autoUpdateHealth: false,
             autoUpdateStability: false,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,10 +16,10 @@ dockerBuild {
       sh 'git submodule update --init --recursive'
     }
     stage('First build without test') {
-      sh '''mvn clean install -B -Dmaven.repo.local=./.m2_repo -DskipTests'''
+      sh '''mvn clean install -B -Dmaven.repo.local=./.m2_repo -Ddb.username=geonetwork -Ddb.name=geonetwork -Ddb.type=postgres -Ddb.host=database -Ddb.password=geonetwork -DskipTests'''
     }
     stage('Second build with tests') {
-      sh '''mvn clean install -B -Dmaven.repo.local=./.m2_repo -fn'''
+      sh '''mvn clean install -B -Dmaven.repo.local=./.m2_repo -Ddb.username=geonetwork -Ddb.name=geonetwork -Ddb.type=postgres -Ddb.host=database -Ddb.password=geonetwork -fn'''
     }
     stage('Saving tests results') {
       junit '**/target/surefire-reports/TEST-*.xml'
@@ -49,7 +49,7 @@ dockerBuild {
     stage('Build/publish a docker image') {
       // one-liner to setup docker
       sh 'curl -fsSLO https://get.docker.com/builds/Linux/x86_64/docker-17.05.0-ce.tgz && tar --strip-components=1 -xvzf docker-17.05.0-ce.tgz -C /usr/local/bin'
-      sh '''mvn -s /settings.xml -B -Dmaven.repo.local=./.m2_repo -pl web -Pdocker docker:build docker:push'''
+      sh '''mvn -s /settings.xml -B -Dmaven.repo.local=./.m2_repo  -Ddb.username=geonetwork -Ddb.name=geonetwork -Ddb.type=postgres -Ddb.host=database -Ddb.password=geonetwork -pl web -Pdocker docker:build docker:push'''
     }
   } // withDockerContainer
 
@@ -95,7 +95,7 @@ dockerBuild {
 
         stage('Terraforming') {
           ansiColor('xterm') {
-            sh """cd terraform-geocat                            &&
+            sh """cd terraform-geocat                        &&
               ln -s /root/bin/terraform /usr/bin             &&
               make install                                   &&
               make init                                      &&

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ dockerBuild {
   }
   withDockerContainer(image: 'maven:3-jdk-8') {
     stage('Getting the sources') {
-      git url: 'https://github.com/geoadmin/geocat.git', branch: env.BRANCH_NAME
+      git url: 'https://github.com/camptocamp/geocat.git', branch: env.BRANCH_NAME
       sh 'git submodule update --init --recursive'
     }
     stage('First build without test') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,4 +52,56 @@ dockerBuild {
       sh '''mvn -s /settings.xml -B -Dmaven.repo.local=./.m2_repo -pl web -Pdocker docker:build docker:push'''
     }
   } // withDockerContainer
+
+  // Using another container, deploys the previously published image onto the dev env
+  stage('Deploy newly created images on the dev env') {
+    withDockerContainer(image: 'debian', args: "--privileged -u 0:0") {
+
+      stage('Install / configure needed tools') {
+        sh 'apt update && apt install -y make ssh git wget unzip'
+        sh 'mkdir -p ~/bin'
+      } // stage
+
+      stage("Prepare caas-dev access") {
+        withCredentials([file(credentialsId: 'jenkins-caas-dev-bgdi.ch.json', variable: 'FILE')]) {
+          sh 'mkdir -p ~/.rancher'
+          sh "cp ${FILE} ~/.rancher/caas.dev.bgdi.ch.json"
+        } // withCredentials
+      } // stage
+
+      stage("Configuring AWS / S3") {
+        sh 'mkdir ~/.aws'
+        withCredentials([[$class: 'UsernamePasswordMultiBinding',
+            credentialsId: 'terraform-georchestra-aws-credentials',
+            usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
+          def credentialsFile = """
+[c2c]
+aws_access_key_id = ${env.USERNAME}
+aws_secret_access_key = ${env.PASSWORD}
+region = eu-west-1
+"""
+          sh "echo '${credentialsFile}' > ~/.aws/credentials"
+        } // withCredentials
+      } // stage
+
+      stage('Checking out the terraform-geocat repository') {
+        sshagent(["terraform-geocat-deploy-key"]) {
+          sh "ssh -oStrictHostKeyChecking=no git@github.com || true"
+          sh "rm -rf terraform-geocat"
+          sh "git clone git@github.com:camptocamp/terraform-geocat.git"
+        } // sshagent
+      } // stage
+
+      stage('Terraforming') {
+        ansiColor('xterm') {
+          sh """cd terraform-geocat                            &&
+                ln -s /root/bin/terraform /usr/bin             &&
+                make install                                   &&
+                make init                                      &&
+                cd rancher-environments/geocat-dev             &&
+                terraform apply"""
+        } // ansiColor
+      } // stage
+    } // withDockerContainer
+  } // stage
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,53 @@
+#!/usr/bin/groovy
+
+@Library('c2c-pipeline-library') import static com.camptocamp.utils.*
+
+
+dockerBuild {
+  stage('Docker pull the maven image') {
+    sh 'docker pull maven:3-jdk-8'
+      sh 'docker pull pmauduit/google-drive-publisher'
+  }
+  withDockerContainer(image: 'maven:3-jdk-8') {
+    stage('Getting the sources') {
+      git url: 'git@github.com:camptocamp/geocat.git', branch: env.BRANCHE_NAME
+        sh 'git submodule update --init --recursive'
+    }
+    stage('First build without test') {
+      sh '''mvn clean install -B -Dmaven.repo.local=./.m2_repo -DskipTests'''
+    }
+    stage('Second build with tests') {
+      sh '''mvn clean install -B -Dmaven.repo.local=./.m2_repo -fn'''
+    }
+    stage('Saving tests results') {
+      junit '**/target/surefire-reports/TEST-*.xml'
+    }
+    stage('configure georchestra c2c docker-hub account') {
+      // Requires a username / password configured in Jenkins' credentials, with id docker-c2cgeorchestra
+      withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'dockerhub',
+          usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
+        def configXmlStr = """<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+          http://maven.apache.org/xsd/settings-1.0.0.xsd">
+            <servers>
+              <server>
+                <id>docker-hub</id>
+                <username>USERNAME</username>
+                <password>PASSWORD</password>
+                <configuration>
+                  <email>geocat2@camptocamp.com</email>
+                </configuration>
+              </server>
+            </servers>
+          </settings>""".replaceAll("USERNAME", env.USERNAME).replaceAll("PASSWORD", env.PASSWORD)
+          sh "echo '${configXmlStr}' > /config.xml"
+      }
+    }
+    stage('Build/publish a docker image') {
+      // one-liner to setup docker
+      sh 'curl -fsSLO https://get.docker.com/builds/Linux/x86_64/docker-17.05.0-ce.tgz && tar --strip-components=1 -xvzf docker-17.05.0-ce.tgz -C /usr/local/bin'
+      sh '''mvn -s /settings.xml -B -Dmaven.repo.local=./.m2_repo -pl web -Pdocker docker:build docker:push'''
+    }
+  } // withDockerContainer
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,6 @@ dockerBuild {
   } // withDockerContainer
 
   // Using another container, deploys the previously published image onto the dev env
-  if (env.BRANCH_NAME == 'geocat_3.4.x') {
     stage('Deploy newly created images on the dev env') {
       withDockerContainer(image: 'debian', args: "--privileged -u 0:0") {
 
@@ -95,15 +94,18 @@ dockerBuild {
 
         stage('Terraforming') {
           ansiColor('xterm') {
-            sh """cd terraform-geocat                        &&
-              ln -s /root/bin/terraform /usr/bin             &&
-              make install                                   &&
-              make init                                      &&
-              cd rancher-environments/geocat-dev             &&
-              terraform apply"""
+            if (env.BRANCH_NAME == 'geocat_3.4.x') {
+              sh """cd terraform-geocat                        &&
+                ln -s /root/bin/terraform /usr/bin             &&
+                make install                                   &&
+                make init                                      &&
+                cd rancher-environments/geocat-dev             &&
+                terraform apply"""
+            } else {
+              println "Not onto the 'geocat_3.4.x' branch, skipping redeploy"
+            }// if
           } // ansiColor
         } // stage
       } // withDockerContainer
     } // stage
-  } // if
 } // dockerBuild

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ dockerBuild {
               </server>
             </servers>
           </settings>""".replaceAll("USERNAME", env.USERNAME).replaceAll("PASSWORD", env.PASSWORD)
-          sh "echo '${configXmlStr}' > /config.xml"
+          sh "echo '${configXmlStr}' > /settings.xml"
       }
     }
     stage('Build/publish a docker image') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ dockerBuild {
   }
   withDockerContainer(image: 'maven:3-jdk-8') {
     stage('Getting the sources') {
-      git url: 'git@github.com:camptocamp/geocat.git', branch: env.BRANCHE_NAME
+      git url: 'https://github.com/geoadmin/geocat.git', branch: "geocat_3.4.x"
         sh 'git submodule update --init --recursive'
     }
     stage('First build without test') {

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -793,8 +793,33 @@
         <es.spring.profile>es</es.spring.profile>
       </properties>
     </profile>
+    <profile>
+      <id>docker</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>0.4.14</version>
+            <configuration>
+              <imageName>camptocamp/geocat:${project.version}</imageName>
+              <baseImage>tomcat:8-jre8</baseImage>
+              <resources>
+                <resource>
+                  <targetPath>/usr/local/tomcat/webapps</targetPath>
+                  <directory>${project.build.directory}</directory>
+                  <include>geonetwork.war</include>
+                </resource>
+              </resources>
+              <!-- This will require a settings.xml file for maven -->
+              <serverId>docker-hub</serverId>
+              <registryUrl>https://index.docker.io/v1/</registryUrl>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
-
   <properties>
     <geonetwork.version>${project.version}</geonetwork.version>
     <geonetwork.subversion>SNAPSHOT</geonetwork.subversion>


### PR DESCRIPTION
Needed to have a C2C-enabled CI. Consider merging it if you want to have the whole process described in the Jenkinsfile:

* First compilation with no tests (just to refresh GN artifacts)
* Second compilation with tests enabled
* Third build to calculate the test coverage
* Docker image creation / publication onto docker hub
* Terraforming so that the image is deployed (only on `geocat_3.4.x` though)

Everything is made on a private Jenkins, so all generated reports are unavailable from users outside of c2c, but should be easily ported to a project on another Jenkins instance. The docker-hub project hosting the generated images is public, since no sensitive data are included when generating the docker image.

