### PR TITLE
geocat.ch / Home / Topic aggregation mixing languages

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -106,7 +106,7 @@ goog.require('gn_alert');
               'terms': {
                 'field': 'cl_topic.key',
                 'size': 25,
-                'include': '[A-Za-z_]+'
+                'include': '[a-z]{1}[a-zA-Z]+'
               }
             },
             'groupOwner': {


### PR DESCRIPTION
* First level codelist values always start with lowercase letter
* Only allow first level aggregation codelist values (without "_")
* Exclude values with " " eg. geoinfo records - see https://jira.swisstopo.ch/browse/MGEO_SB-675

Also applied to dev which was also displaying values with " " and as such mixing language due to geoinfo records using translations instead of codelist key in their records. A better long term fix, would be to also update those metadata records.