### PR TITLE
Improved the html formatter again

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -141,6 +141,15 @@
     }
   }
 
+  div.md-text {
+    display: table;
+    width: 100%;
+    border-spacing: 10px 0;
+    dd, dt {
+      display: table-cell;
+    }
+  }
+
   dl {
     margin-bottom: 0;
     padding-bottom: 10px;
@@ -156,8 +165,10 @@
     font-style: italic;
     color: @gray;
     clear: none;
-    padding-left: 15px;
+    float: none;
+    padding-left: 0.5em;
     text-align: left;
+    white-space: normal;
   }
 
   .target {
@@ -213,14 +224,12 @@
     }
     */
     .dl-horizontal {
-      dt { width: (@large-offset - 20); }
-      dd { margin-left: @large-offset; }
-    }
-    .dl-horizontal[class~=col-sm-6],
-    /* .dl-horizontal .dl-horizontal { */
-    .dl-horizontal {
-      dt { width: (@component-offset-horizontal - 20); }
-      dd { margin-left: @component-offset-horizontal; }
+      dt {
+        width: (@component-offset-horizontal - 20);
+      }
+      dd {
+        margin-left: @component-offset-horizontal;
+      }
     }
   }
 
@@ -244,6 +253,7 @@
   dd, .offseted {
     border-left: 1px solid @gray-light;
     background: @gray-lighter;
+    padding-left: 0.6em;
   }
 }
 
@@ -319,9 +329,6 @@ ul.view-outline a[disabled] {
   pointer-events: none;
   cursor: default;
   color: #C0C0C0;
-}
-ul.view-outline > li {
-  max-width: 10em;
 }
 
 a {

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/html/text-el.html
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/html/text-el.html
@@ -1,4 +1,4 @@
-<span fmt-if="text" fmt-only-children="true" class="md-text">
+<div fmt-if="text" class="md-text">
     <dt title="{{label | escapeXmlContent}}">{{label | escapeXmlContent}}</dt>
     <dd>{{text | escapeXmlContent}}</dd>
-</span>
+</div>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/html/url-el.html
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/html/url-el.html
@@ -1,4 +1,4 @@
-<span fmt-if="text" fmt-only-children="true" class="md-text">
+<div fmt-if="text" class="md-text">
     <dt title="{{label | escapeXmlContent}}">{{label | escapeXmlContent}}</dt>
     <dd><a href="{{href | escapeXmlAttrs}}" title="{{href | escapeXmlAttrs}}">{{text | escapeXmlContent}}</a></dd>
-</span>
+</div>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/html/wikitext-el.html
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/html/wikitext-el.html
@@ -1,4 +1,4 @@
-<span fmt-if="text" fmt-only-children="true" class="md-text">
+<div fmt-if="text" class="md-text">
     <dt title="{{label | escapeXmlContent}}">{{label | escapeXmlContent}}</dt>
     <dd>{{text}}</dd>
-</span>
+</div>


### PR DESCRIPTION
Changes are made in `gn_metadata.less`:
* `dt` and `dd` are now all encapsulated in a `div.md-test` element, as it was before (I think)
* `padding` has been restored in `dd` elements
* word wrap has been restored in `dt` elements
* no width limit in tabs

After:
![image](https://user-images.githubusercontent.com/10629150/33371864-5a0fac70-d4fc-11e7-87ba-ae87045d9948.png)


Before:
![image](https://user-images.githubusercontent.com/10629150/33371873-60bfef3a-d4fc-11e7-8ee4-b24799620d59.png)

Note: this should be backported in GN afterwards