### PR TITLE
Thesaurus / All / Add the possibility to exclude.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/AllThesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/AllThesaurus.java
@@ -51,6 +51,7 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -75,10 +76,13 @@ public class AllThesaurus extends Thesaurus {
     private final IsoLanguagesMapper isoLangMapper;
     private final String downloadUrl;
     private final String keywordUrl;
+    private List<String> allThesaurusExclude = new ArrayList<>();
 
-    public AllThesaurus(ThesaurusFinder thesaurusFinder, IsoLanguagesMapper isoLangMapper, String siteUrl) {
+
+    public AllThesaurus(ThesaurusFinder thesaurusFinder, IsoLanguagesMapper isoLangMapper, String siteUrl, List<String> allThesaurusExclude) {
         this.thesaurusFinder = thesaurusFinder;
         this.isoLangMapper = isoLangMapper;
+        this.allThesaurusExclude = allThesaurusExclude;
 
         this.downloadUrl = buildDownloadUrl(FNAME, TYPE, DNAME, siteUrl);
         this.keywordUrl = buildKeywordUrl(FNAME, TYPE, DNAME, siteUrl);
@@ -97,6 +101,15 @@ public class AllThesaurus extends Thesaurus {
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+
+    public List<String> getAllThesaurusExclude() {
+        return allThesaurusExclude;
+    }
+
+    public void setAllThesaurusExclude(List<String> allThesaurusExclude) {
+        this.allThesaurusExclude = allThesaurusExclude;
     }
 
     @Override
@@ -329,7 +342,8 @@ public class AllThesaurus extends Thesaurus {
 
     private <R> R onThesauri(R defaultVal, Function<Thesaurus, R> function) {
         for (Thesaurus thesaurus : this.thesaurusFinder.getThesauriMap().values()) {
-            if (ALL_THESAURUS_KEY.equals(thesaurus.getKey())) {
+            if (ALL_THESAURUS_KEY.equals(thesaurus.getKey())
+            || allThesaurusExclude.contains(thesaurus.getKey())) {
                 continue;
             }
             final R result = function.apply(thesaurus);

--- a/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
@@ -30,10 +30,7 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.SQLException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -69,6 +66,8 @@ import com.google.common.collect.Maps;
 
 import jeeves.server.context.ServiceContext;
 import jeeves.xlink.Processor;
+import org.openrdf.sesame.sailimpl.memory.RdfSchemaRepositoryConfig;
+import org.springframework.beans.factory.config.ListFactoryBean;
 
 
 public class ThesaurusManager implements ThesaurusFinder {
@@ -79,6 +78,15 @@ public class ThesaurusManager implements ThesaurusFinder {
     private Path thesauriDirectory = null;
     private boolean initialized = false;
     private AllThesaurus allThesaurus;
+    private List<String> allThesaurusExclude = new ArrayList<>();
+
+    public void setAllThesaurusExclude(List<String> allThesaurusExclude) {
+        this.allThesaurusExclude = allThesaurusExclude;
+    }
+
+    public List<String> getAllThesaurusExclude() {
+        return allThesaurusExclude;
+    }
 
     /**
      * Initialize ThesaurusManager.
@@ -95,7 +103,7 @@ public class ThesaurusManager implements ThesaurusFinder {
         this.settingManager = context.getBean(SettingManager.class);
 
         final String siteURL = this.settingManager.getSiteURL(context);
-        this.allThesaurus = new AllThesaurus(this, getIsoLanguagesMapper(context), siteURL);
+        this.allThesaurus = new AllThesaurus(this, getIsoLanguagesMapper(context), siteURL, allThesaurusExclude);
 
         // Get Sesame interface
         service = Sesame.getService();
@@ -289,7 +297,7 @@ public class ThesaurusManager implements ThesaurusFinder {
             RepositoryConfig repConfig = new RepositoryConfig(gst.getKey());
 
             SailConfig syncSail = new SailConfig("org.openrdf.sesame.sailimpl.sync.SyncRdfSchemaRepository");
-            SailConfig memSail = new org.openrdf.sesame.sailimpl.memory.RdfSchemaRepositoryConfig(
+            SailConfig memSail = new RdfSchemaRepositoryConfig(
                 gst.getFile().toAbsolutePath().toString(), RDFFormat.RDFXML);
             repConfig.addSail(syncSail);
             repConfig.addSail(memSail);
@@ -399,7 +407,7 @@ public class ThesaurusManager implements ThesaurusFinder {
     }
 
     /**
-     * @return {@link org.jdom.Element}
+     * @return {@link Element}
      */
     public Element buildResultfromThTable(ServiceContext context) throws SQLException, JDOMException, IOException {
 

--- a/core/src/main/resources/config-spring-geonetwork-parent.xml
+++ b/core/src/main/resources/config-spring-geonetwork-parent.xml
@@ -24,14 +24,19 @@
 
 <beans
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://www.springframework.org/schema/beans"
-  xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-    ">
+  xmlns="http://www.springframework.org/schema/beans" xmlns:util="http://www.springframework.org/schema/util"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
   <bean id="threadPool" class="org.fao.geonet.util.ThreadPool"/>
   <bean id="SchemaManager" class="org.fao.geonet.kernel.SchemaManager" lazy-init="true"/>
-  <bean id="ThesaurusManager" class="org.fao.geonet.kernel.ThesaurusManager" lazy-init="true"/>
+
+  <util:list id="allThesaurusExclude">
+    <value>external.theme.access_use_conditions</value>
+  </util:list>
+
+  <bean id="ThesaurusManager" class="org.fao.geonet.kernel.ThesaurusManager" lazy-init="true">
+    <property name="allThesaurusExclude" ref="allThesaurusExclude"/>
+  </bean>
   <bean id="languageProfilesDir" class="java.lang.String">
     <constructor-arg index="0" value="resources/language-profiles"/>
   </bean>

--- a/core/src/test/java/org/fao/geonet/kernel/AllThesaurusTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/AllThesaurusTest.java
@@ -28,7 +28,6 @@ import com.google.common.collect.Maps;
 import org.fao.geonet.exceptions.TermNotFoundException;
 import org.fao.geonet.kernel.search.keyword.KeywordRelation;
 import org.fao.geonet.kernel.search.keyword.KeywordSearchParamsBuilder;
-import org.fao.geonet.utils.IO;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -41,6 +40,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -105,7 +105,7 @@ public class AllThesaurusTest extends AbstractThesaurusBasedTest {
             }
         };
 
-        this.allThesaurus = new AllThesaurus(thesaurusFinder, isoLangMapper, "http://test.com");
+        this.allThesaurus = new AllThesaurus(thesaurusFinder, isoLangMapper, "http://test.com", new ArrayList<>());
     }
 
     @Test
@@ -288,7 +288,7 @@ public class AllThesaurusTest extends AbstractThesaurusBasedTest {
         Mockito.when(thesaurusFinder.getThesaurusByName(regionsThesaurus.getKey())).thenReturn(regionsThesaurus);
         Mockito.when(thesaurusFinder.existsThesaurus(regionsThesaurus.getKey())).thenReturn(true);
 
-        this.allThesaurus = new AllThesaurus(thesaurusFinder, isoLangMapper, "http://blah.com");
+        this.allThesaurus = new AllThesaurus(thesaurusFinder, isoLangMapper, "http://blah.com", new ArrayList<>());
         thesauri.put(AllThesaurus.ALL_THESAURUS_KEY, this.allThesaurus);
 
         final KeywordBean country = regionsThesaurus.getKeyword("http://geonetwork-opensource.org/regions#country", "eng");

--- a/core/src/test/java/org/fao/geonet/kernel/search/KeywordsSearcherTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/KeywordsSearcherTest.java
@@ -41,13 +41,7 @@ import org.junit.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -571,7 +565,7 @@ public class KeywordsSearcherTest extends AbstractThesaurusBasedTest {
 
     @Test
     public void testAllThesaurusSortedLimitedNumber() throws Exception {
-        thesaurusMap.put(AllThesaurus.ALL_THESAURUS_KEY, new AllThesaurus(thesaurusFinder, isoLangMapper, "http://siteurl.com"));
+        thesaurusMap.put(AllThesaurus.ALL_THESAURUS_KEY, new AllThesaurus(thesaurusFinder, isoLangMapper, "http://siteurl.com", new ArrayList<>()));
         KeywordsSearcher searcher = new KeywordsSearcher(isoLangMapper, thesaurusFinder);
         String searchTerm = "1";
         Element params = new Element("params").
@@ -610,6 +604,41 @@ public class KeywordsSearcherTest extends AbstractThesaurusBasedTest {
                 // ignore
             }
         }
+    }
+
+    @Test
+    public void testAllThesaurusExclude() throws Exception {
+        thesaurusMap.put(AllThesaurus.ALL_THESAURUS_KEY,
+            new AllThesaurus(thesaurusFinder, isoLangMapper,
+                "http://siteurl.com",
+                new ArrayList<>()));
+        KeywordsSearcher searcher = new KeywordsSearcher(isoLangMapper, thesaurusFinder);
+        Element params = new Element("params").
+            addContent(new Element("pNewSearch").setText("true")).
+            addContent(new Element("pTypeSearch").setText("" + KeywordSearchType.CONTAINS.ordinal())).
+            addContent(new Element("pThesauri").setText(AllThesaurus.ALL_THESAURUS_KEY)).
+            addContent(new Element("pMode").setText("searchBox")).
+            addContent(new Element("pLanguage").setText("eng"));
+        searcher.search("eng", params);
+        List<KeywordBean> results = searcher.getResults();
+        int allKeywords = results.size();
+
+        String excludeThesaurus = "test.test.testThesaurus";
+        params.getChild("pThesauri").setText(excludeThesaurus);
+        searcher.search("eng", params);
+        int excluded = searcher.getResults().size();
+
+        thesaurusMap.put(AllThesaurus.ALL_THESAURUS_KEY,
+            new AllThesaurus(thesaurusFinder, isoLangMapper,
+                "http://siteurl.com",
+                Arrays.asList(new String[]{"test.test.testThesaurus"})));
+        searcher = new KeywordsSearcher(isoLangMapper, thesaurusFinder);
+        params.getChild("pThesauri").setText(AllThesaurus.ALL_THESAURUS_KEY);
+        searcher.search("eng", params);
+        results = searcher.getResults();
+        int allKeywordsMinusExcluded = results.size();
+
+        assertTrue(allKeywordsMinusExcluded + excluded == allKeywords);
     }
 
     private void assertStartsWith(List<KeywordBean> results, int i, String prefix) {


### PR DESCRIPTION
>
> In some setup, a thesaurus is used to populate a field which is not a keyword. In that case, the catalogue should not list those thesaurus element for general keywords so that the thesaurus is only used to populate the specific field.