### PR TITLE
ISO19139.che / Fix usage of PT_FreeUrl for Anchor element

### DIFF
--- a/schemas/iso19139.che/src/main/java/org/fao/geonet/schema/iso19139che/ISO19139cheSchemaPlugin.java
+++ b/schemas/iso19139.che/src/main/java/org/fao/geonet/schema/iso19139che/ISO19139cheSchemaPlugin.java
@@ -237,6 +237,7 @@ public class ISO19139cheSchemaPlugin
     @Override
     public void addTranslationToElement(Element element, String languageIdentifier, String value) {
         if (element.getChild("PT_FreeText", ISO19139Namespaces.GMD) != null ||
+            element.getChild("Anchor", GMX) != null ||
             element.getChild("CharacterString", ISO19139Namespaces.GCO) != null) {
 //            super.addTranslationToElement(element, languageIdentifier, value);
             // An ISO19139 element containing translation has an xsi:type attribute


### PR DESCRIPTION
Related to https://jira.swisstopo.ch/browse/MGEO_SB-490

`gmx:Anchor` should be handled like `gco:CharacterString`