### PR TITLE
Indexing / Topic category / Index parent too if not defined

### DIFF
--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/index-fields/default.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/index-fields/default.xsl
@@ -514,6 +514,11 @@
 
       <xsl:for-each select="gmd:topicCategory/gmd:MD_TopicCategoryCode">
         <Field name="topicCat" string="{string(.)}" store="true" index="true"/>
+        <xsl:variable name="parentCat" select="tokenize(., '_')[1]"/>
+        <xsl:if test="contains(., '_') and
+                      count(../../gmd:topicCategory/gmd:MD_TopicCategoryCode[. = $parentCat]) = 0">
+         <Field name="topicCat" string="{tokenize(., '_')[1]}" store="true" index="true"/>
+        </xsl:if>
         <!-- <Field name="keyword"
                string="{util:getCodelistTranslation('gmd:MD_TopicCategoryCode', string(.), string($isoLangId))}"
                store="true" index="true"/> -->

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/index-fields/language-default.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/index-fields/language-default.xsl
@@ -471,6 +471,11 @@
 
       <xsl:for-each select="gmd:topicCategory/gmd:MD_TopicCategoryCode">
         <Field name="topicCat" string="{string(.)}" store="true" index="true"/>
+        <xsl:variable name="parentCat" select="tokenize(., '_')[1]"/>
+        <xsl:if test="contains(., '_') and
+                      count(../../gmd:topicCategory/gmd:MD_TopicCategoryCode[. = $parentCat]) = 0">
+          <Field name="topicCat" string="{tokenize(., '_')[1]}" store="true" index="true"/>
+        </xsl:if>
         <!-- <Field name="keyword"
                string="{util:getCodelistTranslation('gmd:MD_TopicCategoryCode', string(.), string($langId))}"
                store="true"


### PR DESCRIPTION
Mainly needed for harvested records which may not respect the rule.
It will also fix facet counter for parent category.

See https://jira.swisstopo.ch/browse/MGEO_SB-483