### PR TITLE
add --delete to s3 sync command fix #MGEO_SB-372

### DIFF
--- a/s3sync-geocat-folders.sh
+++ b/s3sync-geocat-folders.sh
@@ -18,7 +18,7 @@ fi
 for BUCKET_NAME in "$@"
 do
   echo "Will attempt to sync whole bucket 's3://${BUCKET_NAME}/' to '${DEST_DIR}/${BUCKET_NAME}/'"
-  aws s3 sync "s3://${BUCKET_NAME}/" "${DEST_DIR}/${BUCKET_NAME}/"
+  aws s3 sync --delete "s3://${BUCKET_NAME}/" "${DEST_DIR}/${BUCKET_NAME}/"
   ret=$?
 done
 # ugly workaround for bug [Errno 21] Is a directory: u'/path/to/local/sync/dir' : fake exit status


### PR DESCRIPTION
extract from aws s3 sync help:
  --delete  (boolean)  Files that exist in the destination but not in the
       source are deleted during sync.