### PR TITLE
Adapt batch processes for iso19139.che

### DIFF
--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/process/keywords-mapper.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/process/keywords-mapper.xsl
@@ -3,6 +3,13 @@
                 xmlns:geonet="http://www.fao.org/geonetwork" xmlns:gco="http://www.isotc211.org/2005/gco"
                 xmlns:gmd="http://www.isotc211.org/2005/gmd" version="1.0" exclude-result-prefixes="exslt">
 
+  <!-- The keyword separator -->
+  <xsl:param name="separator">;</xsl:param>
+  <!-- The keyword to search for -->
+  <xsl:param name="search">key1;key2/</xsl:param>
+  <!-- The keyword to put in -->
+  <xsl:param name="replace">newkey1;newkey2</xsl:param>
+
   <!-- Do a copy of every nodes and attributes -->
   <xsl:template match="@*|node()">
     <xsl:copy>
@@ -13,8 +20,12 @@
   <!-- Remove geonet:* elements. -->
   <xsl:template match="geonet:*" priority="2"/>
 
+  <!-- Build a map from the inputs parameters -->
   <xsl:variable name="map">
-    <map key="Env" value="Environment"/>
+    <xsl:for-each select="tokenize($search, $separator)">
+      <xsl:variable name="pos" select="position()"/>
+      <map key="{.}" value="{tokenize($replace, $separator)[position() = $pos]}"/>
+    </xsl:for-each>
   </xsl:variable>
 
   <!-- Map all keywords to new value.

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/process/massive-content-update-clean-changes.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/process/massive-content-update-clean-changes.xsl
@@ -2,12 +2,13 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:geonet="http://www.fao.org/geonetwork"
                 xmlns:gmd="http://www.isotc211.org/2005/gmd"
-                version="1.0" exclude-result-prefixes="gmd geonet">
+                xmlns:che="http://www.geocat.ch/2008/che"
+                version="1.0" exclude-result-prefixes="gmd geonet che">
 
 
   <!-- ================================================================= -->
 
-  <xsl:template match="gmd:MD_Metadata">
+  <xsl:template match="che:CHE_MD_Metadata">
     <xsl:copy>
       <xsl:copy-of select="@*"/>
       <xsl:apply-templates select="node()"/>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/process/massive-content-update-extract-changes.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/process/massive-content-update-extract-changes.xsl
@@ -2,10 +2,11 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:geonet="http://www.fao.org/geonetwork"
                 xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:che="http://www.geocat.ch/2008/che"
                 version="2.0"
-                exclude-result-prefixes="gmd xsl geonet">
+                exclude-result-prefixes="gmd xsl geonet che">
 
-  <xsl:template match="gmd:MD_Metadata">
+  <xsl:template match="che:CHE_MD_Metadata">
     <changes>
       <xsl:apply-templates select="@*|node()"/>
     </changes>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/process/massive-content-update.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/process/massive-content-update.xsl
@@ -3,8 +3,9 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:geonet="http://www.fao.org/geonetwork"
                 xmlns:srv="http://www.isotc211.org/2005/srv"
                 xmlns:gco="http://www.isotc211.org/2005/gco"
-                xmlns:gmd="http://www.isotc211.org/2005/gmd" version="2.0"
-                exclude-result-prefixes="gmd xsl gco srv geonet">
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:che="http://www.geocat.ch/2008/che" version="2.0"
+                exclude-result-prefixes="gmd xsl gco srv geonet che">
 
 
   <!-- Example of replacements parameter:
@@ -35,16 +36,16 @@
     </xsl:copy>
   </xsl:template>
 
-  <!-- METADATA CONTACT updates: gmd:MD_Metadata/gmd:contact -->
+  <!-- METADATA CONTACT updates: che:CHE_MD_Metadata/gmd:contact -->
   <!-- individualName -->
-  <xsl:template match="gmd:MD_Metadata/gmd:contact/gmd:CI_ResponsibleParty/gmd:individualName">
+  <xsl:template match="che:CHE_MD_Metadata/gmd:contact/che:CHE_CI_ResponsibleParty/*[name()='che:individualFirstName' or name()='che:individualLastName']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.contact.individualName</xsl:with-param>
     </xsl:call-template>
   </xsl:template>
 
   <!-- organisationName -->
-  <xsl:template match="gmd:MD_Metadata/gmd:contact/gmd:CI_ResponsibleParty/gmd:organisationName">
+  <xsl:template match="che:CHE_MD_Metadata/gmd:contact/che:CHE_CI_ResponsibleParty/*[name()='gmd:organisationName' or name()='che:organisationAcronym']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.contact.organisationName</xsl:with-param>
     </xsl:call-template>
@@ -52,7 +53,7 @@
 
   <!-- voice -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice">
+    match="che:CHE_MD_Metadata/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/*[name()='gmd:voice' or name()='che:directNumber' or name()='che:mobile']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.contact.voicePhone</xsl:with-param>
     </xsl:call-template>
@@ -60,7 +61,7 @@
 
   <!-- facsimile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile">
+    match="che:CHE_MD_Metadata/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.contact.faxPhone</xsl:with-param>
     </xsl:call-template>
@@ -68,7 +69,7 @@
 
   <!-- deliveryPoint -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint">
+    match="che:CHE_MD_Metadata/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/*[name()='che:streetName' or name()='che:streetNumber']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.contact.address</xsl:with-param>
     </xsl:call-template>
@@ -76,7 +77,7 @@
 
   <!-- city -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city">
+    match="che:CHE_MD_Metadata/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:city">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.contact.city</xsl:with-param>
     </xsl:call-template>
@@ -84,7 +85,7 @@
 
   <!-- administrativeArea/province -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea">
+    match="che:CHE_MD_Metadata/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:administrativeArea">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.contact.province</xsl:with-param>
     </xsl:call-template>
@@ -92,7 +93,7 @@
 
   <!-- postalCode -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode">
+    match="che:CHE_MD_Metadata/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:postalCode">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.contact.postalCode</xsl:with-param>
     </xsl:call-template>
@@ -100,7 +101,7 @@
 
   <!-- country -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country">
+    match="che:CHE_MD_Metadata/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:country">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.contact.country</xsl:with-param>
     </xsl:call-template>
@@ -108,7 +109,7 @@
 
   <!-- email -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+    match="che:CHE_MD_Metadata/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:electronicMailAddress">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.contact.email</xsl:with-param>
     </xsl:call-template>
@@ -116,7 +117,7 @@
 
   <!-- hoursOfService -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
+    match="che:CHE_MD_Metadata/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.contact.hoursOfService</xsl:with-param>
     </xsl:call-template>
@@ -124,7 +125,7 @@
 
   <!-- contactInstructions -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions">
+    match="che:CHE_MD_Metadata/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.contact.contactInstructions</xsl:with-param>
     </xsl:call-template>
@@ -132,14 +133,14 @@
 
   <!-- onlineResource url -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
+    match="che:CHE_MD_Metadata/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.contact.or.url</xsl:with-param>
     </xsl:call-template>
   </xsl:template>
 
   <!-- onlineResource protocol -->
-  <!--<xsl:template match="gmd:MD_Metadata/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:protocol">
+  <!--<xsl:template match="che:CHE_MD_Metadata/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:protocol">
       <xsl:call-template name="replaceField">
           <xsl:with-param name="fieldId">id.contact.or.protocol</xsl:with-param>
       </xsl:call-template>
@@ -147,7 +148,7 @@
 
   <!-- onlineResource app profile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile">
+    match="che:CHE_MD_Metadata/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.contact.or.ap</xsl:with-param>
     </xsl:call-template>
@@ -155,7 +156,7 @@
 
   <!-- onlineResource name -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name">
+    match="che:CHE_MD_Metadata/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.contact.or.name</xsl:with-param>
     </xsl:call-template>
@@ -163,16 +164,16 @@
 
   <!-- onlineResource description -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description">
+    match="che:CHE_MD_Metadata/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.contact.or.description</xsl:with-param>
     </xsl:call-template>
   </xsl:template>
 
-  <!-- IDENTIFICATION updates: gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact -->
+  <!-- IDENTIFICATION updates: che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact -->
   <!-- individualName -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:individualName|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:individualName">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/*[name()='che:individualFirstName' or name()='che:individualLastName']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/*[name()='che:individualFirstName' or name()='che:individualLastName']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.poc.individualName</xsl:with-param>
     </xsl:call-template>
@@ -180,7 +181,7 @@
 
   <!-- organisationName -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:organisationName|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:organisationName">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/*[name()='gmd:organisationName' or name()='che:organisationAcronym']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/*[name()='gmd:organisationName' or name()='che:organisationAcronym']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.poc.organisationName</xsl:with-param>
     </xsl:call-template>
@@ -188,7 +189,7 @@
 
   <!-- voice -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/*[name()='gmd:voice' or name()='che:directNumber' or name()='che:mobile']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/*[name()='gmd:voice' or name()='che:directNumber' or name()='che:mobile']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.poc.voicePhone</xsl:with-param>
     </xsl:call-template>
@@ -196,7 +197,7 @@
 
   <!-- facsimile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.poc.faxPhone</xsl:with-param>
     </xsl:call-template>
@@ -204,7 +205,7 @@
 
   <!-- deliveryPoint -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/*[name()='che:streetName' or name()='che:streetNumber']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/*[name()='che:streetName' or name()='che:streetNumber']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.poc.address</xsl:with-param>
     </xsl:call-template>
@@ -212,7 +213,7 @@
 
   <!-- city -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:city|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:city">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.poc.city</xsl:with-param>
     </xsl:call-template>
@@ -220,7 +221,7 @@
 
   <!-- administrativeArea/province -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:administrativeArea|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:administrativeArea">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.poc.province</xsl:with-param>
     </xsl:call-template>
@@ -228,7 +229,7 @@
 
   <!-- postalCode -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:postalCode|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:postalCode">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.poc.postalCode</xsl:with-param>
     </xsl:call-template>
@@ -236,7 +237,7 @@
 
   <!-- country -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:country|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:country">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.poc.country</xsl:with-param>
     </xsl:call-template>
@@ -244,7 +245,7 @@
 
   <!-- email -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:electronicMailAddress|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:electronicMailAddress">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.poc.email</xsl:with-param>
     </xsl:call-template>
@@ -252,7 +253,7 @@
 
   <!-- hoursOfService -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.poc.hoursOfService</xsl:with-param>
     </xsl:call-template>
@@ -260,7 +261,7 @@
 
   <!-- contactInstructions -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.poc.contactInstructions</xsl:with-param>
     </xsl:call-template>
@@ -268,7 +269,7 @@
 
   <!-- onlineResource url -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.poc.or.url</xsl:with-param>
     </xsl:call-template>
@@ -276,7 +277,7 @@
 
   <!-- onlineResource app profile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.poc.or.ap</xsl:with-param>
     </xsl:call-template>
@@ -284,7 +285,7 @@
 
   <!-- onlineResource name -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.poc.or.name</xsl:with-param>
     </xsl:call-template>
@@ -292,7 +293,7 @@
 
   <!-- onlineResource description -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.poc.or.description</xsl:with-param>
     </xsl:call-template>
@@ -301,7 +302,7 @@
 
   <!-- abstract -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:abstract">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:abstract|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:abstract">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.abstract</xsl:with-param>
     </xsl:call-template>
@@ -309,16 +310,16 @@
 
   <!-- purpose -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:purpose|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:purpose">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:purpose|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:purpose">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.purpose</xsl:with-param>
     </xsl:call-template>
   </xsl:template>
 
-  <!-- IDENTIFICATION CITATION updates: gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:CI_ResponsibleParty  -->
+  <!-- IDENTIFICATION CITATION updates: che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/che:CHE_CI_ResponsibleParty  -->
   <!-- individualName -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:individualName|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:individualName">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/*[name()='che:individualFirstName' or name()='che:individualLastName']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/*[name()='che:individualFirstName' or name()='che:individualLastName']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.citation.individualName</xsl:with-param>
     </xsl:call-template>
@@ -326,7 +327,7 @@
 
   <!-- organisationName -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:organisationName|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:organisationName">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/*[name()='gmd:organisationName' or name()='che:organisationAcronym']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/*[name()='gmd:organisationName' or name()='che:organisationAcronym']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.citation.organisationName</xsl:with-param>
     </xsl:call-template>
@@ -334,7 +335,7 @@
 
   <!-- voice -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/*[name()='gmd:voice' or name()='che:directNumber' or name()='che:mobile']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/*[name()='gmd:voice' or name()='che:directNumber' or name()='che:mobile']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.citation.voicePhone</xsl:with-param>
     </xsl:call-template>
@@ -342,7 +343,7 @@
 
   <!-- facsimile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.citation.faxPhone</xsl:with-param>
     </xsl:call-template>
@@ -350,7 +351,7 @@
 
   <!-- deliveryPoint -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/*[name()='che:streetName' or name()='che:streetNumber']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/*[name()='che:streetName' or name()='che:streetNumber']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.citation.address</xsl:with-param>
     </xsl:call-template>
@@ -358,7 +359,7 @@
 
   <!-- city -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:city|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:city">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.citation.city</xsl:with-param>
     </xsl:call-template>
@@ -366,7 +367,7 @@
 
   <!-- administrativeArea/province -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:administrativeArea|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:administrativeArea">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.citation.province</xsl:with-param>
     </xsl:call-template>
@@ -374,7 +375,7 @@
 
   <!-- postalCode -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:postalCode|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:postalCode">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.citation.postalCode</xsl:with-param>
     </xsl:call-template>
@@ -382,7 +383,7 @@
 
   <!-- country -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:country|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:country">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.citation.country</xsl:with-param>
     </xsl:call-template>
@@ -390,7 +391,7 @@
 
   <!-- email -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:electronicMailAddress|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:electronicMailAddress">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.citation.email</xsl:with-param>
     </xsl:call-template>
@@ -398,7 +399,7 @@
 
   <!-- onlineResource url -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.citation.or.url</xsl:with-param>
     </xsl:call-template>
@@ -406,7 +407,7 @@
 
   <!-- onlineResource app profile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.citation.or.ap</xsl:with-param>
     </xsl:call-template>
@@ -414,7 +415,7 @@
 
   <!-- onlineResource name -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.citation.or.name</xsl:with-param>
     </xsl:call-template>
@@ -422,7 +423,7 @@
 
   <!-- onlineResource description -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.citation.or.description</xsl:with-param>
     </xsl:call-template>
@@ -430,7 +431,7 @@
 
   <!-- hoursOfService -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.citation.hoursOfService</xsl:with-param>
     </xsl:call-template>
@@ -438,7 +439,7 @@
 
   <!-- contactInstructions -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.citation.contactInstructions</xsl:with-param>
     </xsl:call-template>
@@ -446,7 +447,7 @@
 
   <!-- keywords -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.keyword</xsl:with-param>
     </xsl:call-template>
@@ -454,7 +455,7 @@
 
   <!-- resource constraints general - use limitation -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints/gmd:MD_Constraints/gmd:useLimitation|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:resourceConstraints/gmd:MD_Constraints/gmd:useLimitation">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:resourceConstraints/gmd:MD_Constraints/gmd:useLimitation|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:resourceConstraints/gmd:MD_Constraints/gmd:useLimitation">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.resc.gc.useLimitation</xsl:with-param>
     </xsl:call-template>
@@ -462,7 +463,7 @@
 
   <!-- resource constraints legal - use limitation -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:resourceConstraints/che:CHE_MD_LegalConstraints/gmd:useLimitation|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:resourceConstraints/che:CHE_MD_LegalConstraints/gmd:useLimitation">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.resc.lc.useLimitation</xsl:with-param>
     </xsl:call-template>
@@ -470,7 +471,7 @@
 
   <!-- resource constraints legal - other constraints -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:otherConstraints|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:otherConstraints">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:resourceConstraints/che:CHE_MD_LegalConstraints/gmd:otherConstraints|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:resourceConstraints/che:CHE_MD_LegalConstraints/gmd:otherConstraints">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.resc.lc.otherConstraints</xsl:with-param>
     </xsl:call-template>
@@ -478,7 +479,7 @@
 
   <!-- resource constraints security - use limitation -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints/gmd:MD_SecurityConstraints/gmd:useLimitation|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='gmd:MD_DataIdentification']/gmd:resourceConstraints/gmd:MD_SecurityConstraints/gmd:useLimitation">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/che:CHE_MD_DataIdentification/gmd:resourceConstraints/gmd:MD_SecurityConstraints/gmd:useLimitation|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='che:CHE_MD_DataIdentification']/gmd:resourceConstraints/gmd:MD_SecurityConstraints/gmd:useLimitation">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.dataid.resc.sc.useLimitation</xsl:with-param>
     </xsl:call-template>
@@ -488,7 +489,7 @@
   <!-- SERVICE IDENTIFICATION -->
   <!-- abstract -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:abstract|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:abstract">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:abstract|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:abstract">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.abstract</xsl:with-param>
     </xsl:call-template>
@@ -496,7 +497,7 @@
 
   <!-- purpose -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:purpose|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:purpose">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:purpose|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:purpose">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.purpose</xsl:with-param>
     </xsl:call-template>
@@ -505,7 +506,7 @@
 
   <!-- individualName -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:individualName|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:individualName">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/*[name()='che:individualFirstName' or name()='che:individualLastName']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/*[name()='che:individualFirstName' or name()='che:individualLastName']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.citation.individualName</xsl:with-param>
     </xsl:call-template>
@@ -513,7 +514,7 @@
 
   <!-- organisationName -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:organisationName|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:organisationName">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/*[name()='gmd:organisationName' or name()='che:organisationAcronym']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/*[name()='gmd:organisationName' or name()='che:organisationAcronym']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.citation.organisationName</xsl:with-param>
     </xsl:call-template>
@@ -521,7 +522,7 @@
 
   <!-- voice -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/*[name()='gmd:voice' or name()='che:directNumber' or name()='che:mobile']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/*[name()='gmd:voice' or name()='che:directNumber' or name()='che:mobile']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.citation.voicePhone</xsl:with-param>
     </xsl:call-template>
@@ -529,7 +530,7 @@
 
   <!-- facsimile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.citation.faxPhone</xsl:with-param>
     </xsl:call-template>
@@ -537,7 +538,7 @@
 
   <!-- deliveryPoint -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/*[name()='che:streetName' or name()='che:streetNumber']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/*[name()='che:streetName' or name()='che:streetNumber']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.citation.address</xsl:with-param>
     </xsl:call-template>
@@ -545,7 +546,7 @@
 
   <!-- city -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:city|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:city">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.citation.city</xsl:with-param>
     </xsl:call-template>
@@ -553,7 +554,7 @@
 
   <!-- administrativeArea/province -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:administrativeArea|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:administrativeArea">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.citation.province</xsl:with-param>
     </xsl:call-template>
@@ -561,7 +562,7 @@
 
   <!-- postalCode -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:postalCode|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:postalCode">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.citation.postalCode</xsl:with-param>
     </xsl:call-template>
@@ -569,7 +570,7 @@
 
   <!-- country -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:country|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:country">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.citation.country</xsl:with-param>
     </xsl:call-template>
@@ -577,7 +578,7 @@
 
   <!-- email -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:electronicMailAddress|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:electronicMailAddress">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.citation.email</xsl:with-param>
     </xsl:call-template>
@@ -585,7 +586,7 @@
 
   <!-- onlineResource url -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.citation.or.url</xsl:with-param>
     </xsl:call-template>
@@ -593,7 +594,7 @@
 
   <!-- onlineResource app profile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.citation.or.ap</xsl:with-param>
     </xsl:call-template>
@@ -601,7 +602,7 @@
 
   <!-- onlineResource name -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.citation.or.name</xsl:with-param>
     </xsl:call-template>
@@ -609,7 +610,7 @@
 
   <!-- onlineResource description -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.citation.or.description</xsl:with-param>
     </xsl:call-template>
@@ -617,7 +618,7 @@
 
   <!-- hoursOfService -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.citation.hoursOfService</xsl:with-param>
     </xsl:call-template>
@@ -625,7 +626,7 @@
 
   <!-- contactInstructions -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.citation.contactInstructions</xsl:with-param>
     </xsl:call-template>
@@ -634,7 +635,7 @@
   <!-- poc -->
   <!-- individualName -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:individualName|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:individualName">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/*[name()='che:individualFirstName' or name()='che:individualLastName']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/*[name()='che:individualFirstName' or name()='che:individualLastName']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.poc.individualName</xsl:with-param>
     </xsl:call-template>
@@ -642,7 +643,7 @@
 
   <!-- organisationName -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:organisationName|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:organisationName">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/*[name()='gmd:organisationName' or name()='che:organisationAcronym']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/*[name()='gmd:organisationName' or name()='che:organisationAcronym']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.poc.organisationName</xsl:with-param>
     </xsl:call-template>
@@ -650,7 +651,7 @@
 
   <!-- voice -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/*[name()='gmd:voice' or name()='che:directNumber' or name()='che:mobile']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/*[name()='gmd:voice' or name()='che:directNumber' or name()='che:mobile']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.poc.voicePhone</xsl:with-param>
     </xsl:call-template>
@@ -658,7 +659,7 @@
 
   <!-- facsimile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.poc.faxPhone</xsl:with-param>
     </xsl:call-template>
@@ -666,7 +667,7 @@
 
   <!-- deliveryPoint -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/*[name()='che:streetName' or name()='che:streetNumber']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/*[name()='che:streetName' or name()='che:streetNumber']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.poc.address</xsl:with-param>
     </xsl:call-template>
@@ -674,7 +675,7 @@
 
   <!-- city -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:city|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:city">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.poc.city</xsl:with-param>
     </xsl:call-template>
@@ -682,7 +683,7 @@
 
   <!-- administrativeArea/province -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:administrativeArea|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:administrativeArea">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.poc.province</xsl:with-param>
     </xsl:call-template>
@@ -690,7 +691,7 @@
 
   <!-- postalCode -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:postalCode|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:postalCode">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.poc.postalCode</xsl:with-param>
     </xsl:call-template>
@@ -698,7 +699,7 @@
 
   <!-- country -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:country|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:country">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.poc.country</xsl:with-param>
     </xsl:call-template>
@@ -706,7 +707,7 @@
 
   <!-- email -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:electronicMailAddress|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:electronicMailAddress">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.poc.email</xsl:with-param>
     </xsl:call-template>
@@ -714,7 +715,7 @@
 
   <!-- hoursOfService -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.poc.hoursOfService</xsl:with-param>
     </xsl:call-template>
@@ -722,7 +723,7 @@
 
   <!-- contactInstructions -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.poc.contactInstructions</xsl:with-param>
     </xsl:call-template>
@@ -730,7 +731,7 @@
 
   <!-- onlineResource url -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.poc.or.url</xsl:with-param>
     </xsl:call-template>
@@ -738,7 +739,7 @@
 
   <!-- onlineResource app profile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.poc.or.ap</xsl:with-param>
     </xsl:call-template>
@@ -746,7 +747,7 @@
 
   <!-- onlineResource name -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.poc.or.name</xsl:with-param>
     </xsl:call-template>
@@ -754,7 +755,7 @@
 
   <!-- onlineResource description -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:pointOfContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.poc.or.description</xsl:with-param>
     </xsl:call-template>
@@ -763,7 +764,7 @@
   <!-- connect point -->
   <!-- onlineResource url -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:connectPoint/gmd:CI_OnlineResource/gmd:linkage/gmd:URL|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/srv:containsOperations/srv:SV_OperationMetadata/srv:connectPoint/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:connectPoint/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/srv:containsOperations/srv:SV_OperationMetadata/srv:connectPoint/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.connectpoint.url</xsl:with-param>
     </xsl:call-template>
@@ -771,7 +772,7 @@
 
   <!-- onlineResource app profile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:connectPoint/gmd:CI_OnlineResource/gmd:applicationProfile|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/srv:containsOperations/srv:SV_OperationMetadata/srv:connectPoint/gmd:CI_OnlineResource/gmd:applicationProfile">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:connectPoint/gmd:CI_OnlineResource/gmd:applicationProfile|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/srv:containsOperations/srv:SV_OperationMetadata/srv:connectPoint/gmd:CI_OnlineResource/gmd:applicationProfile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.connectpoint.ap</xsl:with-param>
     </xsl:call-template>
@@ -779,7 +780,7 @@
 
   <!-- onlineResource name -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:connectPoint/gmd:CI_OnlineResource/gmd:name|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/srv:containsOperations/srv:SV_OperationMetadata/srv:connectPoint/gmd:CI_OnlineResource/gmd:name">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:connectPoint/gmd:CI_OnlineResource/gmd:name|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/srv:containsOperations/srv:SV_OperationMetadata/srv:connectPoint/gmd:CI_OnlineResource/gmd:name">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.connectpoint.name</xsl:with-param>
     </xsl:call-template>
@@ -787,17 +788,17 @@
 
   <!-- onlineResource description -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:connectPoint/gmd:CI_OnlineResource/gmd:description|gmd:MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/srv:containsOperations/srv:SV_OperationMetadata/srv:connectPoint/gmd:CI_OnlineResource/gmd:description">
+    match="che:CHE_MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:connectPoint/gmd:CI_OnlineResource/gmd:description|che:CHE_MD_Metadata/gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']/srv:containsOperations/srv:SV_OperationMetadata/srv:connectPoint/gmd:CI_OnlineResource/gmd:description">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">id.serviceid.connectpoint.description</xsl:with-param>
     </xsl:call-template>
   </xsl:template>
 
 
-  <!-- MAINTENANCE INFORMATION updates:  gmd:MD_Metadata/gmd:metadataMaintenance -->
+  <!-- MAINTENANCE INFORMATION updates:  che:CHE_MD_Metadata/gmd:metadataMaintenance -->
   <!-- individualName -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:individualName|*[@gco:isoType='gmd:MD_Metadata']/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:individualName">
+    match="che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/*[name()='che:individualFirstName' or name()='che:individualLastName']|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/*[name()='che:individualFirstName' or name()='che:individualLastName']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">mi.contact.individualName</xsl:with-param>
     </xsl:call-template>
@@ -806,7 +807,7 @@
 
   <!-- individualName -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:organisationName|*[@gco:isoType='gmd:MD_Metadata']/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:organisationName">
+    match="che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/*[name()='gmd:organisationName' or name()='che:organisationAcronym']|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/*[name()='gmd:organisationName' or name()='che:organisationAcronym']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">mi.contact.organisationName</xsl:with-param>
     </xsl:call-template>
@@ -814,7 +815,7 @@
 
   <!-- voice -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice|*[@gco:isoType='gmd:MD_Metadata']/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice">
+    match="che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/*[name()='gmd:voice' or name()='che:directNumber' or name()='che:mobile']|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/*[name()='gmd:voice' or name()='che:directNumber' or name()='che:mobile']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">mi.contact.voicePhone</xsl:with-param>
     </xsl:call-template>
@@ -822,7 +823,7 @@
 
   <!-- facsimile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile|*[@gco:isoType='gmd:MD_Metadata']/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile">
+    match="che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">mi.contact.faxPhone</xsl:with-param>
     </xsl:call-template>
@@ -830,7 +831,7 @@
 
   <!-- deliveryPoint -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint|*[@gco:isoType='gmd:MD_Metadata']/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint">
+    match="che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/*[name()='che:streetName' or name()='che:streetNumber']|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/*[name()='che:streetName' or name()='che:streetNumber']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">mi.contact.address</xsl:with-param>
     </xsl:call-template>
@@ -838,7 +839,7 @@
 
   <!-- city -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city|*[@gco:isoType='gmd:MD_Metadata']/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city">
+    match="che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:city|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:city">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">mi.contact.city</xsl:with-param>
     </xsl:call-template>
@@ -846,7 +847,7 @@
 
   <!-- administrativeArea/province -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea|*[@gco:isoType='gmd:MD_Metadata']/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea">
+    match="che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:administrativeArea|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:administrativeArea">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">mi.contact.province</xsl:with-param>
     </xsl:call-template>
@@ -854,7 +855,7 @@
 
   <!-- country -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country|*[@gco:isoType='gmd:MD_Metadata']/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country">
+    match="che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:country|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:country">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">mi.contact.country</xsl:with-param>
     </xsl:call-template>
@@ -862,7 +863,7 @@
 
   <!-- postalCode -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode|*[@gco:isoType='gmd:MD_Metadata']/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode">
+    match="che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:postalCode|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:postalCode">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">mi.contact.postalCode</xsl:with-param>
     </xsl:call-template>
@@ -870,7 +871,7 @@
 
   <!-- email -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress|*[@gco:isoType='gmd:MD_Metadata']/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+    match="che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:electronicMailAddress|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:electronicMailAddress">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">mi.contact.email</xsl:with-param>
     </xsl:call-template>
@@ -879,7 +880,7 @@
 
   <!-- onlineResource url -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL|*[@gco:isoType='gmd:MD_Metadata']/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
+    match="che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">mi.contact.or.url</xsl:with-param>
     </xsl:call-template>
@@ -887,7 +888,7 @@
 
   <!-- onlineResource app profile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile|*[@gco:isoType='gmd:MD_Metadata']/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile">
+    match="che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">mi.contact.or.ap</xsl:with-param>
     </xsl:call-template>
@@ -895,7 +896,7 @@
 
   <!-- onlineResource name -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name|*[@gco:isoType='gmd:MD_Metadata']/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name">
+    match="che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">mi.contact.or.name</xsl:with-param>
     </xsl:call-template>
@@ -903,7 +904,7 @@
 
   <!-- onlineResource description -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description|*[@gco:isoType='gmd:MD_Metadata']/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description">
+    match="che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">mi.contact.or.description</xsl:with-param>
     </xsl:call-template>
@@ -912,7 +913,7 @@
 
   <!-- hoursOfService -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService|*[@gco:isoType='gmd:MD_Metadata']/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
+    match="che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">mi.contact.hoursOfService</xsl:with-param>
     </xsl:call-template>
@@ -920,17 +921,17 @@
 
   <!-- contactInstructions -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions|*[@gco:isoType='gmd:MD_Metadata']/gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions">
+    match="che:CHE_MD_Metadata/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:metadataMaintenance/che:CHE_MD_MaintenanceInformation/gmd:contact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">mi.contact.contactInstructions</xsl:with-param>
     </xsl:call-template>
   </xsl:template>
 
 
-  <!-- CONTENT INFORMATION updates: gmd:MD_Metadata/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty    -->
+  <!-- CONTENT INFORMATION updates: che:CHE_MD_Metadata/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty    -->
   <!-- individualName -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:individualName|*[@gco:isoType='gmd:MD_Metadata']/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:individualName">
+    match="che:CHE_MD_Metadata/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/*[name()='che:individualFirstName' or name()='che:individualLastName']|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/*[name()='che:individualFirstName' or name()='che:individualLastName']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">ci.citation.individualName</xsl:with-param>
     </xsl:call-template>
@@ -938,7 +939,7 @@
 
   <!-- organisationName -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:organisationName|*[@gco:isoType='gmd:MD_Metadata']/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:organisationName">
+    match="che:CHE_MD_Metadata/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/*[name()='gmd:organisationName' or name()='che:organisationAcronym']|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/*[name()='gmd:organisationName' or name()='che:organisationAcronym']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">ci.citation.organisationName</xsl:with-param>
     </xsl:call-template>
@@ -946,7 +947,7 @@
 
   <!-- voice -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice|*[@gco:isoType='gmd:MD_Metadata']/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice">
+    match="che:CHE_MD_Metadata/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/*[name()='gmd:voice' or name()='che:directNumber' or name()='che:mobile']|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/*[name()='gmd:voice' or name()='che:directNumber' or name()='che:mobile']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">ci.citation.voicePhone</xsl:with-param>
     </xsl:call-template>
@@ -954,7 +955,7 @@
 
   <!-- facsimile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile|*[@gco:isoType='gmd:MD_Metadata']/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile">
+    match="che:CHE_MD_Metadata/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">ci.citation.faxPhone</xsl:with-param>
     </xsl:call-template>
@@ -962,7 +963,7 @@
 
   <!-- deliveryPoint -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint|*[@gco:isoType='gmd:MD_Metadata']/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint">
+    match="che:CHE_MD_Metadata/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/*[name()='che:streetName' or name()='che:streetNumber']|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/*[name()='che:streetName' or name()='che:streetNumber']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">ci.citation.address</xsl:with-param>
     </xsl:call-template>
@@ -970,7 +971,7 @@
 
   <!-- city -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city|*[@gco:isoType='gmd:MD_Metadata']/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city">
+    match="che:CHE_MD_Metadata/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:city|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:city">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">ci.citation.city</xsl:with-param>
     </xsl:call-template>
@@ -978,7 +979,7 @@
 
   <!-- administrative area -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea|*[@gco:isoType='gmd:MD_Metadata']/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea">
+    match="che:CHE_MD_Metadata/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:administrativeArea|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:administrativeArea">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">ci.citation.province</xsl:with-param>
     </xsl:call-template>
@@ -986,7 +987,7 @@
 
   <!-- postal code -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode|*[@gco:isoType='gmd:MD_Metadata']/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode">
+    match="che:CHE_MD_Metadata/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:postalCode|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:postalCode">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">ci.citation.postalCode</xsl:with-param>
     </xsl:call-template>
@@ -994,7 +995,7 @@
 
   <!-- country -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country|*[@gco:isoType='gmd:MD_Metadata']/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country">
+    match="che:CHE_MD_Metadata/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:country|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:country">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">ci.citation.country</xsl:with-param>
     </xsl:call-template>
@@ -1002,7 +1003,7 @@
 
   <!-- email -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress|*[@gco:isoType='gmd:MD_Metadata']/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+    match="che:CHE_MD_Metadata/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:electronicMailAddress|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:electronicMailAddress">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">ci.citation.email</xsl:with-param>
     </xsl:call-template>
@@ -1010,7 +1011,7 @@
 
   <!-- hours of service -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService|*[@gco:isoType='gmd:MD_Metadata']/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
+    match="che:CHE_MD_Metadata/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">ci.citation.hoursOfService</xsl:with-param>
     </xsl:call-template>
@@ -1018,7 +1019,7 @@
 
   <!-- contact instructions -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions|*[@gco:isoType='gmd:MD_Metadata']/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions">
+    match="che:CHE_MD_Metadata/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">ci.citation.contactInstructions</xsl:with-param>
     </xsl:call-template>
@@ -1026,7 +1027,7 @@
 
   <!-- onlineResource url -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL|*[@gco:isoType='gmd:MD_Metadata']/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
+    match="che:CHE_MD_Metadata/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">ci.citation.or.url</xsl:with-param>
     </xsl:call-template>
@@ -1035,7 +1036,7 @@
 
   <!-- onlineResource app profile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile|*[@gco:isoType='gmd:MD_Metadata']/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile">
+    match="che:CHE_MD_Metadata/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">ci.citation.or.ap</xsl:with-param>
     </xsl:call-template>
@@ -1043,7 +1044,7 @@
 
   <!-- onlineResource name -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name|*[@gco:isoType='gmd:MD_Metadata']/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name">
+    match="che:CHE_MD_Metadata/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">ci.citation.or.name</xsl:with-param>
     </xsl:call-template>
@@ -1051,16 +1052,16 @@
 
   <!-- onlineResource description -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description|*[@gco:isoType='gmd:MD_Metadata']/gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description">
+    match="che:CHE_MD_Metadata/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:contentInfo/che:CHE_MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:citedResponsibleParty/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">ci.citation.or.description</xsl:with-param>
     </xsl:call-template>
   </xsl:template>
 
-  <!-- DISTRIBUTION INFORMATION updates: gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution -->
+  <!-- DISTRIBUTION INFORMATION updates: che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution -->
   <!-- individualName -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:individualName|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:individualName">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/*[name()='che:individualFirstName' or name()='che:individualLastName']|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/*[name()='che:individualFirstName' or name()='che:individualLastName']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.contact.individualName</xsl:with-param>
     </xsl:call-template>
@@ -1068,7 +1069,7 @@
 
   <!-- organisationName -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:organisationName|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:organisationName">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/*[name()='gmd:organisationName' or name()='che:organisationAcronym']|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/*[name()='gmd:organisationName' or name()='che:organisationAcronym']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.contact.organisationName</xsl:with-param>
     </xsl:call-template>
@@ -1077,7 +1078,7 @@
 
   <!-- voice -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/*[name()='gmd:voice' or name()='che:directNumber' or name()='che:mobile']|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/*[name()='gmd:voice' or name()='che:directNumber' or name()='che:mobile']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.contact.voicePhone</xsl:with-param>
     </xsl:call-template>
@@ -1085,7 +1086,7 @@
 
   <!-- facsimile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:facsimile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.contact.faxPhone</xsl:with-param>
     </xsl:call-template>
@@ -1093,7 +1094,7 @@
 
   <!-- deliveryPoint -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/*[name()='che:streetName' or name()='che:streetNumber']|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/*[name()='che:streetName' or name()='che:streetNumber']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.contact.address</xsl:with-param>
     </xsl:call-template>
@@ -1101,7 +1102,7 @@
 
   <!-- city -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:city|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:city">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.contact.city</xsl:with-param>
     </xsl:call-template>
@@ -1109,7 +1110,7 @@
 
   <!-- administrative area -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:administrativeArea|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:administrativeArea">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.contact.province</xsl:with-param>
     </xsl:call-template>
@@ -1117,7 +1118,7 @@
 
   <!-- country -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:country|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:country">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.contact.country</xsl:with-param>
     </xsl:call-template>
@@ -1125,7 +1126,7 @@
 
   <!-- postal code -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:postalCode|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:postalCode">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.contact.postalCode</xsl:with-param>
     </xsl:call-template>
@@ -1133,7 +1134,7 @@
 
   <!-- email -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:electronicMailAddress|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/che:CHE_CI_Address/gmd:electronicMailAddress">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.contact.email</xsl:with-param>
     </xsl:call-template>
@@ -1141,7 +1142,7 @@
 
   <!-- hours of service -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.contact.hoursOfService</xsl:with-param>
     </xsl:call-template>
@@ -1149,14 +1150,14 @@
 
   <!-- onlineResource url -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.contact.or.url</xsl:with-param>
     </xsl:call-template>
   </xsl:template>
 
   <!-- onlineResource protocol -->
-  <!--<xsl:template match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:protocol|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:protocol">
+  <!--<xsl:template match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:protocol|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:protocol">
       <xsl:call-template name="replaceField">
           <xsl:with-param name="fieldId">di.contact.or.protocol</xsl:with-param>
       </xsl:call-template>
@@ -1164,7 +1165,7 @@
 
   <!-- onlineResource app profile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:applicationProfile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.contact.or.ap</xsl:with-param>
     </xsl:call-template>
@@ -1172,7 +1173,7 @@
 
   <!-- onlineResource name -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:name">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.contact.or.name</xsl:with-param>
     </xsl:call-template>
@@ -1180,7 +1181,7 @@
 
   <!-- onlineResource description -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:description">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.contact.or.description</xsl:with-param>
     </xsl:call-template>
@@ -1189,7 +1190,7 @@
 
   <!-- contact instructions -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/che:CHE_CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:contactInstructions">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.contact.contactInstructions</xsl:with-param>
     </xsl:call-template>
@@ -1197,7 +1198,7 @@
 
   <!-- fees -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributionOrderProcess/gmd:MD_StandardOrderProcess/gmd:fees|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributionOrderProcess/gmd:MD_StandardOrderProcess/gmd:fees">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributionOrderProcess/gmd:MD_StandardOrderProcess/gmd:fees|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributionOrderProcess/gmd:MD_StandardOrderProcess/gmd:fees">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.fees</xsl:with-param>
     </xsl:call-template>
@@ -1205,7 +1206,7 @@
 
   <!-- ordering instructions -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributionOrderProcess/gmd:MD_StandardOrderProcess/gmd:orderingInstructions|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributionOrderProcess/gmd:MD_StandardOrderProcess/gmd:orderingInstructions">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributionOrderProcess/gmd:MD_StandardOrderProcess/gmd:orderingInstructions|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributionOrderProcess/gmd:MD_StandardOrderProcess/gmd:orderingInstructions">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.orderingInstructions</xsl:with-param>
     </xsl:call-template>
@@ -1215,14 +1216,14 @@
   <!-- transfer options -->
   <!-- onlineResource url -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:linkage/gmd:URL|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:linkage//*[name()='gmd:URL' or name()='che:LocalisedURL']">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.transferOptions.url</xsl:with-param>
     </xsl:call-template>
   </xsl:template>
 
   <!-- onlineResource protocol -->
-  <!--<xsl:template match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:protocol|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:protocol">
+  <!--<xsl:template match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:protocol|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:protocol">
       <xsl:call-template name="replaceField">
           <xsl:with-param name="fieldId">di.transferOptions.protocol</xsl:with-param>
       </xsl:call-template>
@@ -1230,7 +1231,7 @@
 
   <!-- onlineResource app profile -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:applicationProfile|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:applicationProfile">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:applicationProfile|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:applicationProfile">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.transferOptions.ap</xsl:with-param>
     </xsl:call-template>
@@ -1238,7 +1239,7 @@
 
   <!-- onlineResource name -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:name|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:CI_OnlineResource/gmd:name">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:name|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:CI_OnlineResource/gmd:name">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.transferOptions.name</xsl:with-param>
     </xsl:call-template>
@@ -1246,7 +1247,7 @@
 
   <!-- onlineResource description -->
   <xsl:template
-    match="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:description|*[@gco:isoType='gmd:MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:description">
+    match="che:CHE_MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:description|*[@gco:isoType='che:CHE_MD_Metadata']/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:description">
     <xsl:call-template name="replaceField">
       <xsl:with-param name="fieldId">di.transferOptions.description</xsl:with-param>
     </xsl:call-template>
@@ -1271,7 +1272,7 @@
 
           <xsl:choose>
             <!-- gmd:URL -->
-            <xsl:when test="name() = 'gmd:URL'">
+            <xsl:when test="name() = 'gmd:URL' or name() = 'che:LocalisedURL'">
               <xsl:call-template name="replaceValueForField">
                 <xsl:with-param name="fieldId" select="$fieldId"/>
                 <xsl:with-param name="value" select="."/>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/process/url-host-relocator.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/process/url-host-relocator.xsl
@@ -16,7 +16,8 @@
                 xmlns:geonet="http://www.fao.org/geonetwork"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:gco="http://www.isotc211.org/2005/gco"
-                xmlns:gmd="http://www.isotc211.org/2005/gmd" version="1.0">
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:che="http://www.geocat.ch/2008/che" version="1.0">
 
   <xsl:param name="urlPrefix">http://localhost:8080/</xsl:param>
   <xsl:param name="newUrlPrefix">http://newhost.org/</xsl:param>
@@ -34,6 +35,7 @@
   <!-- Replace in gmd:URL (uploaded document)
       or gco:CharacterString (eg. resource identifier may be based on host name) -->
   <xsl:template match="gmd:URL[starts-with(text(), $urlPrefix)]|
+        che:LocalisedURL[starts-with(text(), $urlPrefix)]|
         gco:CharacterString[starts-with(text(), $urlPrefix)]" priority="2">
     <xsl:copy>
       <xsl:apply-templates select="@*"/>


### PR DESCRIPTION
The following processes were non functional in iso.che:
* URL replacer
* Keyword mapper
* Batch replacer

I've adapted the first and last ones for the CHE profile. The keyword mapper would need to be rewritten entirely since all keywords are now handled through xlinks. I simply took the most recent code from the iso19139 schema for now.