### PR TITLE
Add a iso.che schematron rule for validating URLs inside a text content

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -857,6 +857,18 @@ public final class XslUtil {
         }
     }
 
+    public static boolean findAndValidateURLs(final String textContent) throws ExecutionException {
+        Pattern p = Pattern.compile("(http|ftp|https):\\/\\/([\\w_-]+(?:(?:\\.[\\w_-]+)+))([\\w.,@?^=%&:\\/~+#-]*[\\w@?^=%&\\/~+#-])?");
+        Matcher m = p.matcher(textContent);
+        boolean result = true;
+
+        while (m.find()) {
+            result = result && validateURL(m.group());
+        }
+
+        return result;
+    }
+
     // End geocat
     public static boolean validateURL(final String urlString) throws ExecutionException {
         return URL_VALIDATION_CACHE.get(urlString, new Callable<Boolean>() {

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/schematron/schematron-rules-url-check.report_only.sch
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/schematron/schematron-rules-url-check.report_only.sch
@@ -28,4 +28,19 @@
         </sch:rule>
     </sch:pattern>
 
+    <sch:pattern>
+        <sch:title>$loc/strings/invalidURLCheck</sch:title>
+        <!-- Check specification names and status -->
+        <sch:rule context="//gco:CharacterString[matches(., 'http|ftp')] |
+                           //gmd:LocalisedCharacterString[matches(., 'http|ftp')]">
+
+            <sch:let name="isValidUrl" value="xslutil:findAndValidateURLs(text())" />
+
+            <sch:assert test="$isValidUrl = true()">
+                <sch:value-of select="$loc/strings/alert.invalidURL/div" />
+                '<sch:value-of select="string(.)" />'
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+
 </sch:schema>


### PR DESCRIPTION
https://jira.swisstopo.ch/browse/MGEO_SB-334

Result:
![image](https://user-images.githubusercontent.com/10629150/45431770-a099e000-b6a8-11e8-800f-7342342ba694.png)


This could be added to Geonetwork eventually, but would need specific labels.