### PR TITLE
Fix updating existing online resources (MGEO_SB-343)

### DIFF
--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/process/onlinesrc-add.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/process/onlinesrc-add.xsl
@@ -140,8 +140,7 @@ Insert is made in first transferOptions found.
                         gmd:CI_OnlineResource/gmd:linkage/gmd:URL,
                         gmd:CI_OnlineResource/gmd:linkage/che:PT_FreeURL/che:URLGroup/che:LocalisedURL[@locale = '#DE'],
                         gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString,
-                        gmd:CI_OnlineResource/gmd:name/gco:CharacterString,
-                        gmd:CI_OnlineResource/gmd:name/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE'])
+                        gmd:CI_OnlineResource/gmd:name/gco:CharacterString)
                        ]">
     <xsl:call-template name="createOnlineSrc"/>
   </xsl:template>

--- a/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-add.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-add.xsl
@@ -139,8 +139,7 @@ Insert is made in first transferOptions found.
                         gmd:CI_OnlineResource/gmd:linkage/gmd:URL,
                         gmd:CI_OnlineResource/gmd:linkage/che:PT_FreeURL/che:URLGroup/che:LocalisedURL[@locale = '#DE'],
                         gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString,
-                        gmd:CI_OnlineResource/gmd:name/gco:CharacterString,
-                        gmd:CI_OnlineResource/gmd:name/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE'])
+                        gmd:CI_OnlineResource/gmd:name/gco:CharacterString)
                         ]">
     <xsl:call-template name="createOnlineSrc"/>
   </xsl:template>


### PR DESCRIPTION
Without this commit the `updateKey` used to match an existing online resource would never match any element as the `gco:CharacterString` is always set even for localized strings.

Fixes: https://jira.swisstopo.ch/browse/MGEO_SB-343