### PR TITLE
Handle extents outside of the EPSG:21781 range

### DIFF
--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/formatter/groovy/iso19139che/Handlers.groovy
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/formatter/groovy/iso19139che/Handlers.groovy
@@ -1,6 +1,7 @@
 package iso19139che
 
 import groovy.util.slurpersupport.GPathResult
+import org.fao.geonet.api.records.formatters.groovy.MapConfig
 
 public class Handlers extends iso19139.Handlers {
   public Handlers(handlers, f, env) {
@@ -57,5 +58,72 @@ public class Handlers extends iso19139.Handlers {
       return findParentXLink(el.parent())
     }
     return el['@xlink:href'].text()
+  }
+
+  // bbox bounds are checked against the limits of the swiss projection (EPSG:21781)
+  def isProj4326(extentEl) {
+      def bboxEl = extentEl.'*'.'gmd:EX_GeographicBoundingBox'
+      if (bboxEl.isEmpty()) {
+          return false
+      }
+      if (bboxEl.'gmd:westBoundLongitude'.'gco:Decimal'.text().toFloat() < 5.9700 ||
+          bboxEl.'gmd:eastBoundLongitude'.'gco:Decimal'.text().toFloat() > 10.4900||
+          bboxEl.'gmd:southBoundLatitude'.'gco:Decimal'.text().toFloat() < 45.8300 ||
+          bboxEl.'gmd:northBoundLatitude'.'gco:Decimal'.text().toFloat() > 47.8100) {
+          return true
+      }
+      return false
+  }
+
+  def polygonEl(thumbnail) {
+      return { el ->
+          MapConfig mapConfig = env.mapConfiguration
+          def mapproj = mapConfig.mapproj
+          def background = mapConfig.background
+          def width = thumbnail? mapConfig.thumbnailWidth : mapConfig.width
+          def mdId = env.getMetadataId();
+          def xpath = f.getXPathFrom(el);
+
+          // Geocat specific: when extent is given in 4326, force values
+          if (isProj4326(el.parent().parent())) {
+            mapproj = 'EPSG:4326'
+            background = 'osm'
+          }
+
+          if (xpath != null) {
+              def encoded = java.net.URLEncoder.encode(xpath, "UTF-8");
+              def source = "region.getmap.png?mapsrs=$mapproj&amp;width=$width&amp;background=$background&amp;id=metadata:@id$mdId:@xpath$encoded";
+              def image = "<img src=\"$source\" style=\"min-width:${width/4}px; min-height:${width/4}px;\" />"
+
+              def inclusion = el.'gmd:extentTypeCode'.text() == '0' ? 'exclusive' : 'inclusive';
+
+              def label = f.nodeLabel(el) + " (" + f.translate(inclusion) + ")"
+              handlers.fileResult('html/2-level-entry.html', [label: label, childData: image])
+          }
+      }
+  }
+
+  def bboxEl(thumbnail) {
+      return { el ->
+          if (el.parent().'gmd:EX_BoundingPolygon'.text().isEmpty() &&
+                  el.parent().parent().'gmd:geographicElement'.'gmd:EX_BoundingPolygon'.text().isEmpty()) {
+
+              def inclusion = el.'gmd:extentTypeCode'.text() == '0' ? 'exclusive' : 'inclusive';
+
+              def label = f.nodeLabel(el) + " (" + f.translate(inclusion) + ")"
+
+              def replacements = bbox(thumbnail, el)
+              replacements['label'] = label
+              replacements['pdfOutput'] = commonHandlers.func.isPDFOutput()
+
+              // Geocat specific: when extent is given in 4326, force values
+              if (isProj4326(el.parent().parent())) {
+                replacements['mapconfig']['mapproj'] = 'EPSG:4326'
+                replacements['mapconfig']['background'] = 'osm'
+              }
+
+              handlers.fileResult("html/bbox.html", replacements)
+          }
+      }
   }
 }

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/formatter/groovy/iso19139che/Handlers.groovy
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/formatter/groovy/iso19139che/Handlers.groovy
@@ -61,7 +61,7 @@ public class Handlers extends iso19139.Handlers {
   }
 
   // bbox bounds are checked against the limits of the swiss projection (EPSG:21781)
-  def isProj4326(extentEl) {
+  def isWorldExtentUsed(extentEl) {
       def bboxEl = extentEl.'*'.'gmd:EX_GeographicBoundingBox'
       if (bboxEl.isEmpty()) {
           return false
@@ -84,8 +84,8 @@ public class Handlers extends iso19139.Handlers {
           def mdId = env.getMetadataId();
           def xpath = f.getXPathFrom(el);
 
-          // Geocat specific: when extent is given in 4326, force values
-          if (isProj4326(el.parent().parent())) {
+          // Geocat specific: use 4326 projection when bbox bounds are too wide
+          if (isWorldExtentUsed(el.parent().parent())) {
             mapproj = 'EPSG:4326'
             background = 'osm'
           }
@@ -116,8 +116,8 @@ public class Handlers extends iso19139.Handlers {
               replacements['label'] = label
               replacements['pdfOutput'] = commonHandlers.func.isPDFOutput()
 
-              // Geocat specific: when extent is given in 4326, force values
-              if (isProj4326(el.parent().parent())) {
+              // Geocat specific: use 4326 projection when bbox bounds are too wide
+              if (isWorldExtentUsed(el.parent().parent())) {
                 replacements['mapconfig']['mapproj'] = 'EPSG:4326'
                 replacements['mapconfig']['background'] = 'osm'
               }

--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -829,7 +829,7 @@
       },
 
       // SPECIFIC GEOCAT
-      isProj4326: function(i) {
+      isWorldExtentUsed: function(i) {
         if (!this.geoBox[i]) {
           return false;
         }

--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -826,6 +826,21 @@
           });
         }
         return res;
+      },
+
+      // SPECIFIC GEOCAT
+      isProj4326: function(i) {
+        if (!this.geoBox[i]) {
+          return false;
+        }
+        var coords = this.geoBox[i].split('|');
+        if (parseFloat(coords[0]) < 5.9700 ||
+            parseFloat(coords[2]) > 10.4900||
+            parseFloat(coords[1]) < 45.8300 ||
+            parseFloat(coords[3]) > 47.8100) {
+          return true
+        }
+        return false;
       }
     };
     return Metadata;

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -452,10 +452,14 @@
             <li data-ng-repeat="d in mdView.current.record.geoDesc">{{d}}</li>
           </ul>
           </p>
-          <!-- TODO: use map config -->
+          <!-- SPECIFIC GEOCAT: handle 4326 case -->
           <p data-ng-repeat="bbox in mdView.current.record.geoBox">
             <img class="gn-img-thumbnail img-thumbnail gn-img-extent"
+                 ng-if="!mdView.current.record.isProj4326($index)"
                  data-ng-src="{{gnUrl}}/{{lang}}/region.getmap.png?mapsrs=EPSG:21781&width=250&background=settings&geomsrs=EPSG:4326&geom={{mdView.current.record.getBoxAsPolygon($index)}}"/>
+            <img class="gn-img-thumbnail img-thumbnail gn-img-extent"
+                 ng-if="mdView.current.record.isProj4326($index)"
+                 data-ng-src="{{gnUrl}}/{{lang}}/region.getmap.png?mapsrs=EPSG:4326&width=250&background=osm&geomsrs=EPSG:4326&geom={{mdView.current.record.getBoxAsPolygon($index)}}"/>
           </p>
 
         </section>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -455,10 +455,10 @@
           <!-- SPECIFIC GEOCAT: handle 4326 case -->
           <p data-ng-repeat="bbox in mdView.current.record.geoBox">
             <img class="gn-img-thumbnail img-thumbnail gn-img-extent"
-                 ng-if="!mdView.current.record.isProj4326($index)"
+                 ng-if="!mdView.current.record.isWorldExtentUsed($index)"
                  data-ng-src="{{gnUrl}}/{{lang}}/region.getmap.png?mapsrs=EPSG:21781&width=250&background=settings&geomsrs=EPSG:4326&geom={{mdView.current.record.getBoxAsPolygon($index)}}"/>
             <img class="gn-img-thumbnail img-thumbnail gn-img-extent"
-                 ng-if="mdView.current.record.isProj4326($index)"
+                 ng-if="mdView.current.record.isWorldExtentUsed($index)"
                  data-ng-src="{{gnUrl}}/{{lang}}/region.getmap.png?mapsrs=EPSG:4326&width=250&background=osm&geomsrs=EPSG:4326&geom={{mdView.current.record.getBoxAsPolygon($index)}}"/>
           </p>
 


### PR DESCRIPTION
Either in angular JS view or groovy formatter, compare the bounding box bounds with the [EPSG:21781 range](http://spatialreference.org/ref/epsg/21781/).

If bounds exceed this range, switch to EPSG:4326 with an OSM background (the swisstopo basemap cannot be used anymore).

Example with record `248211e2-fd0a-40ee-94d8-3ab80e934250`:
![image](https://user-images.githubusercontent.com/10629150/44668342-6d572000-aa1d-11e8-95cc-8070da2e3667.png)
