### PR TITLE
MGEO_SB-606 / use gmd:URL if available in CHE>iso19139 transformation

### DIFF
--- a/web/src/main/webapp/xslt/geocat/xml_iso19139.xsl
+++ b/web/src/main/webapp/xslt/geocat/xml_iso19139.xsl
@@ -87,7 +87,9 @@
           <xsl:value-of select=".//che:LocalisedURL[1]"/>
         </gmd:URL>
       </xsl:when>
-      <xsl:otherwise><!--if character string then don't use url--></xsl:otherwise>
+      <xsl:otherwise>
+        <xsl:copy-of select="./gmd:URL"/>
+      </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
 


### PR DESCRIPTION
https://jira.swisstopo.ch/browse/MGEO_SB-606

Use `gmd:URL` if available in linkages when converting from CHE to 19139.