### PR TITLE
Add title attributes in groovy formatter (MGEO_SB-244)

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/data/formatter/html/text-el.html
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/html/text-el.html
@@ -1,4 +1,4 @@
 <span fmt-if="text" fmt-only-children="true" class="md-text">
-    <dt>{{label | escapeXmlContent}}</dt>
+    <dt title="{{label | escapeXmlContent}}">{{label | escapeXmlContent}}</dt>
     <dd>{{text | escapeXmlContent}}</dd>
 </span>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/html/url-el.html
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/html/url-el.html
@@ -1,4 +1,4 @@
-<span fmt-if="text" fmt-only-children="true" class="md-text">    
-    <dt>{{label | escapeXmlContent}}</dt>
+<span fmt-if="text" fmt-only-children="true" class="md-text">
+    <dt title="{{label | escapeXmlContent}}">{{label | escapeXmlContent}}</dt>
     <dd><a href="{{href | escapeXmlAttrs}}" title="{{href | escapeXmlAttrs}}">{{text | escapeXmlContent}}</a></dd>
 </span>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/html/wikitext-el.html
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/html/wikitext-el.html
@@ -1,4 +1,4 @@
 <span fmt-if="text" fmt-only-children="true" class="md-text">
-    <dt>{{label | escapeXmlContent}}</dt>
+    <dt title="{{label | escapeXmlContent}}">{{label | escapeXmlContent}}</dt>
     <dd>{{text}}</dd>
 </span>


### PR DESCRIPTION
This compensates the fact that some labels are truncated by bootstrap:
![image](https://user-images.githubusercontent.com/10629150/33135025-96751c96-cfa1-11e7-9e60-60ef25d9dd8c.png)
