### PR TITLE
Import & new metadata / Consistent group list.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
@@ -341,19 +341,22 @@
                     });
                   }
 
-                  // Select by default the first group.
-                  if (setDefaultValue && (angular.isUndefined(scope.ownerGroup) ||
-                    scope.ownerGroup === '' ||
-                    scope.ownerGroup === null) && data) {
-                    // Requires to be converted to string, otherwise
-                    // angularjs adds empty non valid option
-                    scope.ownerGroup = scope.groups[0].id + "";
-                  }
                   if (optional) {
                     scope.groups.unshift({
                       id: 'undefined',
                       name: ''
                     });
+                  }
+
+                  // Select by default the first group.
+                  if (setDefaultValue && (angular.isUndefined(scope.ownerGroup) ||
+                      scope.ownerGroup === '' ||
+                      scope.ownerGroup === null) && data) {
+                    // Requires to be converted to string, otherwise
+                    // angularjs adds empty non valid option
+                    scope.ownerGroup = scope.groups[0].id + "";
+                  } else if (scope.groups.length === 1) {
+                    scope.ownerGroup = scope.groups[0].id + "";
                   }
                 });
           }

--- a/web-ui/src/main/resources/catalog/js/edit/NewMetadataController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/NewMetadataController.js
@@ -68,13 +68,6 @@
         dataset: 'fa-file'
       };
 
-      $scope.$watchCollection('groups', function() {
-        if (!angular.isUndefined($scope.groups)) {
-          if ($scope.groups.length == 1) {
-            $scope.ownerGroup = $scope.groups[0].id;
-          }
-        }
-      });
 
       // List of record type to not take into account
       // Could be avoided if a new index field is created FIXME ?

--- a/web-ui/src/main/resources/catalog/templates/editor/import.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/import.html
@@ -268,6 +268,7 @@
               <div class="col-sm-7">
                 <div id="gn-import-assigngroup-list"
                      data-groups-combo=""
+                     data-optional="{{user.isAdministrator()}}"
                      data-owner-group="params.group"
                      lang="lang"
                      data-groups="groups" data-exclude-special-groups="true"/>


### PR DESCRIPTION
* Import / Group contains blank value only if admin
* Avoid duplicated empty option in list (add optional first and select first item)
* New metadata / Don't select first user group in the list - let the group combo directive take care of the default based on config.

https://jira.swisstopo.ch/browse/MGEO_SB-580