### PR TITLE
INSPIRE conformity improvement

### DIFF
--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/convert/to19139.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/convert/to19139.xsl
@@ -9,6 +9,10 @@
                 exclude-result-prefixes="#all">
   <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
 
+  <xsl:variable name="langId"
+                select="/che:CHE_MD_Metadata/gmd:language/*/@codeListValue"/>
+
+
   <!-- Some default values -->
   <xsl:template match="gmd:metadataStandardName">
     <gmd:metadataStandardName>
@@ -20,6 +24,23 @@
     <gmd:metadataStandardVersion>
       <gco:CharacterString/>
     </gmd:metadataStandardVersion>
+  </xsl:template>
+
+  <xsl:template match="che:*[not(@gco:isoType)]" priority="100"/>
+
+  <xsl:template match="@xsi:type[.='che:PT_FreeURL_PropertyType']" priority="2">
+    <xsl:apply-templates mode="url" select=".."/>
+  </xsl:template>
+
+  <xsl:template match="gmd:linkage">
+    <gmd:linkage>
+      <gmd:URL>
+        <xsl:value-of select="(che:LocalisedURL
+                      |*/che:URLGroup/che:LocalisedURL[@locale = $langId]
+                      |gmd:URL
+                      |*/che:URLGroup/che:LocalisedURL[. != ''])[1]"/>
+      </gmd:URL>
+    </gmd:linkage>
   </xsl:template>
 
   <!-- Remove all non ISO19139 enumeration value. -->

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/convert/to19139.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/convert/to19139.xsl
@@ -22,6 +22,9 @@
     </gmd:metadataStandardVersion>
   </xsl:template>
 
+  <!-- Remove all non ISO19139 enumeration value. -->
+  <xsl:template match="gmd:topicCategory[contains(*, '_')]" priority="2"/>
+
   <!-- All profil specific elements should be bypassed -->
   <xsl:template match="che:*[not(@gco:isoType)]" priority="2"/>
 

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/inflate-metadata.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/inflate-metadata.xsl
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet   xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+                  xmlns:gco="http://www.isotc211.org/2005/gco"
+                  xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                  exclude-result-prefixes="#all">
+  <xsl:import href="../iso19139/inflate-metadata.xsl"/>
+</xsl:stylesheet>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
@@ -43,7 +43,14 @@
     <for name="gco:Integer" use="number"/>
     <for name="gco:Real" use="number"/>
     <for name="gco:Boolean" use="checkbox"/>
-
+    <for name="gco:Boolean"
+         xpath="/che:CHE_MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:pass"
+         use="data-gn-checkbox-with-nilreason">
+      <directiveAttributes
+        data-tag-name="gmd:pass"
+        data-nilreason="eval#@gco:nilReason"
+        data-labels='{"true": "conformant", "false": "notConformant", "unknown": "notEvaluated"}'/>
+    </for>
 
     <for name="gco:Date" use="data-gn-date-picker"/>
     <for name="gco:DateTime" use="data-gn-date-picker"/>
@@ -472,6 +479,9 @@
         <thesaurus key="external.none.allThesaurus"
                    transformations="to-iso19139-keyword-as-xlink"
                    />
+        <thesaurus key="external.theme.httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory-SpatialDataServiceCategory"
+                   transformations="to-iso19139-keyword-as-xlink-with-anchor"
+                   />
       </thesaurusList>
     </view>
     <view name="advanced">
@@ -571,6 +581,9 @@
         <thesaurus key="external.none.allThesaurus"
                    transformations="to-iso19139-keyword-as-xlink"
                    />
+        <thesaurus key="external.theme.httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory-SpatialDataServiceCategory"
+                   transformations="to-iso19139-keyword-as-xlink-with-anchor"
+        />
       </thesaurusList>
     </view>
     <view name="bgdi">

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/process/geocat-inspire-conformity.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/process/geocat-inspire-conformity.xsl
@@ -423,7 +423,7 @@
         </xsl:variable>
 
         <gmd:descriptiveKeywords
-          xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory-SpatialDataServiceCategory&amp;id={$serviceTypeMapping[@key = $serviceType]/@value}&amp;lang={$threeLettersLanguageCodeList}"/>
+          xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory-SpatialDataServiceCategory&amp;id={$serviceTypeMapping[@key = $serviceType]/@value}&amp;lang={$threeLettersLanguageCodeList}&amp;transformation=to-iso19139-keyword-with-anchor"/>
       </xsl:if>
 
 
@@ -766,7 +766,7 @@
             <gmd:level>
               <gmd:MD_ScopeCode
                 codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode"
-                codeListValue="dataset"/>
+                codeListValue="{if ($isService) then 'service' else 'dataset'}"/>
             </gmd:level>
           </gmd:DQ_Scope>
         </gmd:scope>
@@ -775,7 +775,6 @@
           <gmd:LI_Lineage>
             <gmd:statement xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString>-</gco:CharacterString>
-              <!-- TODO: Multilingual content -->
             </gmd:statement>
           </gmd:LI_Lineage>
         </gmd:lineage>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/process/geocat-inspire-conformity.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/process/geocat-inspire-conformity.xsl
@@ -1,0 +1,558 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:srv="http://www.isotc211.org/2005/srv"
+                xmlns:che="http://www.geocat.ch/2008/che"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
+                xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                exclude-result-prefixes="#all"
+                version="2.0">
+
+  <xsl:output indent="yes"/>
+
+  <xsl:variable name="uuid"
+                select="/che:CHE_MD_Metadata//gmd:fileIdentifier/gco:CharacterString"/>
+
+  <xsl:variable name="hasSpatialScope"
+                select="count(/che:CHE_MD_Metadata/gmd:identificationInfo/*/gmd:descriptiveKeywords[*/gmd:thesaurusName/*/gmd:title/*/text() = 'Spatial scope']) > 0"/>
+
+  <xsl:param name="thesauriDir"
+             select="'/data/dev/gn/mongeosource/web/src/main/webapp/WEB-INF/data/config/codelist'"/>
+
+  <xsl:variable name="inspire-themes"
+                select="document(concat('file:///', $thesauriDir, '/external/thesauri/theme/httpinspireeceuropaeutheme-theme.rdf'))//skos:Concept"/>
+
+  <xsl:variable name="hasQualitySection"
+                select="count(/che:CHE_MD_Metadata/gmd:dataQualityInfo) > 0"/>
+
+  <xsl:variable name="hasQualityReport10892010"
+                select="count(/che:CHE_MD_Metadata/gmd:dataQualityInfo/*/
+                  gmd:report/gmd:DQ_DomainConsistency/gmd:result/*/
+                    gmd:specification/*/gmd:title[
+                      contains(*[1]/text(), '1089/2010')]) > 0"/>
+
+  <xsl:variable name="hasQualityReport9762009"
+                select="count(/che:CHE_MD_Metadata/gmd:dataQualityInfo/*/
+                  gmd:report/gmd:DQ_DomainConsistency/gmd:result/*/
+                    gmd:specification/*/gmd:title[
+                      contains(*[1]/text(), '976/2009')]) > 0"/>
+
+  <xsl:variable name="isService"
+                select="count(/che:CHE_MD_Metadata/*/srv:SV_ServiceIdentification) > 0"/>
+
+  <xsl:variable name="mainLanguage"
+                select="/che:CHE_MD_Metadata/gmd:language/gmd:LanguageCode/@codeListValue"/>
+
+  <xsl:variable name="threeLettersLanguageCodeList"
+                select="string-join(($mainLanguage|/che:CHE_MD_Metadata/gmd:locale/*/
+                          gmd:languageCode/*/@codeListValue[. != $mainLanguage]), ',')"/>
+
+  <xsl:variable name="contactXlinkRoleExpression"
+                select="'~(distributor|processor|owner|originator|resourceProvider|custodian|author|principalInvestigator|distributor)'"/>
+
+  <!-- Metadata / Role is pointOfContact -->
+  <xsl:template match="che:CHE_MD_Metadata/gmd:contact
+                        /@xlink:href[matches(., $contactXlinkRoleExpression)]">
+    <xsl:message select="concat('INSPIRE|', $uuid, '|Metadata|Contact: Change role to pointOfContact.')"/>
+    <xsl:attribute name="xlink:href"
+                   select="replace(., $contactXlinkRoleExpression, '~pointOfContact')"/>
+  </xsl:template>
+
+  <!-- Resource / Identification / Temporal reference / LastRevision -->
+  <xsl:template match="@codeListValue[. = 'lastRevision']">
+    <xsl:message select="concat('INSPIRE|', $uuid, '|Identification|Date: Replace lastRevision by revision.')"/>
+    <xsl:attribute name="codeListValue"
+                   select="'revision'"/>
+  </xsl:template>
+
+
+  <xsl:template match="che:CHE_MD_Metadata">
+    <xsl:copy>
+      <xsl:copy-of select="@*"/>
+
+      <xsl:apply-templates select="
+        gmd:fileIdentifier|
+        gmd:language|
+        gmd:characterSet|
+        gmd:parentIdentifier|
+        gmd:hierarchyLevel"/>
+
+      <xsl:if test="not(gmd:hierarchyLevel)">
+        <xsl:message select="concat('INSPIRE|', $uuid, '|Metadata|Add hierarchy level.')"/>
+        <gmd:hierarchyLevel>
+          <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode"
+                            codeListValue="{if ($isService) then 'service' else 'dataset'}"/>
+        </gmd:hierarchyLevel>
+      </xsl:if>
+
+
+      <xsl:apply-templates select="
+        gmd:hierarchyLevelName|
+        gmd:contact|
+        gmd:dateStamp|
+        gmd:metadataStandardName|
+        gmd:metadataStandardVersion|
+        gmd:dataSetURI|
+        gmd:locale|
+        gmd:spatialRepresentationInfo|
+        gmd:referenceSystemInfo"/>
+
+      <xsl:if test="not(gmd:referenceSystemInfo) and not($isService)">
+        <xsl:message select="concat('INSPIRE|', $uuid, '|CRS|Add default EPSG:2056.')"/>
+        <gmd:referenceSystemInfo>
+          <gmd:MD_ReferenceSystem>
+            <gmd:referenceSystemIdentifier>
+              <gmd:RS_Identifier>
+                <gmd:code xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>EPSG:2056</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#DE">EPSG:2056</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#FR">EPSG:2056</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#IT">EPSG:2056</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#EN">EPSG:2056</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:code>
+              </gmd:RS_Identifier>
+            </gmd:referenceSystemIdentifier>
+          </gmd:MD_ReferenceSystem>
+        </gmd:referenceSystemInfo>
+      </xsl:if>
+
+      <xsl:apply-templates select="
+        gmd:metadataExtensionInfo|
+        gmd:identificationInfo|
+        gmd:contentInfo|
+        gmd:distributionInfo|
+        gmd:dataQualityInfo"/>
+
+      <!-- Resource / Quality / Lineage -->
+      <xsl:if test="not($hasQualitySection)">
+        <xsl:call-template name="create-dq-section"/>
+      </xsl:if>
+
+      <xsl:apply-templates select="
+        gmd:portrayalCatalogueInfo|
+        gmd:metadataConstraints|
+        gmd:applicationSchemaInfo|
+        gmd:metadataMaintenance|
+        gmd:series|
+        gmd:describes|
+        gmd:propertyType|
+        gmd:featureType|
+        gmd:featureAttribute"/>
+
+      <xsl:apply-templates select="
+        *[namespace-uri()!='http://www.isotc211.org/2005/gmd' and
+          namespace-uri()!='http://www.isotc211.org/2005/srv']"/>
+    </xsl:copy>
+  </xsl:template>
+
+
+  <xsl:template match="gmd:identificationInfo/*">
+    <xsl:copy>
+      <xsl:copy-of select="@*"/>
+      <xsl:apply-templates select="gmd:citation"/>
+      <xsl:apply-templates select="gmd:abstract"/>
+      <xsl:apply-templates select="gmd:purpose"/>
+      <xsl:apply-templates select="gmd:credit"/>
+      <xsl:apply-templates select="gmd:status"/>
+
+      <!-- Resource / Responsible organization missing -->
+      <xsl:apply-templates select="gmd:pointOfContact"/>
+      <xsl:if test="count(gmd:pointOfContact) = 0">
+        <xsl:message
+          select="concat('INSPIRE|', $uuid, '|Identification|Point of contact: copy first metadata contact as resource contact.')"/>
+        <gmd:pointOfContact xlink:href="{replace(
+                              ancestor::che:CHE_MD_Metadata/gmd:contact[1]/@xlink:href,
+                              $contactXlinkRoleExpression,
+                              '~pointOfContact')}"/>
+      </xsl:if>
+
+      <xsl:apply-templates select="gmd:resourceMaintenance"/>
+      <xsl:apply-templates select="gmd:graphicOverview"/>
+      <xsl:apply-templates select="gmd:resourceFormat"/>
+      <xsl:apply-templates select="gmd:descriptiveKeywords"/>
+
+      <xsl:variable name="hasClassificationOfService"
+                    select="count(gmd:descriptiveKeywords[contains(@xlink:href, 'httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory')]) > 0"/>
+      <xsl:if test="$isService and not($hasClassificationOfService)">
+        <xsl:variable name="serviceType"
+                      select="srv:serviceType/gco:LocalName"/>
+        <!-- TODO: Can't add keyword with XLink and Anchor -->
+        <xsl:message
+          select="concat('INSPIRE|', $uuid, '|Service: Add missing service classification based on service type ', $serviceType, '.')"/>
+
+        <xsl:variable name="serviceTypeMapping" as="node()*">
+          <entry key="download"
+                 value="http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialDataServiceCategory%2FinfoProductAccessService"/>
+          <entry key="OGC:WFS"
+                 value="http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialDataServiceCategory%2FinfoProductAccessService"/>
+          <entry key="view"
+                 value="http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialDataServiceCategory%2FinfoMapAccessService"/>
+          <entry key="OGC:WMS"
+                 value="http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialDataServiceCategory%2FinfoMapAccessService"/>
+          <entry key="OGC:WMTS"
+                 value="http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialDataServiceCategory%2FinfoMapAccessService"/>
+          <entry key="discovery"
+                 value="http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialDataServiceCategory%2FinfoCatalogueService"/>
+          <entry key="OGC:CSW"
+                 value="http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialDataServiceCategory%2FinfoCatalogueService"/>
+        </xsl:variable>
+
+        <gmd:descriptiveKeywords
+          xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory-SpatialDataServiceCategory&amp;id={$serviceTypeMapping[@key = $serviceType]/@value}&amp;lang={$threeLettersLanguageCodeList}"/>
+      </xsl:if>
+
+
+      <xsl:variable name="basicGeodataIDType"
+                    select="che:basicGeodataIDType/che:basicGeodataIDTypeCode/@codeListValue"/>
+      <xsl:variable name="hasSpatialScope"
+                    select="count(gmd:descriptiveKeywords[contains(@xlink:href, 'httpinspireeceuropaeumetadatacodelistSpatialScope')]) > 0"/>
+
+      <xsl:if test="not($hasSpatialScope)">
+        <xsl:choose>
+          <xsl:when test="$basicGeodataIDType = 'federal'">
+            <gmd:descriptiveKeywords xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope&amp;id=http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialScope%2Fnational&amp;lang={$threeLettersLanguageCodeList}"/>
+          </xsl:when>
+          <xsl:when test="$basicGeodataIDType = 'cantonal'">
+            <gmd:descriptiveKeywords xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope&amp;id=http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialScope%2Fregional&amp;lang={$threeLettersLanguageCodeList}"/>
+          </xsl:when>
+          <xsl:when test="$basicGeodataIDType = 'communal'">
+            <gmd:descriptiveKeywords xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope&amp;id=http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialScope%2Flocal&amp;lang={$threeLettersLanguageCodeList}"/>
+          </xsl:when>
+        </xsl:choose>
+      </xsl:if>
+
+      <xsl:apply-templates select="gmd:resourceSpecificUsage"/>
+
+      <!-- Resource / Access constraint / Limitation on public access AND condition to access and use TODO -->
+      <xsl:apply-templates select="gmd:resourceConstraints"/>
+
+      <xsl:if test="not($isService) and not(gmd:resourceConstraints)">
+        <xsl:message
+          select="concat('INSPIRE|', $uuid, '|Identification|Adding default resource constraints.')"/>
+        <gmd:resourceConstraints>
+          <gmd:MD_LegalConstraints>
+            <gmd:accessConstraints>
+              <gmd:MD_RestrictionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_RestrictionCode"
+                                      codeListValue="otherRestrictions"/>
+            </gmd:accessConstraints>
+            <gmd:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
+              <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">No limitations to public access</gmx:Anchor>
+              <gmd:PT_FreeText>
+                <gmd:textGroup>
+                  <gmd:LocalisedCharacterString locale="#DE">No limitations to public access</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+                <gmd:textGroup>
+                  <gmd:LocalisedCharacterString locale="#FR">No limitations to public access</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+                <gmd:textGroup>
+                  <gmd:LocalisedCharacterString locale="#IT">No limitations to public access</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+                <gmd:textGroup>
+                  <gmd:LocalisedCharacterString locale="#EN">No limitations to public access</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+              </gmd:PT_FreeText>
+            </gmd:otherConstraints>
+          </gmd:MD_LegalConstraints>
+        </gmd:resourceConstraints>
+        <gmd:resourceConstraints>
+          <gmd:MD_LegalConstraints>
+            <gmd:useConstraints>
+              <gmd:MD_RestrictionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_RestrictionCode"
+                                      codeListValue="otherRestrictions"/>
+            </gmd:useConstraints>
+            <gmd:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
+              <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/ConditionsApplyingToAccessAndUse/noConditionsApply">No conditions to access and use</gmx:Anchor>
+              <gmd:PT_FreeText>
+                <gmd:textGroup>
+                  <gmd:LocalisedCharacterString locale="#DE">No conditions to access and use</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+                <gmd:textGroup>
+                  <gmd:LocalisedCharacterString locale="#FR">No conditions to access and use</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+                <gmd:textGroup>
+                  <gmd:LocalisedCharacterString locale="#IT">No conditions to access and use</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+                <gmd:textGroup>
+                  <gmd:LocalisedCharacterString locale="#EN">No conditions to access and use</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+              </gmd:PT_FreeText>
+            </gmd:otherConstraints>
+          </gmd:MD_LegalConstraints>
+        </gmd:resourceConstraints>
+
+      </xsl:if>
+
+      <xsl:apply-templates select="gmd:aggregationInfo"/>
+      <xsl:apply-templates select="gmd:spatialRepresentationType"/>
+
+      <!--
+       XML document 'file.xml', record '8fc6f748-80ce-47b2-8d49-b05a0c8ba975': The spatial representation type shall be given using at least one element gmd:spatialRepresentationType/gmd:MD_SpatialRepresentationTypeCode.
+       -->
+      <xsl:if test="not($isService) and not(gmd:spatialRepresentationType)">
+        <xsl:message
+          select="concat('INSPIRE|', $uuid, '|Identification|Spatial representation type: add default vector because missing.')"/>
+        <gmd:spatialRepresentationType>
+          <gmd:MD_SpatialRepresentationTypeCode
+            codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_SpatialRepresentationTypeCode"
+            codeListValue="vector"/>
+        </gmd:spatialRepresentationType>
+      </xsl:if>
+
+      <xsl:apply-templates select="gmd:spatialResolution"/>
+      <xsl:apply-templates select="gmd:language"/>
+      <xsl:apply-templates select="gmd:characterSet"/>
+      <xsl:apply-templates select="gmd:topicCategory"/>
+      <xsl:apply-templates select="gmd:environmentDescription"/>
+      <xsl:apply-templates select="gmd:extent"/>
+      <xsl:apply-templates select="gmd:supplementalInformation"/>
+
+      <xsl:apply-templates select="srv:*"/>
+      <xsl:apply-templates select="*[namespace-uri()!='http://www.isotc211.org/2005/gmd' and
+                                     namespace-uri()!='http://www.isotc211.org/2005/srv']"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="gmd:resourceConstraints[string-join((.//*|//@*), '') = '']">
+    <xsl:message
+      select="concat('AAAINSPIRE|', $uuid, '|Identification|Removing empty resource constraints.')"/>
+  </xsl:template>
+
+  <xsl:template match="gmd:identificationInfo/*/gmd:citation/*[
+                                not(gmd:identifier)
+                                and not($isService)]">
+    <xsl:copy>
+      <xsl:copy-of select="@*"/>
+      <xsl:variable name="elements"
+                    select="gmd:title|gmd:alternateTitle|gmd:date|gmd:edition|gmd:editionDate"/>
+      <xsl:apply-templates select="$elements"/>
+
+      <!-- Dataset / No resource identifier -->
+      <xsl:variable name="basicgeodataId"
+                    select="ancestor::gmd:identificationInfo/*/che:basicGeodataID/*/text()"/>
+      <gmd:identifier>
+        <gmd:MD_Identifier>
+          <gmd:code>
+            <gco:CharacterString>
+              <xsl:choose>
+                <xsl:when test="$basicgeodataId != ''">
+                  <xsl:message
+                    select="concat('INSPIRE|', $uuid, '|Identification|Resource identifier: copy basic geodata id ', $basicgeodataId , ' as identifier.')"/>
+                  <xsl:value-of select="$basicgeodataId"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:message
+                    select="concat('INSPIRE|', $uuid, '|Identification|Resource identifier: copy uuid ', $uuid , ' as identifier.')"/>
+                  <xsl:value-of select="$uuid"/>
+                </xsl:otherwise>
+              </xsl:choose>
+            </gco:CharacterString>
+          </gmd:code>
+        </gmd:MD_Identifier>
+      </gmd:identifier>
+
+      <xsl:apply-templates select="* except $elements"/>
+    </xsl:copy>
+  </xsl:template>
+
+
+  <xsl:template match="gmd:dataQualityInfo/*">
+    <xsl:copy>
+      <xsl:apply-templates select="gmd:scope"/>
+      <xsl:apply-templates select="gmd:report"/>
+      <xsl:call-template name="add-inspire-regulation-conformity"/>
+      <xsl:apply-templates select="gmd:lineage"/>
+    </xsl:copy>
+  </xsl:template>
+
+
+  <xsl:template name="add-inspire-regulation-conformity">
+    <xsl:if test="not($hasQualityReport10892010)">
+      <xsl:message select="concat('INSPIRE|', $uuid, '|DataQuality|Regulation: add conformity for metadata.')"/>
+      <gmd:report>
+        <gmd:DQ_DomainConsistency>
+          <gmd:result>
+            <gmd:DQ_ConformanceResult>
+              <gmd:specification>
+                <gmd:CI_Citation>
+                  <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gmx:Anchor xlink:href="http://data.europa.eu/eli/reg/2010/1089"></gmx:Anchor>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">Verordnung (EG) Nr. 1089/2010 der Kommission vom 23.
+                          November 2010 zur Durchführung der Richtlinie 2007/2/EG des Europäischen Parlaments und des
+                          Rates hinsichtlich der Interoperabilität von Geodatensätzen und -diensten
+                        </gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#FR">Règlement (UE) n ° 1089/2010 de la Commission du 23
+                          novembre 2010 portant modalités d'application de la directive 2007/2/CE du Parlement européen
+                          et du Conseil en ce qui concerne l'interopérabilité des séries et des services de données
+                          géographiques
+                        </gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#IT">Regolamento (UE) n. 1089/2010 della Commissione, del
+                          23 novembre 2010 , recante attuazione della direttiva 2007/2/CE del Parlamento europeo e del
+                          Consiglio per quanto riguarda l'interoperabilità dei set di dati territoriali e dei servizi di
+                          dati territoriali
+                        </gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#EN">Commission Regulation (EU) No 1089/2010 of 23
+                          November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council
+                          as regards interoperability of spatial data sets and services
+                        </gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gmd:title>
+                  <gmd:date>
+                    <gmd:CI_Date>
+                      <gmd:date>
+                        <gco:Date>2010-12-08</gco:Date>
+                      </gmd:date>
+                      <gmd:dateType>
+                        <gmd:CI_DateTypeCode
+                          codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"
+                          codeListValue="publication"/>
+                      </gmd:dateType>
+                    </gmd:CI_Date>
+                  </gmd:date>
+                </gmd:CI_Citation>
+              </gmd:specification>
+              <gmd:explanation>
+                <gco:CharacterString>See the referenced specification</gco:CharacterString>
+              </gmd:explanation>
+              <gmd:pass gco:nilReason="unknown"/>
+            </gmd:DQ_ConformanceResult>
+          </gmd:result>
+        </gmd:DQ_DomainConsistency>
+      </gmd:report>
+    </xsl:if>
+    <xsl:if test="$isService and not($hasQualityReport9762009)">
+      <xsl:message select="concat('INSPIRE|', $uuid, '|DataQuality|Regulation: add conformity for service.')"/>
+      <gmd:report>
+        <gmd:DQ_DomainConsistency>
+          <gmd:result>
+            <gmd:DQ_ConformanceResult>
+              <gmd:specification>
+                <gmd:CI_Citation>
+                  <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gmx:Anchor xlink:href="http://data.europa.eu/eli/reg/2009/976"></gmx:Anchor>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">Verordnung (EG) Nr. 976/2009 der Kommission vom 19.
+                          Oktober 2009 zur Durchführung der Richtlinie 2007/2/EG des Europäischen Parlaments und des
+                          Rates hinsichtlich der Netzdienste
+                        </gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#FR">Règlement (CE) n o 976/2009 de la Commission du 19
+                          octobre 2009 portant modalités d’application de la directive 2007/2/CE du Parlement européen
+                          et du Conseil en ce qui concerne les services en réseau
+                        </gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#IT">Regolamento (CE) n. 976/2009 della Commissione, del
+                          19 ottobre 2009 , recante attuazione della direttiva 2007/2/CE del Parlamento europeo e del
+                          Consiglio per quanto riguarda i servizi di rete
+                        </gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#EN">Commission Regulation (EC) No 976/2009 of 19 October
+                          2009 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards
+                          the Network Services
+                        </gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gmd:title>
+                  <gmd:date>
+                    <gmd:CI_Date>
+                      <gmd:date>
+                        <gco:Date>2009-10-19</gco:Date>
+                      </gmd:date>
+                      <gmd:dateType>
+                        <gmd:CI_DateTypeCode
+                          codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"
+                          codeListValue="publication"/>
+                      </gmd:dateType>
+                    </gmd:CI_Date>
+                  </gmd:date>
+                </gmd:CI_Citation>
+              </gmd:specification>
+              <gmd:explanation>
+                <gco:CharacterString>See the referenced specification</gco:CharacterString>
+              </gmd:explanation>
+              <gmd:pass gco:nilReason="unknown"/>
+            </gmd:DQ_ConformanceResult>
+          </gmd:result>
+        </gmd:DQ_DomainConsistency>
+      </gmd:report>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template name="create-dq-section">
+    <gmd:dataQualityInfo>
+      <gmd:DQ_DataQuality>
+        <gmd:scope>
+          <gmd:DQ_Scope>
+            <gmd:level>
+              <gmd:MD_ScopeCode
+                codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode"
+                codeListValue="dataset"/>
+            </gmd:level>
+          </gmd:DQ_Scope>
+        </gmd:scope>
+        <xsl:call-template name="add-inspire-regulation-conformity"/>
+        <gmd:lineage>
+          <gmd:LI_Lineage>
+            <gmd:statement xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>-</gco:CharacterString>
+              <!-- TODO: Multilingual content -->
+            </gmd:statement>
+          </gmd:LI_Lineage>
+        </gmd:lineage>
+      </gmd:DQ_DataQuality>
+    </gmd:dataQualityInfo>
+  </xsl:template>
+
+  <xsl:template match="srv:serviceType/gco:LocalName[. = 'OGC:CSW']">
+    <xsl:message select="concat('INSPIRE|', $uuid, '|Service| Replace OGC:CSW by discovery.')"/>
+    <gco:LocalName>discovery</gco:LocalName>
+  </xsl:template>
+  <xsl:template match="srv:serviceType/gco:LocalName[. = 'OGC:WFS']">
+    <xsl:message select="concat('INSPIRE|', $uuid, '|Service| Replace OGC:WFS by download.')"/>
+    <gco:LocalName>download</gco:LocalName>
+  </xsl:template>
+  <xsl:template match="srv:serviceType/gco:LocalName[. = ('OGC:WMS', 'OGC:WMTS', 'OGC:WMTS (Web Map Tile Service)')]">
+    <xsl:message select="concat('INSPIRE|', $uuid, '|Service: Replace OGC:WMT?S by view.')"/>
+    <gco:LocalName>view</gco:LocalName>
+  </xsl:template>
+
+
+  <!-- Do a copy of every nodes and attributes -->
+  <xsl:template match="@*|node()|comment()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()|comment()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Remove geonet:* elements. -->
+  <xsl:template match="geonet:*" priority="2"/>
+
+</xsl:stylesheet>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/process/geocat-inspire-conformity.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/process/geocat-inspire-conformity.xsl
@@ -242,9 +242,9 @@
       <!-- Resource / Access constraint / Limitation on public access AND condition to access and use TODO -->
       <xsl:apply-templates select="gmd:resourceConstraints"/>
 
-      <xsl:if test="not($isService) and not(gmd:resourceConstraints)">
+      <xsl:if test="not(gmd:resourceConstraints[*/gmd:accessConstraints])">
         <xsl:message
-          select="concat('INSPIRE|', $uuid, '|Identification|Adding default resource constraints.')"/>
+          select="concat('INSPIRE|', $uuid, '|Identification|Adding default access resource constraints.')"/>
         <gmd:resourceConstraints>
           <gmd:MD_LegalConstraints>
             <gmd:accessConstraints>
@@ -270,6 +270,11 @@
             </gmd:otherConstraints>
           </gmd:MD_LegalConstraints>
         </gmd:resourceConstraints>
+      </xsl:if>
+
+      <xsl:if test="not(gmd:resourceConstraints[*/gmd:useConstraints])">
+        <xsl:message
+          select="concat('INSPIRE|', $uuid, '|Identification|Adding default use access resource constraints.')"/>
         <gmd:resourceConstraints>
           <gmd:MD_LegalConstraints>
             <gmd:useConstraints>
@@ -532,15 +537,15 @@
   </xsl:template>
 
   <xsl:template match="srv:serviceType/gco:LocalName[. = 'OGC:CSW']">
-    <xsl:message select="concat('INSPIRE|', $uuid, '|Service| Replace OGC:CSW by discovery.')"/>
+    <xsl:message select="concat('INSPIRE|', $uuid, '|Service|Replace OGC:CSW by discovery.')"/>
     <gco:LocalName>discovery</gco:LocalName>
   </xsl:template>
   <xsl:template match="srv:serviceType/gco:LocalName[. = 'OGC:WFS']">
-    <xsl:message select="concat('INSPIRE|', $uuid, '|Service| Replace OGC:WFS by download.')"/>
+    <xsl:message select="concat('INSPIRE|', $uuid, '|Service|Replace OGC:WFS by download.')"/>
     <gco:LocalName>download</gco:LocalName>
   </xsl:template>
   <xsl:template match="srv:serviceType/gco:LocalName[. = ('OGC:WMS', 'OGC:WMTS', 'OGC:WMTS (Web Map Tile Service)')]">
-    <xsl:message select="concat('INSPIRE|', $uuid, '|Service: Replace OGC:WMT?S by view.')"/>
+    <xsl:message select="concat('INSPIRE|', $uuid, '|Service|Replace OGC:WMT?S by view.')"/>
     <gco:LocalName>view</gco:LocalName>
   </xsl:template>
 

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/process/geocat-inspire-conformity.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/process/geocat-inspire-conformity.xsl
@@ -6,9 +6,7 @@
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
-                xmlns:util="java:org.fao.geonet.util.XslUtil"
                 xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:geonet="http://www.fao.org/geonetwork"
                 exclude-result-prefixes="#all"
@@ -19,14 +17,204 @@
   <xsl:variable name="uuid"
                 select="/che:CHE_MD_Metadata//gmd:fileIdentifier/gco:CharacterString"/>
 
+
+  <xsl:variable name="ithemeTopiccatMap">
+    <entry>
+      <theme>Geographical names</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/gn</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/3</itheme>
+      <topiccat>location</topiccat>
+    </entry>
+    <entry>
+      <theme>Administrative units</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/au</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/4</itheme>
+      <topiccat>boundaries</topiccat>
+    </entry>
+    <entry>
+      <theme>Addresses</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/ad</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/5</itheme>
+      <topiccat>location</topiccat>
+    </entry>
+    <entry>
+      <theme>Cadastral parcels</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/cp</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/6</itheme>
+      <topiccat>planningCadastre</topiccat>
+    </entry>
+    <entry>
+      <theme>Transport networks</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/tn</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/7</itheme>
+      <topiccat>transportation</topiccat>
+    </entry>
+    <entry>
+      <theme>Hydrography</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/hy</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/8</itheme>
+      <topiccat>inlandWaters</topiccat>
+    </entry>
+    <entry>
+      <theme>Protected sites</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/ps</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/9</itheme>
+      <topiccat>environment</topiccat>
+    </entry>
+    <entry>
+      <theme>Elevation</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/el</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/10</itheme>
+      <topiccat>elevation</topiccat>
+    </entry>
+    <entry>
+      <theme>Land cover</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/lc</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/11</itheme>
+      <topiccat>imageryBaseMapsEarthCover</topiccat>
+    </entry>
+    <entry>
+      <theme>Orthoimagery</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/oi</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/12</itheme>
+      <topiccat>imageryBaseMapsEarthCover</topiccat>
+    </entry>
+    <entry>
+      <theme>Geology</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/ge</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/13</itheme>
+      <topiccat>geoscientificInformation</topiccat>
+    </entry>
+    <entry>
+      <theme>Statistical units</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/su</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/14</itheme>
+      <topiccat>boundaries</topiccat>
+    </entry>
+    <entry>
+      <theme>Buildings</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/bu</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/15</itheme>
+      <topiccat>structure</topiccat>
+    </entry>
+    <entry>
+      <theme>Soil</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/so</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/16</itheme>
+      <topiccat>geoscientificInformation</topiccat>
+    </entry>
+    <entry>
+      <theme>Land use</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/lu</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/17</itheme>
+      <topiccat>planningCadastre</topiccat>
+    </entry>
+    <entry>
+      <theme>Human health and safety</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/hh</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/18</itheme>
+      <topiccat>health</topiccat>
+    </entry>
+    <entry>
+      <theme>Utility and governmental services</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/us</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/19</itheme>
+      <topiccat>utilitiesCommunication</topiccat>
+    </entry>
+    <entry>
+      <theme>Environmental monitoring facilities</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/ef</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/20</itheme>
+      <topiccat>structure</topiccat>
+    </entry>
+    <entry>
+      <theme>Production and industrial facilities</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/pf</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/21</itheme>
+      <topiccat>structure</topiccat>
+    </entry>
+    <entry>
+      <theme>Agricultural and aquaculture facilities</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/af</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/22</itheme>
+      <topiccat>farming</topiccat>
+    </entry>
+    <entry>
+      <theme>Population distribution — demography</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/pd</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/23</itheme>
+      <topiccat>society</topiccat>
+    </entry>
+    <entry>
+      <theme>Area management/restriction/regulation zones and reporting units</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/am</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/24</itheme>
+      <topiccat>planningCadastre</topiccat>
+    </entry>
+    <entry>
+      <theme>Natural risk zones</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/nz</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/25</itheme>
+      <topiccat>geoscientificInformation</topiccat>
+    </entry>
+    <entry>
+      <theme>Atmospheric conditions</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/ac</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/26</itheme>
+      <topiccat>climatologyMeteorologyAtmosphere</topiccat>
+    </entry>
+    <entry>
+      <theme>Meteorological geographical features</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/mf</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/27</itheme>
+      <topiccat>climatologyMeteorologyAtmosphere</topiccat>
+    </entry>
+    <entry>
+      <theme>Oceanographic geographical features</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/of</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/28</itheme>
+      <topiccat>oceans</topiccat>
+    </entry>
+    <entry>
+      <theme>Sea regions</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/sr</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/29</itheme>
+      <topiccat>oceans</topiccat>
+    </entry>
+    <entry>
+      <theme>Bio-geographical regions</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/br</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/30</itheme>
+      <topiccat>biota</topiccat>
+    </entry>
+    <entry>
+      <theme>Habitats and biotopes</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/hb</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/31</itheme>
+      <topiccat>biota</topiccat>
+    </entry>
+    <entry>
+      <theme>Species distribution</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/sd</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/32</itheme>
+      <topiccat>biota</topiccat>
+    </entry>
+    <entry>
+      <theme>Energy resources</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/er</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/33</itheme>
+      <topiccat>economy</topiccat>
+    </entry>
+    <entry>
+      <theme>Mineral resources</theme>
+      <newitheme>http://inspire.ec.europa.eu/theme/mr</newitheme>
+      <itheme>http://rdfdata.eionet.europa.eu/inspirethemes/themes/34</itheme>
+      <topiccat>economy</topiccat>
+    </entry>
+  </xsl:variable>
+
   <xsl:variable name="hasSpatialScope"
                 select="count(/che:CHE_MD_Metadata/gmd:identificationInfo/*/gmd:descriptiveKeywords[*/gmd:thesaurusName/*/gmd:title/*/text() = 'Spatial scope']) > 0"/>
-
-  <xsl:param name="thesauriDir"
-             select="'/data/dev/gn/mongeosource/web/src/main/webapp/WEB-INF/data/config/codelist'"/>
-
-  <xsl:variable name="inspire-themes"
-                select="document(concat('file:///', $thesauriDir, '/external/thesauri/theme/httpinspireeceuropaeutheme-theme.rdf'))//skos:Concept"/>
 
   <xsl:variable name="hasQualitySection"
                 select="count(/che:CHE_MD_Metadata/gmd:dataQualityInfo) > 0"/>
@@ -86,8 +274,9 @@
       <xsl:if test="not(gmd:hierarchyLevel)">
         <xsl:message select="concat('INSPIRE|', $uuid, '|Metadata|Add hierarchy level.')"/>
         <gmd:hierarchyLevel>
-          <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode"
-                            codeListValue="{if ($isService) then 'service' else 'dataset'}"/>
+          <gmd:MD_ScopeCode
+            codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode"
+            codeListValue="{if ($isService) then 'service' else 'dataset'}"/>
         </gmd:hierarchyLevel>
       </xsl:if>
 
@@ -187,6 +376,26 @@
       <xsl:apply-templates select="gmd:resourceFormat"/>
       <xsl:apply-templates select="gmd:descriptiveKeywords"/>
 
+
+      <xsl:variable name="hasInspireKeywords"
+                    select="count(gmd:descriptiveKeywords[
+                              contains(@xlink:href,
+                              'thesaurus=external.theme.httpinspireeceuropaeutheme-theme')]) > 0"/>
+
+      <xsl:if test="not($hasInspireKeywords)">
+        <xsl:message
+          select="concat('INSPIRE|', $uuid, '|Identification|Add INSPIRE themes based on topic category.')"/>
+
+        <xsl:variable name="topics"
+                      select="gmd:topicCategory/*/text()"/>
+        <xsl:variable name="listOfId"
+                      select="string-join($ithemeTopiccatMap//entry[topiccat = $topics]/newitheme/encode-for-uri(.), ',')"/>
+
+        <gmd:descriptiveKeywords
+          xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.httpinspireeceuropaeutheme-theme&amp;id={$listOfId}&amp;lang={$threeLettersLanguageCodeList}"/>
+
+      </xsl:if>
+
       <xsl:variable name="hasClassificationOfService"
                     select="count(gmd:descriptiveKeywords[contains(@xlink:href, 'httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory')]) > 0"/>
       <xsl:if test="$isService and not($hasClassificationOfService)">
@@ -194,7 +403,7 @@
                       select="srv:serviceType/gco:LocalName"/>
         <!-- TODO: Can't add keyword with XLink and Anchor -->
         <xsl:message
-          select="concat('INSPIRE|', $uuid, '|Service: Add missing service classification based on service type ', $serviceType, '.')"/>
+          select="concat('INSPIRE|', $uuid, '|Service| Add missing service classification based on service type ', $serviceType, '.')"/>
 
         <xsl:variable name="serviceTypeMapping" as="node()*">
           <entry key="download"
@@ -226,13 +435,16 @@
       <xsl:if test="not($hasSpatialScope)">
         <xsl:choose>
           <xsl:when test="$basicGeodataIDType = 'federal'">
-            <gmd:descriptiveKeywords xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope&amp;id=http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialScope%2Fnational&amp;lang={$threeLettersLanguageCodeList}"/>
+            <gmd:descriptiveKeywords
+              xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope&amp;id=http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialScope%2Fnational&amp;lang={$threeLettersLanguageCodeList}"/>
           </xsl:when>
           <xsl:when test="$basicGeodataIDType = 'cantonal'">
-            <gmd:descriptiveKeywords xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope&amp;id=http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialScope%2Fregional&amp;lang={$threeLettersLanguageCodeList}"/>
+            <gmd:descriptiveKeywords
+              xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope&amp;id=http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialScope%2Fregional&amp;lang={$threeLettersLanguageCodeList}"/>
           </xsl:when>
           <xsl:when test="$basicGeodataIDType = 'communal'">
-            <gmd:descriptiveKeywords xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope&amp;id=http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialScope%2Flocal&amp;lang={$threeLettersLanguageCodeList}"/>
+            <gmd:descriptiveKeywords
+              xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope&amp;id=http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialScope%2Flocal&amp;lang={$threeLettersLanguageCodeList}"/>
           </xsl:when>
         </xsl:choose>
       </xsl:if>
@@ -248,23 +460,31 @@
         <gmd:resourceConstraints>
           <gmd:MD_LegalConstraints>
             <gmd:accessConstraints>
-              <gmd:MD_RestrictionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_RestrictionCode"
-                                      codeListValue="otherRestrictions"/>
+              <gmd:MD_RestrictionCode
+                codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_RestrictionCode"
+                codeListValue="otherRestrictions"/>
             </gmd:accessConstraints>
             <gmd:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
-              <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">No limitations to public access</gmx:Anchor>
+              <gmx:Anchor
+                xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">No
+                limitations to public access
+              </gmx:Anchor>
               <gmd:PT_FreeText>
                 <gmd:textGroup>
-                  <gmd:LocalisedCharacterString locale="#DE">No limitations to public access</gmd:LocalisedCharacterString>
+                  <gmd:LocalisedCharacterString locale="#DE">No limitations to public access
+                  </gmd:LocalisedCharacterString>
                 </gmd:textGroup>
                 <gmd:textGroup>
-                  <gmd:LocalisedCharacterString locale="#FR">No limitations to public access</gmd:LocalisedCharacterString>
+                  <gmd:LocalisedCharacterString locale="#FR">No limitations to public access
+                  </gmd:LocalisedCharacterString>
                 </gmd:textGroup>
                 <gmd:textGroup>
-                  <gmd:LocalisedCharacterString locale="#IT">No limitations to public access</gmd:LocalisedCharacterString>
+                  <gmd:LocalisedCharacterString locale="#IT">No limitations to public access
+                  </gmd:LocalisedCharacterString>
                 </gmd:textGroup>
                 <gmd:textGroup>
-                  <gmd:LocalisedCharacterString locale="#EN">No limitations to public access</gmd:LocalisedCharacterString>
+                  <gmd:LocalisedCharacterString locale="#EN">No limitations to public access
+                  </gmd:LocalisedCharacterString>
                 </gmd:textGroup>
               </gmd:PT_FreeText>
             </gmd:otherConstraints>
@@ -278,29 +498,36 @@
         <gmd:resourceConstraints>
           <gmd:MD_LegalConstraints>
             <gmd:useConstraints>
-              <gmd:MD_RestrictionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_RestrictionCode"
-                                      codeListValue="otherRestrictions"/>
+              <gmd:MD_RestrictionCode
+                codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_RestrictionCode"
+                codeListValue="otherRestrictions"/>
             </gmd:useConstraints>
             <gmd:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
-              <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/ConditionsApplyingToAccessAndUse/noConditionsApply">No conditions to access and use</gmx:Anchor>
+              <gmx:Anchor
+                xlink:href="http://inspire.ec.europa.eu/metadata-codelist/ConditionsApplyingToAccessAndUse/noConditionsApply">
+                No conditions to access and use
+              </gmx:Anchor>
               <gmd:PT_FreeText>
                 <gmd:textGroup>
-                  <gmd:LocalisedCharacterString locale="#DE">No conditions to access and use</gmd:LocalisedCharacterString>
+                  <gmd:LocalisedCharacterString locale="#DE">No conditions to access and use
+                  </gmd:LocalisedCharacterString>
                 </gmd:textGroup>
                 <gmd:textGroup>
-                  <gmd:LocalisedCharacterString locale="#FR">No conditions to access and use</gmd:LocalisedCharacterString>
+                  <gmd:LocalisedCharacterString locale="#FR">No conditions to access and use
+                  </gmd:LocalisedCharacterString>
                 </gmd:textGroup>
                 <gmd:textGroup>
-                  <gmd:LocalisedCharacterString locale="#IT">No conditions to access and use</gmd:LocalisedCharacterString>
+                  <gmd:LocalisedCharacterString locale="#IT">No conditions to access and use
+                  </gmd:LocalisedCharacterString>
                 </gmd:textGroup>
                 <gmd:textGroup>
-                  <gmd:LocalisedCharacterString locale="#EN">No conditions to access and use</gmd:LocalisedCharacterString>
+                  <gmd:LocalisedCharacterString locale="#EN">No conditions to access and use
+                  </gmd:LocalisedCharacterString>
                 </gmd:textGroup>
               </gmd:PT_FreeText>
             </gmd:otherConstraints>
           </gmd:MD_LegalConstraints>
         </gmd:resourceConstraints>
-
       </xsl:if>
 
       <xsl:apply-templates select="gmd:aggregationInfo"/>
@@ -333,10 +560,30 @@
     </xsl:copy>
   </xsl:template>
 
+
+  <xsl:template match="gmd:distributionInfo/*[not(gmd:distributionFormat)]">
+    <xsl:copy>
+      <xsl:copy-of select="@*"/>
+      <xsl:apply-templates select="gmd:distributionFormat"/>
+      <xsl:for-each select="gmd:distributor//gmd:distributorFormat">
+        <xsl:message
+          select="concat('INSPIRE|', $uuid, '|Distribution|Move distribution format from distributor to distributionInfo.')"/>
+        <gmd:distributionFormat>
+          <xsl:copy-of select="@*"/>
+        </gmd:distributionFormat>
+      </xsl:for-each>
+      <xsl:apply-templates select="gmd:distributor"/>
+      <xsl:apply-templates select="gmd:transferOptions"/>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="gmd:distributionInfo/*/gmd:distributor/*/gmd:distributorFormat"/>
+
+
   <xsl:template match="gmd:resourceConstraints[string-join((.//*|//@*), '') = '']">
     <xsl:message
-      select="concat('AAAINSPIRE|', $uuid, '|Identification|Removing empty resource constraints.')"/>
+      select="concat('INSPIRE|', $uuid, '|Identification|Removing empty resource constraints.')"/>
   </xsl:template>
+
 
   <xsl:template match="gmd:identificationInfo/*/gmd:citation/*[
                                 not(gmd:identifier)
@@ -358,7 +605,7 @@
                 <xsl:when test="$basicgeodataId != ''">
                   <xsl:message
                     select="concat('INSPIRE|', $uuid, '|Identification|Resource identifier: copy basic geodata id ', $basicgeodataId , ' as identifier.')"/>
-                  <xsl:value-of select="$basicgeodataId"/>
+                  <xsl:value-of select="concat('basicGeodataID:', $basicgeodataId)"/>
                 </xsl:when>
                 <xsl:otherwise>
                   <xsl:message

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/update-fixed-info.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/update-fixed-info.xsl
@@ -972,6 +972,23 @@ is defined in record. If not, remove the element. -->
     </xsl:copy>
   </xsl:template>
 
+
+  <!-- Remove empty boolean  and set gco:nilReason='unknown' -->
+  <xsl:template match="*[gco:Boolean and not(string(gco:Boolean))]">
+    <xsl:copy>
+      <xsl:copy-of select="@*[name() != 'gco:nilReason']" />
+      <xsl:attribute name="gco:nilReason">unknown</xsl:attribute>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Remove gco:nilReason if not empty boolean -->
+  <xsl:template match="*[string(gco:Boolean)]">
+    <xsl:copy>
+      <xsl:copy-of select="@*[name() != 'gco:nilReason']" />
+      <xsl:apply-templates select="*" />
+    </xsl:copy>
+  </xsl:template>
+
   <!-- copy everything else as is -->
 
   <xsl:template match="@*|node()">

--- a/schemas/iso19139.che/src/test/java/org/fao/geonet/schemas/InspireMigrationProcessTest.java
+++ b/schemas/iso19139.che/src/test/java/org/fao/geonet/schemas/InspireMigrationProcessTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.schemas;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.fao.geonet.schema.iso19139.ISO19139Namespaces;
+import org.fao.geonet.schema.iso19139che.ISO19139cheNamespaces;
+import org.fao.geonet.schema.iso19139che.ISO19139cheSchemaPlugin;
+import org.fao.geonet.util.XslUtil;
+import org.fao.geonet.utils.TransformerFactoryFactory;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
+import org.jdom.Namespace;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.builder.Input;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.Diff;
+import org.xmlunit.diff.ElementSelectors;
+
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.xmlunit.matchers.EvaluateXPathMatcher.hasXPath;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(XslUtil.class)
+public class InspireMigrationProcessTest {
+
+    static private Path PATH_TO_XSL;
+
+    static private ImmutableSet<Namespace> ALL_NAMESPACES = ImmutableSet.<Namespace>builder()
+        .add(ISO19139Namespaces.GCO)
+        .add(ISO19139Namespaces.GMD)
+        .add(ISO19139Namespaces.SRV)
+        .add(ISO19139Namespaces.GMX)
+        .add(ISO19139Namespaces.XSI)
+        .add(ISO19139Namespaces.XLINK)
+        .add(ISO19139cheNamespaces.CHE)
+        .build();
+    static private ImmutableMap<String, String> ALL_NS = ImmutableMap.<String, String>builder()
+        .put(ISO19139Namespaces.XLINK.getPrefix(), ISO19139Namespaces.XLINK.getURI())
+        .put(ISO19139Namespaces.GCO.getPrefix(), ISO19139Namespaces.GCO.getURI())
+        .put(ISO19139Namespaces.GMD.getPrefix(), ISO19139Namespaces.GMD.getURI())
+        .put(ISO19139Namespaces.GMX.getPrefix(), ISO19139Namespaces.GMX.getURI())
+        .put(ISO19139Namespaces.SRV.getPrefix(), ISO19139Namespaces.SRV.getURI())
+        .put(ISO19139cheNamespaces.CHE.getPrefix(), ISO19139cheNamespaces.CHE.getURI())
+        .build();
+    public InspireMigrationProcessTest() {
+    }
+
+    @BeforeClass
+    public static void setup() throws URISyntaxException {
+        TransformerFactoryFactory.init("net.sf.saxon.TransformerFactoryImpl");
+        PATH_TO_XSL = Paths.get(InspireMigrationProcessTest.class.getClassLoader().getResource("iso19139.che/process/geocat-inspire-conformity.xsl").toURI());
+
+    }
+
+    @Test
+    public void testDataset() throws Exception {
+        Element input = Xml.loadFile(Paths.get(InspireMigrationProcessTest.class.getClassLoader().getResource("inspiredataset.xml").toURI()));
+        String inputString = Xml.getString(input);
+
+
+        // Metadata / Distributor instead of pointOfContact
+        Element output = Xml.transform(input, PATH_TO_XSL);
+        String outputString = Xml.getString(output);
+        assertThat(
+            inputString, hasXPath(
+                "count(//gmd:contact)",
+                equalTo("2")).withNamespaceContext(ALL_NS)
+        );
+        assertThat(
+            inputString, hasXPath(
+                "count(//gmd:contact[contains(@xlink:href, '~distributor')])",
+                equalTo("1")).withNamespaceContext(ALL_NS)
+        );
+        assertThat(
+            inputString, hasXPath(
+                "count(//gmd:contact[contains(@xlink:href, '~principalInvestigator')])",
+                equalTo("1")).withNamespaceContext(ALL_NS)
+        );
+
+        assertThat(
+            outputString, hasXPath(
+                "count(//gmd:contact[contains(@xlink:href, '~pointOfContact')])",
+                equalTo("2")).withNamespaceContext(ALL_NS)
+        );
+        assertThat(
+            outputString, hasXPath(
+                "count(//gmd:contact[contains(@xlink:href, '~distributor') or contains(@xlink:href, '~principalInvestigator')])",
+                equalTo("0")).withNamespaceContext(ALL_NS)
+        );
+        assertThat(
+            outputString, hasXPath(
+                "//gmd:contact[1]/@xlink:href",
+                equalTo("local://srv/api/registries/entries/d8d920c8-cc8c-47b7-ba1b-2b039ad0f4b3?process=*//gmd:CI_RoleCode/@codeListValue~pointOfContact&lang=fre,ger,ita,eng,roh")).withNamespaceContext(ALL_NS)
+        );
+
+
+
+        // Resource / Responsible organization missing
+        assertThat(
+            inputString, hasXPath(
+                "count(/che:CHE_MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact)",
+                equalTo("0")).withNamespaceContext(ALL_NS)
+        );
+        assertThat(
+            outputString, hasXPath(
+                "count(/che:CHE_MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact)",
+                equalTo("1")).withNamespaceContext(ALL_NS)
+        );
+        assertThat(
+            outputString, hasXPath(
+                "/che:CHE_MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact/@xlink:href",
+                equalTo("local://srv/api/registries/entries/d8d920c8-cc8c-47b7-ba1b-2b039ad0f4b3?process=*//gmd:CI_RoleCode/@codeListValue~pointOfContact&lang=fre,ger,ita,eng,roh")).withNamespaceContext(ALL_NS)
+        );
+
+
+        // Resource / Identification / Temporal reference / LastRevision
+        assertThat(
+            inputString, hasXPath(
+                "count(/che:CHE_MD_Metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:date/*/gmd:dateType/*/@codeListValue[. = 'lastRevision'])",
+                equalTo("1")).withNamespaceContext(ALL_NS)
+        );
+        assertThat(
+            outputString, hasXPath(
+                "count(/che:CHE_MD_Metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:date/*/gmd:dateType/*/@codeListValue[. = 'revision'])",
+                equalTo("2")).withNamespaceContext(ALL_NS)
+        );
+
+
+        // Resource / Quality / Lineage
+        assertThat(
+            inputString, hasXPath(
+                "count(/che:CHE_MD_Metadata/gmd:dataQualityInfo)",
+                equalTo("0")).withNamespaceContext(ALL_NS)
+        );
+        assertThat(
+            outputString, hasXPath(
+                "count(/che:CHE_MD_Metadata/gmd:dataQualityInfo)",
+                equalTo("1")).withNamespaceContext(ALL_NS)
+        );
+
+        // Resource / Conformity missing
+        assertThat(
+            inputString, hasXPath(
+                "count(/che:CHE_MD_Metadata/gmd:dataQualityInfo/*/gmd:report/*/gmd:result/*/gmd:specification/*/gmd:title[gmx:Anchor/@xlink:href = 'http://data.europa.eu/eli/reg/2010/1089'])",
+                equalTo("0")).withNamespaceContext(ALL_NS)
+        );
+        assertThat(
+            outputString, hasXPath(
+                "count(/che:CHE_MD_Metadata/gmd:dataQualityInfo/*/gmd:report/*/gmd:result/*/gmd:specification/*/gmd:title[gmx:Anchor/@xlink:href = 'http://data.europa.eu/eli/reg/2010/1089'])",
+                equalTo("1")).withNamespaceContext(ALL_NS)
+        );
+
+        // Resource / Access constraint / Limitation on public access AND condition to access and use
+        assertThat(
+            inputString, hasXPath(
+                "count(//gmd:resourceConstraints[count(*) = 0])",
+                equalTo("1")).withNamespaceContext(ALL_NS)
+        );
+        assertThat(
+            outputString, hasXPath(
+                "count(//gmd:resourceConstraints[count(*) = 0])",
+                equalTo("1")).withNamespaceContext(ALL_NS)
+        );
+        assertThat(
+            outputString, hasXPath(
+                "count(//gmd:resourceConstraints[.//*/@codeListValue='restricted'])",
+                equalTo("1")).withNamespaceContext(ALL_NS)
+        );
+    }
+
+
+    @Test
+    public void testDatasetWithNoResourceIdentifierNoCRS() throws Exception {
+        Element input = Xml.loadFile(Paths.get(InspireMigrationProcessTest.class.getClassLoader().getResource("inspiredataset-noresourceidentifier.xml").toURI()));
+        String inputString = Xml.getString(input);
+
+
+        // Dataset / No resource identifier
+        Element output = Xml.transform(input, PATH_TO_XSL);
+        String outputString = Xml.getString(output);
+        assertThat(
+            inputString, hasXPath(
+                "count(//gmd:identificationInfo/*/gmd:citation/*/gmd:identifier)",
+                equalTo("0")).withNamespaceContext(ALL_NS)
+        );
+        assertThat(
+            outputString, hasXPath(
+                "//gmd:identificationInfo/*/gmd:citation/*/gmd:identifier/*/gmd:code/*/text()",
+                equalTo("166.1")).withNamespaceContext(ALL_NS)
+        );
+
+
+        // Dataset / No CRS
+        assertThat(
+            inputString, hasXPath(
+                "count(//gmd:referenceSystemInfo)",
+                equalTo("0")).withNamespaceContext(ALL_NS)
+        );
+        assertThat(
+            outputString, hasXPath(
+                "count(//gmd:referenceSystemInfo)",
+                equalTo("1")).withNamespaceContext(ALL_NS)
+        );
+
+
+
+        // Resource / Access constraint / Limitation on public access AND condition to access and use
+        assertThat(
+            outputString, hasXPath(
+                "count(//gmd:resourceConstraints)",
+                equalTo("2")).withNamespaceContext(ALL_NS)
+        );
+    }
+
+
+    @Test
+    public void testService() throws Exception {
+        Element input = Xml.loadFile(Paths.get(InspireMigrationProcessTest.class.getClassLoader().getResource("inspireservice.xml").toURI()));
+        String inputString = Xml.getString(input);
+
+
+        // Service / Spatial data service type
+        Element output = Xml.transform(input, PATH_TO_XSL);
+        String outputString = Xml.getString(output);
+        assertThat(
+            inputString, hasXPath(
+                "count(//srv:serviceType[* = 'OGC:WFS'])",
+                equalTo("1")).withNamespaceContext(ALL_NS)
+        );
+        assertThat(
+            outputString, hasXPath(
+                "count(//srv:serviceType[* = 'OGC:WFS'])",
+                equalTo("0")).withNamespaceContext(ALL_NS)
+        );
+        assertThat(
+            outputString, hasXPath(
+                "count(//srv:serviceType[* = 'download'])",
+                equalTo("1")).withNamespaceContext(ALL_NS)
+        );
+
+        // Service / Spatial data service category
+        assertThat(
+            outputString, hasXPath(
+                "//gmd:descriptiveKeywords[contains(@xlink:href, 'httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory')]/@xlink:href",
+                equalTo("local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&thesaurus=external.theme.httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory-SpatialDataServiceCategory&id=http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialDataServiceCategory%2FinfoProductAccessService&lang=ger,fre,eng,ita")).withNamespaceContext(ALL_NS)
+        );
+    }
+}

--- a/schemas/iso19139.che/src/test/java/org/fao/geonet/schemas/InspireMigrationProcessTest.java
+++ b/schemas/iso19139.che/src/test/java/org/fao/geonet/schemas/InspireMigrationProcessTest.java
@@ -202,6 +202,8 @@ public class InspireMigrationProcessTest {
                 "count(//gmd:resourceConstraints[.//*/@codeListValue='restricted'])",
                 equalTo("1")).withNamespaceContext(ALL_NS)
         );
+
+
     }
 
 
@@ -222,7 +224,7 @@ public class InspireMigrationProcessTest {
         assertThat(
             outputString, hasXPath(
                 "//gmd:identificationInfo/*/gmd:citation/*/gmd:identifier/*/gmd:code/*/text()",
-                equalTo("166.1")).withNamespaceContext(ALL_NS)
+                equalTo("basicGeodataID:166.1")).withNamespaceContext(ALL_NS)
         );
 
 
@@ -245,6 +247,14 @@ public class InspireMigrationProcessTest {
             outputString, hasXPath(
                 "count(//gmd:resourceConstraints)",
                 equalTo("2")).withNamespaceContext(ALL_NS)
+        );
+
+
+        // Dataset / No INSPIRE theme
+        assertThat(
+            outputString, hasXPath(
+                "//gmd:descriptiveKeywords[contains(@xlink:href, 'httpinspireeceuropaeutheme')]/@xlink:href",
+                equalTo("local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&thesaurus=external.theme.httpinspireeceuropaeutheme-theme&id=http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fge,http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fso,http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fnz&lang=fre")).withNamespaceContext(ALL_NS)
         );
     }
 
@@ -278,7 +288,7 @@ public class InspireMigrationProcessTest {
         assertThat(
             outputString, hasXPath(
                 "//gmd:descriptiveKeywords[contains(@xlink:href, 'httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory')]/@xlink:href",
-                equalTo("local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&thesaurus=external.theme.httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory-SpatialDataServiceCategory&id=http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialDataServiceCategory%2FinfoProductAccessService&lang=ger,fre,eng,ita")).withNamespaceContext(ALL_NS)
+                equalTo("local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&thesaurus=external.theme.httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory-SpatialDataServiceCategory&id=http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialDataServiceCategory%2FinfoProductAccessService&lang=ger,fre,eng,ita&transformation=to-iso19139-keyword-with-anchor")).withNamespaceContext(ALL_NS)
         );
     }
 }

--- a/schemas/iso19139.che/src/test/resources/org/fao/geonet/schemas/inspiredataset-noresourceidentifier.xml
+++ b/schemas/iso19139.che/src/test/resources/org/fao/geonet/schemas/inspiredataset-noresourceidentifier.xml
@@ -1,0 +1,63 @@
+<che:CHE_MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                     xmlns:gts="http://www.isotc211.org/2005/gts"
+                     xmlns:gml="http://www.opengis.net/gml/3.2"
+                     xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                     xmlns:srv="http://www.isotc211.org/2005/srv"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xmlns:gco="http://www.isotc211.org/2005/gco"
+                     xmlns:che="http://www.geocat.ch/2008/che"
+                     xmlns:gsr="http://www.isotc211.org/2005/gsr"
+                     xmlns:gmi="http://www.isotc211.org/2005/gmi"
+                     xmlns:xlink="http://www.w3.org/1999/xlink"
+                     gco:isoType="gmd:MD_Metadata">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>norid-02a0e24c-4269-48a4-9501-564d66be075c</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <che:CHE_MD_DataIdentification gco:isoType="gmd:MD_DataIdentification">
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Carte des dangers géologiques par processus détaillé</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Carte des dangers géologiques par processus détaillé</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Geologische Gefahrenkarte nach Teilprozess</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:alternateTitle xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Secteurs des dangers géologiques</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Secteurs des dangers géologiques</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">geologische Gefahrengebiete</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:alternateTitle>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2022-07-27</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"
+                                     codeListValue="lastRevision"/>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <che:basicGeodataID>
+        <gco:CharacterString>166.1</gco:CharacterString>
+      </che:basicGeodataID>
+      <che:basicGeodataIDType>
+        <che:basicGeodataIDTypeCode codeListValue="fédéral" codeList="#basicGeodataIDTypeCode"/>
+      </che:basicGeodataIDType>
+    </che:CHE_MD_DataIdentification>
+  </gmd:identificationInfo>
+</che:CHE_MD_Metadata>

--- a/schemas/iso19139.che/src/test/resources/org/fao/geonet/schemas/inspiredataset-noresourceidentifier.xml
+++ b/schemas/iso19139.che/src/test/resources/org/fao/geonet/schemas/inspiredataset-noresourceidentifier.xml
@@ -13,6 +13,9 @@
   <gmd:fileIdentifier>
     <gco:CharacterString>norid-02a0e24c-4269-48a4-9501-564d66be075c</gco:CharacterString>
   </gmd:fileIdentifier>
+  <gmd:language>
+    <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre"/>
+  </gmd:language>
   <gmd:identificationInfo>
     <che:CHE_MD_DataIdentification gco:isoType="gmd:MD_DataIdentification">
       <gmd:citation>
@@ -52,6 +55,12 @@
           </gmd:date>
         </gmd:CI_Citation>
       </gmd:citation>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>geoscientificInformation</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>geoscientificInformation_NaturalHazards</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
       <che:basicGeodataID>
         <gco:CharacterString>166.1</gco:CharacterString>
       </che:basicGeodataID>

--- a/schemas/iso19139.che/src/test/resources/org/fao/geonet/schemas/inspiredataset.xml
+++ b/schemas/iso19139.che/src/test/resources/org/fao/geonet/schemas/inspiredataset.xml
@@ -729,7 +729,7 @@
           </gmd:thesaurusName>
         </gmd:MD_Keywords>
       </gmd:descriptiveKeywords>
-      <gmd:descriptiveKeywords xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.inspire-theme&amp;id=http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F25&amp;lang=fre,ger,ita,eng,roh">
+      <gmd:descriptiveKeywords xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.httpinspireeceuropaeutheme-theme&amp;id=http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F25&amp;lang=fre,ger,ita,eng,roh">
         <gmd:MD_Keywords>
           <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
             <gco:CharacterString>Zones à risque naturel</gco:CharacterString>

--- a/schemas/iso19139.che/src/test/resources/org/fao/geonet/schemas/inspiredataset.xml
+++ b/schemas/iso19139.che/src/test/resources/org/fao/geonet/schemas/inspiredataset.xml
@@ -1,0 +1,1608 @@
+<che:CHE_MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                     xmlns:gts="http://www.isotc211.org/2005/gts"
+                     xmlns:gml="http://www.opengis.net/gml/3.2"
+                     xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                     xmlns:srv="http://www.isotc211.org/2005/srv"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xmlns:gco="http://www.isotc211.org/2005/gco"
+                     xmlns:che="http://www.geocat.ch/2008/che"
+                     xmlns:gsr="http://www.isotc211.org/2005/gsr"
+                     xmlns:gmi="http://www.isotc211.org/2005/gmi"
+                     xmlns:xlink="http://www.w3.org/1999/xlink"
+                     gco:isoType="gmd:MD_Metadata">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>02a0e24c-4269-48a4-9501-564d66be075c</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language>
+    <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre"/>
+  </gmd:language>
+  <gmd:characterSet>
+    <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode"
+                             codeListValue="utf8"/>
+  </gmd:characterSet>
+  <gmd:hierarchyLevel>
+    <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode"
+                      codeListValue="dataset"/>
+  </gmd:hierarchyLevel>
+  <gmd:hierarchyLevelName gco:nilReason="missing">
+    <gco:CharacterString/>
+  </gmd:hierarchyLevelName>
+  <gmd:contact xlink:href="local://srv/api/registries/entries/d8d920c8-cc8c-47b7-ba1b-2b039ad0f4b3?process=*//gmd:CI_RoleCode/@codeListValue~principalInvestigator&amp;lang=fre,ger,ita,eng,roh"
+               xlink:show="embed"/>
+  <gmd:contact xlink:href="local://srv/api/registries/entries/d8d920c8-cc8c-47b7-ba1b-2b039ad0f4b3?lang=fre,ger,ita,eng,roh&amp;process=*//gmd:CI_RoleCode/@codeListValue~distributor"
+               xlink:show="embed">
+    <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
+      <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Canton du Valais - Service de la géoinformation (SGI) - CC GEO</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Canton du Valais - Service de la géoinformation (SGI) - CC GEO</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">Kanton Wallis - Dienststelle für Geoinformation (DGI) - CC GEO</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#IT">Canton du Valais - Service de la géoinformation (SGI) - CC GEO</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">Kanton Wallis - Dienststelle für Geoinformation (DGI) - CC GEO</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#RM">Kanton Wallis - Dienststelle für Geoinformation (DGI) - CC GEO</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:organisationName>
+      <gmd:positionName xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>CC GEO</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">CC GEO</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">CC GEO</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#IT">CC GEO</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">CC GEO</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#RM">CC GEO</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:positionName>
+      <gmd:contactInfo>
+        <gmd:CI_Contact>
+          <gmd:phone>
+            <che:CHE_CI_Telephone gco:isoType="gmd:CI_Telephone">
+              <gmd:voice>
+                <gco:CharacterString>+41 27 606 28 00</gco:CharacterString>
+              </gmd:voice>
+            </che:CHE_CI_Telephone>
+          </gmd:phone>
+          <gmd:address>
+            <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+              <gmd:city>
+                <gco:CharacterString>Sion</gco:CharacterString>
+              </gmd:city>
+              <gmd:postalCode>
+                <gco:CharacterString>1950</gco:CharacterString>
+              </gmd:postalCode>
+              <gmd:country>
+                <gco:CharacterString>CH</gco:CharacterString>
+              </gmd:country>
+              <gmd:electronicMailAddress>
+                <gco:CharacterString>sitvs@admin.vs.ch</gco:CharacterString>
+              </gmd:electronicMailAddress>
+              <che:streetName>
+                <gco:CharacterString>Rue du Scex</gco:CharacterString>
+              </che:streetName>
+              <che:streetNumber>
+                <gco:CharacterString>4</gco:CharacterString>
+              </che:streetNumber>
+            </che:CHE_CI_Address>
+          </gmd:address>
+          <gmd:onlineResource>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#EN">https://www.geo.vs.ch</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">https://geo.vs.ch/de/</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">https://geo.vs.ch</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#IT">https://www.geo.vs.ch</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#RM">https://www.geo.vs.ch</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK</gco:CharacterString>
+              </gmd:protocol>
+            </gmd:CI_OnlineResource>
+          </gmd:onlineResource>
+        </gmd:CI_Contact>
+      </gmd:contactInfo>
+      <gmd:role>
+        <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode"
+                         codeListValue="distributor"/>
+      </gmd:role>
+      <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Service de la géoinformation (SGI)</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Service de la géoinformation (SGI)</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">Dienststelle für Geoinformation (DGI)</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#IT">Service de la géoinformation (SGI)</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">Dienststelle für Geoinformation (DGI)</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#RM">Dienststelle für Geoinformation (DGI)</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </che:organisationAcronym>
+    </che:CHE_CI_ResponsibleParty>
+  </gmd:contact>
+  <gmd:dateStamp>
+    <gco:DateTime>2022-10-20T12:21:53.567Z</gco:DateTime>
+  </gmd:dateStamp>
+  <gmd:metadataStandardName>
+    <gco:CharacterString>GM03 2+</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:dataSetURI>
+    <gco:CharacterString>https://www.vs.ch/web/sdana/instabilites-de-terrain</gco:CharacterString>
+  </gmd:dataSetURI>
+  <gmd:locale>
+    <gmd:PT_Locale id="DE">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger"/>
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode"
+                                 codeListValue="utf8"/>
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale id="IT">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ita"/>
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode"
+                                 codeListValue="utf8"/>
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale id="EN">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng"/>
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode"
+                                 codeListValue="utf8"/>
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale id="RM">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="roh"/>
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeListValue="utf8"
+                                 codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode"/>
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale id="FR">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre"/>
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode"
+                                 codeListValue="utf8"/>
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:spatialRepresentationInfo>
+    <gmd:MD_VectorSpatialRepresentation>
+      <gmd:geometricObjects>
+        <gmd:MD_GeometricObjects>
+          <gmd:geometricObjectType>
+            <gmd:MD_GeometricObjectTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_GeometricObjectTypeCode"
+                                            codeListValue="surface"/>
+          </gmd:geometricObjectType>
+          <gmd:geometricObjectCount>
+            <gco:Integer>170</gco:Integer>
+          </gmd:geometricObjectCount>
+        </gmd:MD_GeometricObjects>
+      </gmd:geometricObjects>
+      <gmd:geometricObjects>
+        <gmd:MD_GeometricObjects>
+          <gmd:geometricObjectType>
+            <gmd:MD_GeometricObjectTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_GeometricObjectTypeCode"
+                                            codeListValue="surface"/>
+          </gmd:geometricObjectType>
+          <gmd:geometricObjectCount>
+            <gco:Integer>796</gco:Integer>
+          </gmd:geometricObjectCount>
+        </gmd:MD_GeometricObjects>
+      </gmd:geometricObjects>
+      <gmd:geometricObjects>
+        <gmd:MD_GeometricObjects>
+          <gmd:geometricObjectType>
+            <gmd:MD_GeometricObjectTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_GeometricObjectTypeCode"
+                                            codeListValue="surface"/>
+          </gmd:geometricObjectType>
+          <gmd:geometricObjectCount>
+            <gco:Integer>908</gco:Integer>
+          </gmd:geometricObjectCount>
+        </gmd:MD_GeometricObjects>
+      </gmd:geometricObjects>
+      <gmd:geometricObjects>
+        <gmd:MD_GeometricObjects>
+          <gmd:geometricObjectType>
+            <gmd:MD_GeometricObjectTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_GeometricObjectTypeCode"
+                                            codeListValue="surface"/>
+          </gmd:geometricObjectType>
+          <gmd:geometricObjectCount>
+            <gco:Integer>1306</gco:Integer>
+          </gmd:geometricObjectCount>
+        </gmd:MD_GeometricObjects>
+      </gmd:geometricObjects>
+      <gmd:geometricObjects>
+        <gmd:MD_GeometricObjects>
+          <gmd:geometricObjectType>
+            <gmd:MD_GeometricObjectTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_GeometricObjectTypeCode"
+                                            codeListValue="surface"/>
+          </gmd:geometricObjectType>
+          <gmd:geometricObjectCount>
+            <gco:Integer>7199</gco:Integer>
+          </gmd:geometricObjectCount>
+        </gmd:MD_GeometricObjects>
+      </gmd:geometricObjects>
+    </gmd:MD_VectorSpatialRepresentation>
+  </gmd:spatialRepresentationInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>CH1903+_MN95</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">CH1903+_MN95</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">CH1903+_LV95</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:code>
+          <gmd:codeSpace>
+            <gco:CharacterString>EPSG:2056</gco:CharacterString>
+          </gmd:codeSpace>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:identificationInfo>
+    <che:CHE_MD_DataIdentification gco:isoType="gmd:MD_DataIdentification">
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Carte des dangers géologiques par processus détaillé</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Carte des dangers géologiques par processus détaillé</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Geologische Gefahrenkarte nach Teilprozess</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:alternateTitle xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Secteurs des dangers géologiques</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Secteurs des dangers géologiques</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">geologische Gefahrengebiete</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:alternateTitle>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2010-08-31</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"
+                                     codeListValue="creation"/>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2022-07-27</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"
+                                     codeListValue="revision"/>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2022-07-27</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"
+                                     codeListValue="lastRevision"/>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>130, 228, 279, 280, 281, 332</gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmd:identifier>
+          <gmd:citedResponsibleParty xlink:href="local://srv/api/registries/entries/2f2fbdd0-0582-4c4a-ab47-65f79a80bf01?lang=fre,ger,ita,eng,roh&amp;process=gmd:role/gmd:CI_RoleCode/@codeListValue~custodian&amp;schema=iso19139.che">
+            <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
+              <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Canton du Valais - Service des dangers naturels (SDANA) - Dangers naturels</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Canton du Valais - Service des dangers naturels (SDANA) - Dangers naturels</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Kanton Wallis - Dienststelle Naturgefahren (DNAGE) - Naturgefahren</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#IT"/>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN"/>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:organisationName>
+              <gmd:positionName xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Dangers naturels</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Dangers naturels</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Naturgefahren</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:positionName>
+              <gmd:contactInfo>
+                <gmd:CI_Contact>
+                  <gmd:phone>
+                    <che:CHE_CI_Telephone gco:isoType="gmd:CI_Telephone">
+                      <gmd:voice>
+                        <gco:CharacterString>+41 27 606 35 20</gco:CharacterString>
+                      </gmd:voice>
+                    </che:CHE_CI_Telephone>
+                  </gmd:phone>
+                  <gmd:address>
+                    <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+                      <gmd:city>
+                        <gco:CharacterString>Sion</gco:CharacterString>
+                      </gmd:city>
+                      <gmd:postalCode>
+                        <gco:CharacterString>1950</gco:CharacterString>
+                      </gmd:postalCode>
+                      <gmd:country>
+                        <gco:CharacterString>CH</gco:CharacterString>
+                      </gmd:country>
+                      <gmd:electronicMailAddress>
+                        <gco:CharacterString>sdana@admin.vs.ch</gco:CharacterString>
+                      </gmd:electronicMailAddress>
+                      <che:streetName>
+                        <gco:CharacterString>Rue des Creusets</gco:CharacterString>
+                      </che:streetName>
+                      <che:streetNumber>
+                        <gco:CharacterString>5</gco:CharacterString>
+                      </che:streetNumber>
+                    </che:CHE_CI_Address>
+                  </gmd:address>
+                  <gmd:onlineResource>
+                    <gmd:CI_OnlineResource>
+                      <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                        <gmd:URL>https://www.vs.ch/sdana</gmd:URL>
+                        <che:PT_FreeURL>
+                          <che:URLGroup>
+                            <che:LocalisedURL locale="#FR">https://www.vs.ch/sdana</che:LocalisedURL>
+                          </che:URLGroup>
+                          <che:URLGroup>
+                            <che:LocalisedURL locale="#DE">https://www.vs.ch/de/web/sdana/</che:LocalisedURL>
+                          </che:URLGroup>
+                        </che:PT_FreeURL>
+                      </gmd:linkage>
+                      <gmd:protocol>
+                        <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                      </gmd:protocol>
+                      <gmd:name xsi:type="gmd:PT_FreeText_PropertyType" gco:nilReason="missing">
+                        <gco:CharacterString/>
+                        <gmd:PT_FreeText>
+                          <gmd:textGroup>
+                            <gmd:LocalisedCharacterString locale="#DE"/>
+                          </gmd:textGroup>
+                        </gmd:PT_FreeText>
+                      </gmd:name>
+                      <gmd:description xsi:type="gmd:PT_FreeText_PropertyType" gco:nilReason="missing">
+                        <gco:CharacterString/>
+                        <gmd:PT_FreeText>
+                          <gmd:textGroup>
+                            <gmd:LocalisedCharacterString locale="#DE"/>
+                          </gmd:textGroup>
+                        </gmd:PT_FreeText>
+                      </gmd:description>
+                    </gmd:CI_OnlineResource>
+                  </gmd:onlineResource>
+                </gmd:CI_Contact>
+              </gmd:contactInfo>
+              <gmd:role>
+                <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode"
+                                 codeListValue="custodian"/>
+              </gmd:role>
+              <che:individualFirstName>
+                <gco:CharacterString/>
+              </che:individualFirstName>
+              <che:individualLastName>
+                <gco:CharacterString/>
+              </che:individualLastName>
+              <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Service des dangers naturels (SDANA)</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Service des dangers naturels (SDANA)</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Dienststelle Naturgefahren (DNAGE)</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </che:organisationAcronym>
+            </che:CHE_CI_ResponsibleParty>
+          </gmd:citedResponsibleParty>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Inventaire géographique des zones exposées à des dangers géologiques par processus détaillé (chute de blocs, éboulement, glissement de terrain, effondrement et coulées boueuse).</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Inventaire géographique des zones exposées à des dangers géologiques par processus détaillé (chute de blocs, éboulement, glissement de terrain, effondrement et coulées boueuse).</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">Geografische Inventar der Gebiete, die natürlichen geologischen Gefahren ausgesetzt sind, nach Teilprozess (Stein- / Blockschlag, Fels- / Bergsturz, Rutschung, Hangmure, Eissturz, Einsturz, Absenkung).</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:abstract>
+      <gmd:purpose xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Cartographie des dangers, détermination du degré de danger; utilisation dans l'aménagement du territoire pour l'octroi de permis de construire, dans le cadre de la gestion des risques naturels.</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Cartographie des dangers, détermination du degré de danger; utilisation dans l'aménagement du territoire pour l'octroi de permis de construire, dans le cadre de la gestion des risques naturels.</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">Naturgefahrenkartierung, Bestimmung der Gefahrenstufe; Verwendung in der Raumplanung für die Erteilung von Baubewilligungen und das Naturrisikomanagement.</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:purpose>
+      <gmd:status>
+        <gmd:MD_ProgressCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ProgressCode"
+                             codeListValue="onGoing"/>
+      </gmd:status>
+      <!--
+      Check Resource / Responsible organization
+      <gmd:pointOfContact xlink:href="local://srv/api/registries/entries/2f2fbdd0-0582-4c4a-ab47-65f79a80bf01?lang=fre,ger,ita,eng,roh&amp;process=gmd:role/gmd:CI_RoleCode/@codeListValue~custodian&amp;schema=iso19139.che">
+        <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
+          <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Canton du Valais - Service des dangers naturels (SDANA) - Dangers naturels</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Canton du Valais - Service des dangers naturels (SDANA) - Dangers naturels</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Kanton Wallis - Dienststelle Naturgefahren (DNAGE) - Naturgefahren</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT"/>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN"/>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:organisationName>
+          <gmd:positionName xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Dangers naturels</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Dangers naturels</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Naturgefahren</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:positionName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:phone>
+                <che:CHE_CI_Telephone gco:isoType="gmd:CI_Telephone">
+                  <gmd:voice>
+                    <gco:CharacterString>+41 27 606 35 20</gco:CharacterString>
+                  </gmd:voice>
+                </che:CHE_CI_Telephone>
+              </gmd:phone>
+              <gmd:address>
+                <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+                  <gmd:city>
+                    <gco:CharacterString>Sion</gco:CharacterString>
+                  </gmd:city>
+                  <gmd:postalCode>
+                    <gco:CharacterString>1950</gco:CharacterString>
+                  </gmd:postalCode>
+                  <gmd:country>
+                    <gco:CharacterString>CH</gco:CharacterString>
+                  </gmd:country>
+                  <gmd:electronicMailAddress>
+                    <gco:CharacterString>sdana@admin.vs.ch</gco:CharacterString>
+                  </gmd:electronicMailAddress>
+                  <che:streetName>
+                    <gco:CharacterString>Rue des Creusets</gco:CharacterString>
+                  </che:streetName>
+                  <che:streetNumber>
+                    <gco:CharacterString>5</gco:CharacterString>
+                  </che:streetNumber>
+                </che:CHE_CI_Address>
+              </gmd:address>
+              <gmd:onlineResource>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                    <gmd:URL>https://www.vs.ch/sdana</gmd:URL>
+                    <che:PT_FreeURL>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#FR">https://www.vs.ch/sdana</che:LocalisedURL>
+                      </che:URLGroup>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#DE">https://www.vs.ch/de/web/sdana/</che:LocalisedURL>
+                      </che:URLGroup>
+                    </che:PT_FreeURL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:name xsi:type="gmd:PT_FreeText_PropertyType" gco:nilReason="missing">
+                    <gco:CharacterString/>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE"/>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gmd:name>
+                  <gmd:description xsi:type="gmd:PT_FreeText_PropertyType" gco:nilReason="missing">
+                    <gco:CharacterString/>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE"/>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gmd:description>
+                </gmd:CI_OnlineResource>
+              </gmd:onlineResource>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode"
+                             codeListValue="custodian"/>
+          </gmd:role>
+          <che:individualFirstName>
+            <gco:CharacterString/>
+          </che:individualFirstName>
+          <che:individualLastName>
+            <gco:CharacterString/>
+          </che:individualLastName>
+          <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Service des dangers naturels (SDANA)</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Service des dangers naturels (SDANA)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Dienststelle Naturgefahren (DNAGE)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </che:organisationAcronym>
+        </che:CHE_CI_ResponsibleParty>
+      </gmd:pointOfContact>-->
+      <gmd:resourceMaintenance>
+        <che:CHE_MD_MaintenanceInformation gco:isoType="gmd:MD_MaintenanceInformation">
+          <gmd:maintenanceAndUpdateFrequency>
+            <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode"
+                                             codeListValue="irregular"/>
+          </gmd:maintenanceAndUpdateFrequency>
+        </che:CHE_MD_MaintenanceInformation>
+      </gmd:resourceMaintenance>
+      <gmd:graphicOverview>
+        <gmd:MD_BrowseGraphic>
+          <gmd:fileName>
+            <gco:CharacterString>https://www.geocat.ch:443/geonetwork/srv/fre//resources.get?uuid=02a0e24c-4269-48a4-9501-564d66be075c&amp;fname=Secteurs_danger_DAGEO.png</gco:CharacterString>
+          </gmd:fileName>
+          <gmd:fileDescription xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>large_thumbnail</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">large_thumbnail</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:fileDescription>
+          <gmd:fileType>
+            <gco:CharacterString>png</gco:CharacterString>
+          </gmd:fileType>
+        </gmd:MD_BrowseGraphic>
+      </gmd:graphicOverview>
+      <gmd:resourceFormat xlink:href="local://srv/api/registries/entries/07909ba7-b8e0-4944-90b4-570e99d85a57?lang=fre,ger,ita,eng,roh&amp;"
+                          xlink:show="embed">
+        <gmd:MD_Format>
+          <gmd:name>
+            <gco:CharacterString>ESRI Enterprise Geodatabase</gco:CharacterString>
+          </gmd:name>
+          <gmd:version>
+            <gco:CharacterString>-</gco:CharacterString>
+          </gmd:version>
+        </gmd:MD_Format>
+      </gmd:resourceFormat>
+      <gmd:descriptiveKeywords xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.gemet-theme&amp;id=http%3A%2F%2Fwww.eionet.europa.eu%2Fgemet%2Ftheme%2F32&amp;lang=fre,ger,ita,eng,roh">
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>catastrophes, accidents, risques</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">catastrophes, accidents, risques</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Katastrophen, Unfälle, Risiken</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">disastri, incidenti, rischi</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">disasters, accidents, risk</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM"/>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode"
+                                    codeListValue="theme"/>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>GEMET themes</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2009-09-22</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                                         codeListValue="publication"/>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="http://localhost:8080/geonetwork/srv/api/registries/vocabularies/external.theme.gemet-theme">
+                      geonetwork.thesaurus.external.theme.gemet-theme</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.inspire-theme&amp;id=http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F25&amp;lang=fre,ger,ita,eng,roh">
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Zones à risque naturel</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Zones à risque naturel</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Gebiete mit naturbedingten Risiken</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Zone a rischio naturale</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Natural risk zones</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM"/>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode"
+                                    codeListValue="theme"/>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>GEMET - INSPIRE themes, version 1.0</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2008-06-01</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                                         codeListValue="publication"/>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="http://localhost:8080/geonetwork/srv/api/registries/vocabularies/external.theme.inspire-theme">
+                      geonetwork.thesaurus.external.theme.inspire-theme</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.gemet&amp;id=http%3A%2F%2Fwww.eionet.europa.eu%2Fgemet%2Fconcept%2F3650%2Chttp%3A%2F%2Fwww.eionet.europa.eu%2Fgemet%2Fconcept%2F5013%2Chttp%3A%2F%2Fwww.eionet.europa.eu%2Fgemet%2Fconcept%2F3852&amp;lang=fre,ger,ita,eng,roh">
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>géologie</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">géologie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Geologie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">geologia</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">geology</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM"/>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>cartographie (cartes)</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">cartographie (cartes)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Kartierung</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">mappatura</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">mapping</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM"/>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>danger</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">danger</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Gefahren</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">pericoli</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">hazard</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM"/>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode"
+                                    codeListValue="theme"/>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>GEMET</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2018-08-16</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                                         codeListValue="publication"/>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="http://localhost:8080/geonetwork/srv/api/registries/vocabularies/external.theme.gemet">
+                      geonetwork.thesaurus.external.theme.gemet</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=local.theme.geocat.ch&amp;id=http%3A%2F%2Fgeocat.ch%2Fconcept%2391%2Chttp%3A%2F%2Fgeocat.ch%2Fconcept%23e6485c01-fe69-485e-b194-035f682463db&amp;lang=fre,ger,ita,eng,roh">
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>carte des dangers</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">carte des dangers</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Gefahrenkarte</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">carta dei pericoli</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">hazard map</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM"/>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>opendata.swiss</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">opendata.swiss</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">opendata.swiss</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">opendata.swiss</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">opendata.swiss</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM">opendata.swiss</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode"
+                                    codeListValue="theme"/>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>geocat.ch</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2022-10-11</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                                         codeListValue="publication"/>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="http://localhost:8080/geonetwork/srv/api/registries/vocabularies/local.theme.geocat.ch">
+                      geonetwork.thesaurus.local.theme.geocat.ch</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:resourceConstraints>
+        <gmd:MD_Constraints>
+          <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Il n'est pas possible de garantir l'exactitude, l'exhaustivité, la fiabilité et l'actualité des données. Toutes les données sont par conséquent dépourvues de foi publique.</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Il n'est pas possible de garantir l'exactitude, l'exhaustivité, la fiabilité et l'actualité des données. Toutes les données sont par conséquent dépourvues de foi publique.</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Die Richtigkeit, Vollständigkeit, Zuverlässigkeit und Aktualität der Daten kann nicht garantiert werden. Die Daten sind somit nicht rechtsverbindlich.</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:useLimitation>
+        </gmd:MD_Constraints>
+      </gmd:resourceConstraints>
+      <gmd:resourceConstraints>
+        <che:CHE_MD_LegalConstraints gco:isoType="gmd:MD_LegalConstraints">
+          <gmd:accessConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_RestrictionCode"
+                                    codeListValue="otherRestrictions"/>
+          </gmd:accessConstraints>
+          <gmd:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Géodonnées accessibles au public (niveau A selon l'OGéo)</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Géodonnées accessibles au public (niveau A selon l'OGéo)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Die Geodaten sind öffentlich zugänglich (Zugangsberechtigungsstufe A nach KGeoIG)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:otherConstraints>
+          <gmd:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Les conditions générales d'utilisation des géodonnées du Canton du Valais font foi (https://www.vs.ch/fr/web/guest/information-legale).</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Les conditions générales d'utilisation des géodonnées du Canton du Valais font foi (https://www.vs.ch/fr/web/guest/information-legale).</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Es gelten die Nutzungsbedingungen für Geodaten des Kantons Wallis (https://www.vs.ch/de/web/guest/rechtliches).</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:otherConstraints>
+        </che:CHE_MD_LegalConstraints>
+      </gmd:resourceConstraints>
+
+      <gmd:resourceConstraints>
+        <gmd:MD_SecurityConstraints>
+          <gmd:classification>
+            <gmd:MD_ClassificationCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ClassificationCode" codeListValue="restricted"/>
+          </gmd:classification>
+        </gmd:MD_SecurityConstraints>
+      </gmd:resourceConstraints>
+
+      <gmd:resourceConstraints>
+        <gmd:MD_Constraints/>
+      </gmd:resourceConstraints>
+
+      <gmd:resourceConstraints/>
+
+      <gmd:spatialRepresentationType>
+        <gmd:MD_SpatialRepresentationTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_SpatialRepresentationTypeCode"
+                                              codeListValue="vector"/>
+      </gmd:spatialRepresentationType>
+      <gmd:spatialResolution>
+        <gmd:MD_Resolution>
+          <gmd:equivalentScale>
+            <gmd:MD_RepresentativeFraction>
+              <gmd:denominator>
+                <gco:Integer>10000</gco:Integer>
+              </gmd:denominator>
+            </gmd:MD_RepresentativeFraction>
+          </gmd:equivalentScale>
+        </gmd:MD_Resolution>
+      </gmd:spatialResolution>
+      <gmd:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre"/>
+      </gmd:language>
+      <gmd:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger"/>
+      </gmd:language>
+      <gmd:characterSet>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode"
+                                 codeListValue="utf8"/>
+      </gmd:characterSet>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>geoscientificInformation</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>geoscientificInformation_NaturalHazards</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:environmentDescription xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>S:\Géodonnées VS\F3 Dangers naturels\Danger géologique.lyr</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">S:\Géodonnées VS\F3 Dangers naturels\Danger géologique.lyr</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">S:\Geodaten VS\F3 Naturbedingte Risiken\geologische Gefahr.lyr</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:environmentDescription>
+      <gmd:extent xlink:href="local://srv/api/registries/entries/geocatch-subtpl-extent-kantonsgebiet-23?lang=fre,ger,ita,eng,roh&amp;"
+                  xlink:show="embed">
+        <gmd:EX_Extent>
+          <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Canton du Valais (VS)</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Canton du Valais (VS)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Kanton Wallis (VS)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Cantone del Vallese (VS)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Canton of Valais (VS)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM">Chantun Vallais (VS)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:description>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicBoundingBox>
+              <gmd:westBoundLongitude>
+                <gco:Decimal>6.770442</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>8.478160</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>45.858680</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>46.654008</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+          </gmd:geographicElement>
+          <gmd:geographicElement>
+            <gmd:EX_BoundingPolygon>
+              <gmd:polygon>
+                <gml:MultiSurface xmlns="http://www.opengis.net/gml/3.2" gml:id="d119470e77" srsDimension="2">
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="d119470e79">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>8.4328037 46.5429376 8.4350984 46.5401017 8.4395539 46.5406293 8.4452736 46.5369173 8.4579574 46.5334127 8.4649734 46.5356167 8.4734418 46.5285228 8.4776735 46.5276025 8.4781598 46.5250971 8.4728195 46.5232385 8.4603018 46.5111886 8.4517429 46.5078196 8.4429137 46.4954291 8.4316097 46.4970218 8.4195714 46.4926282 8.4143076 46.4947247 8.4110159 46.4927737 8.4010438 46.4923638 8.3987586 46.4942454 8.3922931 46.4947317 8.3946615 46.4849958 8.3859018 46.4756231 8.3923949 46.4679489 8.3853488 46.4655788 8.3857525 46.46186 8.3822668 46.4598019 8.384717 46.4521585 8.379003 46.450803 8.3752945 46.4531265 8.366936 46.4519225 8.355762 46.446963 8.352464 46.441643 8.325441 46.425714 8.3149635 46.4236315 8.3074915 46.425851 8.2988965 46.417438 8.298948 46.414246 8.288934 46.4081095 8.3035475 46.4024505 8.3066035 46.402026 8.3096725 46.4040245 8.3157325 46.3989655 8.317292 46.394 8.3141565 46.389825 8.3186947 46.3864446 8.3149465 46.383949 8.3128995 46.377066 8.3000135 46.3740745 8.2897935 46.3691385 8.2842825 46.3636305 8.273075 46.366862 8.2637725 46.364023 8.260755 46.360849 8.265034 46.357109 8.2658795 46.3518435 8.2599275 46.3486625 8.2628835 46.3459665 8.2529435 46.3464415 8.2500425 46.340758 8.235424 46.340364 8.2239955 46.334448 8.225024 46.3328605 8.221613 46.3302465 8.22507 46.3264105 8.214654 46.319662 8.2149275 46.316228 8.2112405 46.312589 8.212012 46.309277 8.2053895 46.3060225 8.1987505 46.3022505 8.192956 46.304233 8.178897 46.2973895 8.1614215 46.295884 8.1470015 46.3015375 8.141117 46.301929 8.1375635 46.301767 8.1288565 46.2947535 8.120857 46.2918735 8.113563 46.2811435 8.105455 46.279647 8.1004975 46.273701 8.085928 46.2666175 8.0860575 46.2621135 8.080412 46.260629 8.086245 46.254283 8.1013505 46.2524125 8.1016175 46.2494685 8.1101545 46.2495045 8.113034 46.238738 8.1153275 46.236003 8.120479 46.2360315 8.1242735 46.229622 8.1388775 46.226148 8.1435255 46.2115955 8.1513925 46.202821 8.153295 46.1911035 8.1655095 46.1822275 8.1651559 46.1768906 8.1585815 46.174064 8.1498785 46.162503 8.1497415 46.1569375 8.1553445 46.147631 8.1443895 46.136823 8.125187 46.135272 8.1154155 46.130346 8.113807 46.1174395 8.108233 46.1116285 8.099867 46.11099 8.0971445 46.1084075 8.081798 46.10545 8.069219 46.1059955 8.0543095 46.1012955 8.0491265 46.1022755 8.0430585 46.0999255 8.0343476 46.1008406 8.0339015 46.095251 8.029584 46.0896005 8.029099 46.0809215 8.022531 46.0747085 8.021662 46.069366 8.024564 46.0675445 8.0238735 46.062984 8.0354145 46.044045 8.0220525 46.0389655 8.0118915 46.03121 8.017501 46.0247045 8.0107585 46.0188535 8.0132475 46.0158635 8.012413 46.01197 8.001084 46.012211 7.993937 45.9998735 7.9890945 45.9959335 7.977114 45.9994535 7.957335 45.996073 7.9494915 45.9976065 7.9326335 45.9959785 7.9086896 45.9969673 7.893849 45.978635 7.877425 45.97386 7.8818115 45.964009 7.8748915 45.957932 7.878907 45.9543695 7.8772065 45.9491135 7.8703745 45.9473635 7.8685 45.9363415 7.8770243 45.9270917 7.8730735 45.920466 7.8663385 45.9195725 7.8635763 45.9166995 7.8585005 45.9208695 7.8367205 45.9217245 7.831447 45.924964 7.8203905 45.92696 7.7995019 45.9173909 7.793984 45.9200005 7.790813 45.924949 7.7765605 45.9310665 7.769268 45.9371175 7.7477515 45.9410085 7.745829 45.934878 7.736871 45.928299 7.7350975 45.9239905 7.7204805 45.92379 7.7163335 45.9277345 7.7126735 45.928228 7.711274 45.932909 7.7073705 45.9347755 7.70977 45.9481555 7.6996915 45.9540255 7.6876185 45.9549075 7.67963 45.957772 7.676995 45.9650475 7.6681735 45.9739855 7.657467 45.976632 7.6395005 45.9701115 7.619635 45.9723685 7.6100033 45.9693909 7.588791 45.9705165 7.5817275 45.974389 7.5786075 45.9860125 7.574703 45.987574 7.561997 45.9856875 7.550134 45.9865565 7.5456985 45.9837665 7.541537 45.976177 7.546722 45.9631395 7.542764 45.9569425 7.538434 45.954946 7.5354645 45.9568615 7.5279785 45.9564935 7.5176275 45.9623245 7.5075315 45.957968 7.499186 45.9624185 7.4934395 45.9556885 7.487446 45.95581 7.477937 45.952407 7.4714595 45.94719 7.4749315 45.9366275 7.471644 45.9340595 7.458734 45.935557 7.4558995 45.932148 7.4446205 45.9317465 7.434417 45.920225 7.4270565 45.915402 7.410806 45.9087115 7.405508 45.9090885 7.401733 45.911475 7.397883 45.908473 7.3971965 45.904861 7.3863375 45.8971555 7.3823845 45.8965045 7.3660675 45.904138 7.3612165 45.9033275 7.3564495 45.907242 7.3564625 45.9106425 7.350536 45.9115895 7.344303 45.9152405 7.3307235 45.9105165 7.323765 45.9102295 7.318112 45.911672 7.3161745 45.9165795 7.301557 45.9172215 7.2945123 45.9217959 7.285315 45.9157505 7.2767715 45.900668 7.271476 45.8998515 7.2568775 45.888218 7.2531435 45.8884655 7.2494865 45.893134 7.24054 45.890064 7.228292 45.89202 7.225684 45.889768 7.2164395 45.8887795 7.2157005 45.883872 7.206093 45.880181 7.203609 45.8764775 7.200118 45.8755135 7.1977005 45.870343 7.2008235 45.8630825 7.1965885 45.8602745 7.1906025 45.8586795 7.1789075 45.863512 7.1752145 45.862855 7.161742 45.8714995 7.164099 45.8766845 7.1535435 45.8792495 7.1352765 45.8727095 7.131419 45.866735 7.117904 45.8591925 7.101175 45.8592705 7.092143 45.872066 7.095292 45.8758335 7.0799395 45.885293 7.0764615 45.890179 7.0766055 45.895182 7.064193 45.899928 7.0644555 45.909366 7.0605835 45.913383 7.053107 45.915546 7.044886 45.922413 7.041839 45.9309505 7.035672 45.9384115 7.038539 45.944797 7.0376 45.954273 7.018369 45.9601745 7.00905 45.969391 7.010733 45.9733045 7.020972 45.9762495 7.0222415 45.980541 7.015547 45.9867095 7.012056 45.9873545 7.010531 45.9972765 7.005619 46.0012095 6.999714 45.999138 6.984753 46.005127 6.980931 46.0202485 6.971083 46.025795 6.966569 46.031189 6.962906 46.0305365 6.949742 46.051731 6.943008 46.0509565 6.935878 46.055134 6.937628 46.0640375 6.933153 46.066723 6.928431 46.064171 6.923767 46.064724 6.908989 46.0506405 6.894678 46.0480915 6.890639 46.0424615 6.882989 46.0444795 6.8756385 46.047695 6.873081 46.0555685 6.880819 46.069454 6.8914787 46.0738832 6.888369 46.0786705 6.891781 46.085045 6.8829555 46.095207 6.895308 46.108223 6.893258 46.112938 6.8994739 46.1240551 6.890419 46.1253815 6.882292 46.1229285 6.876219 46.125782 6.851372 46.1265525 6.843122 46.1289635 6.8415572 46.1320299 6.819328 46.131069 6.8152312 46.1293234 6.807956 46.136101 6.800939 46.1353835 6.797889 46.136799 6.790425 46.154316 6.792314 46.1631965 6.805625 46.172802 6.807331 46.177849 6.812422 46.1814195 6.806975 46.1964685 6.803564 46.2031365 6.810092 46.2138865 6.821667 46.223461 6.820745 46.229969 6.821311 46.2321775 6.830511 46.2342455 6.837019 46.240696 6.840119 46.2483065 6.8551085 46.25465 6.854517 46.258896 6.859961 46.265873 6.859064 46.2738 6.864808 46.280594 6.8589235 46.290432 6.854228 46.2923815 6.847147 46.289982 6.834328 46.299793 6.830533 46.299843 6.828208 46.3027765 6.830028 46.306053 6.819344 46.315338 6.806631 46.320652 6.8006585 46.319851 6.796461 46.332802 6.784403 46.3329315 6.7793195 46.344406 6.7746885 46.3472877 6.770442 46.3552055 6.771636 46.361183 6.780803 46.3664705 6.791786 46.367142 6.803819 46.3767015 6.805886 46.3831175 6.8017935 46.38694 6.8052021 46.3940707 6.821064 46.4271545 6.8588447 46.3942594 6.88386 46.3764831 6.8867674 46.3653874 6.8817959 46.3560073 6.8959961 46.3404956 6.9012631 46.3385147 6.9191844 46.3387784 6.9295241 46.3303694 6.9318167 46.32545 6.9320352 46.3243085 6.9361814 46.298644 6.9494863 46.291254 6.95928 46.2843512 6.9617191 46.2799536 6.9644738 46.2690803 6.9704594 46.2639148 6.9792325 46.257177 6.9869257 46.2521705 6.9890608 46.2448925 7.0024026 46.2303718 7.0032549 46.2259312 7.0045537 46.2223559 7.0096228 46.2205132 7.0132274 46.205405 7.0228603 46.1995038 7.0331624 46.1869654 7.0713295 46.2010214 7.0753557 46.1995322 7.0884918 46.2015708 7.0962917 46.2072533 7.1084046 46.2117874 7.1225769 46.2235134 7.1218699 46.2291787 7.1248064 46.2369052 7.1304617 46.2368666 7.1402405 46.2379457 7.1511735 46.244469 7.1552272 46.2527822 7.161861 46.2538782 7.1718364 46.2611258 7.1780004 46.2684897 7.1844981 46.2686844 7.1885228 46.2707175 7.1863389 46.2828478 7.1947985 46.285709 7.1938262 46.2883966 7.1969111 46.2891499 7.189371 46.2949986 7.1891094 46.3038768 7.2005571 46.3128253 7.221457 46.3292126 7.2336088 46.3265457 7.2533065 46.3305379 7.2620991 46.3381803 7.2601694 46.3443573 7.2623194 46.358223 7.2905929 46.3671424 7.2948849 46.3657716 7.2990538 46.3666494 7.310404 46.3751279 7.3128066 46.3703359 7.3080558 46.3519524 7.3152844 46.3438645 7.3374519 46.3465674 7.3478369 46.3506872 7.3535406 46.350197 7.3590701 46.3532865 7.3626509 46.3566984 7.3680674 46.3576555 7.3781938 46.364561 7.3823512 46.3652829 7.3996773 46.3766248 7.4016805 46.3742686 7.4171568 46.3802189 7.427724 46.3806792 7.4380443 46.3861942 7.4432438 46.3829017 7.4572818 46.3815241 7.462128 46.3762338 7.4638054 46.3780056 7.4699922 46.378229 7.4736479 46.3836613 7.4793946 46.3852876 7.4835253 46.3815619 7.4868954 46.3707298 7.494499 46.3719318 7.4993313 46.3698963 7.5022949 46.3704345 7.5072529 46.375838 7.5262782 46.3744847 7.5384353 46.3774433 7.5406827 46.3837832 7.5553824 46.3889776 7.5467994 46.3940326 7.5407553 46.3948568 7.5286733 46.4004982 7.5339815 46.4097684 7.5547846 46.4135723 7.5623775 46.4124309 7.5771247 46.4170647 7.5834725 46.4172637 7.5863766 46.4137786 7.5941604 46.4114024 7.6000637 46.4153973 7.5984035 46.4214267 7.6063864 46.4243838 7.6102111 46.4285701 7.6096512 46.43673 7.6205735 46.4384222 7.6261004 46.4450521 7.6896157 46.4245187 7.6930249 46.424718 7.7050802 46.4159916 7.7123794 46.4138963 7.7240716 46.4212889 7.7364704 46.4240818 7.7442346 46.4283791 7.7680732 46.439953 7.7782317 46.4434494 7.7801657 46.446808 7.7975227 46.4580712 7.8241371 46.466548 7.8274573 46.470252 7.8434111 46.4778607 7.8766472 46.4785022 7.8909077 46.483394 7.8953658 46.4823507 7.9052128 46.4855942 7.9058391 46.4872468 7.9111234 46.4868562 7.9152895 46.4911388 7.9232654 46.4916718 7.9235176 46.4951071 7.932768 46.4981978 7.9345992 46.5032905 7.9420013 46.5077559 7.9535345 46.5080461 7.9646198 46.5131859 7.9676918 46.5128568 7.9729114 46.5242121 7.9688334 46.5270019 7.9627999 46.5392372 7.9677366 46.5414903 7.9696591 46.5447648 7.9796657 46.5480461 7.9860021 46.5480158 7.9927858 46.5560162 7.9973345 46.5583149 8.0012574 46.5580707 8.0157494 46.5632967 8.0303869 46.5624749 8.0427813 46.5570213 8.0539185 46.5559001 8.0614298 46.5513614 8.0627036 46.5532705 8.0757837 46.5555819 8.085205 46.5517145 8.0936121 46.5514326 8.1006006 46.5481806 8.1139708 46.5465277 8.1257441 46.5372454 8.1499067 46.5317893 8.1743417 46.531391 8.174503 46.5240762 8.1807888 46.5205539 8.1846108 46.5208078 8.2001701 46.524429 8.2054367 46.523593 8.225766 46.5270345 8.2412304 46.5265756 8.2580613 46.5294422 8.264351 46.533328 8.2833557 46.5382803 8.2874061 46.543018 8.3027656 46.5455293 8.3127482 46.552497 8.3170146 46.5590673 8.3366106 46.5610824 8.3504065 46.5686554 8.3516061 46.5717225 8.3605278 46.577795 8.3645291 46.5828993 8.3607876 46.5861503 8.3635058 46.5924976 8.3617346 46.6011213 8.3705046 46.6139504 8.368403 46.6245921 8.3726257 46.6332029 8.3803334 46.634093 8.3907536 46.644379 8.3946066 46.6458311 8.3990103 46.6540076 8.4103334 46.6529996 8.4181704 46.6522342 8.4219845 46.6478832 8.4187463 46.6357212 8.4223011 46.6272431 8.4174205 46.610831 8.4138705 46.6050858 8.4080457 46.6012672 8.4103009 46.5967499 8.4061951 46.5860973 8.4101722 46.5808636 8.4100292 46.5772573 8.4169123 46.5711888 8.4206813 46.5610715 8.4236083 46.5599397 8.4246343 46.5511144 8.4290068 46.5434925 8.4328037 46.5429376</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                </gml:MultiSurface>
+              </gmd:polygon>
+            </gmd:EX_BoundingPolygon>
+          </gmd:geographicElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+      <che:basicGeodataID>
+        <gco:CharacterString>166.1</gco:CharacterString>
+      </che:basicGeodataID>
+      <che:basicGeodataIDType>
+        <che:basicGeodataIDTypeCode codeListValue="fédéral" codeList="#basicGeodataIDTypeCode"/>
+      </che:basicGeodataIDType>
+    </che:CHE_MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:contentInfo>
+    <che:CHE_MD_FeatureCatalogueDescription gco:isoType="gmd:MD_FeatureCatalogueDescription">
+      <gmd:includedWithDataset>
+        <gco:Boolean>0</gco:Boolean>
+      </gmd:includedWithDataset>
+      <gmd:featureCatalogueCitation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Catalogue d'objets : Carte des dangers géologiques par processus détaillé, géodonnées de base No. 166.1</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Catalogue d'objets : Carte des dangers géologiques par processus détaillé, géodonnées de base No. 166.1</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Catalogue d'objets : Cartes de danger géologique, géodonnées de base No. 166.1</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2021-06-08</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"
+                                     codeListValue="publication"/>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </gmd:featureCatalogueCitation>
+      <che:dataModel xsi:type="che:PT_FreeURL_PropertyType">
+        <che:PT_FreeURL>
+          <che:URLGroup>
+            <che:LocalisedURL locale="#FR">https://www.vs.ch/documents/17311/472431/Catalogue_Objet_Geologie_Danger_DANAT_SFCEP</che:LocalisedURL>
+          </che:URLGroup>
+          <che:URLGroup>
+            <che:LocalisedURL locale="#DE">https://www.vs.ch/documents/17311/472431/Catalogue_Objet_Geologie_Danger_DANAT_SFCEP</che:LocalisedURL>
+          </che:URLGroup>
+        </che:PT_FreeURL>
+      </che:dataModel>
+      <che:modelType>
+        <che:CHE_MD_modelTypeCode codeListValue="FeatureDescription" codeList="#CHE_MD_modelTypeCode"/>
+      </che:modelType>
+    </che:CHE_MD_FeatureCatalogueDescription>
+  </gmd:contentInfo>
+  <gmd:distributionInfo xmlns:java="java:org.fao.geonet.util.XslUtil">
+    <gmd:MD_Distribution>
+      <gmd:distributionFormat xlink:href="local://srv/api/registries/entries/5533f00e-57f9-4f4d-b2a2-560fee4b32ad?lang=fre,ger,ita,eng,roh&amp;process="
+                              xlink:show="embed">
+        <gmd:MD_Format>
+          <gmd:name>
+            <gco:CharacterString>ESRI Shapefile</gco:CharacterString>
+          </gmd:name>
+          <gmd:version>
+            <gco:CharacterString>-</gco:CharacterString>
+          </gmd:version>
+        </gmd:MD_Format>
+      </gmd:distributionFormat>
+      <gmd:distributionFormat xlink:href="local://srv/api/registries/entries/388d711d-c1ea-49ea-a02d-5868b1174b55?lang=fre,ger,ita,eng,roh&amp;"
+                              xlink:show="embed">
+        <gmd:MD_Format>
+          <gmd:name>
+            <gco:CharacterString>autres formats sur demande / andere Formate auf Anfrage</gco:CharacterString>
+          </gmd:name>
+          <gmd:version gco:nilReason="missing">
+            <gco:CharacterString>-</gco:CharacterString>
+          </gmd:version>
+        </gmd:MD_Format>
+      </gmd:distributionFormat>
+      <gmd:distributor>
+        <gmd:MD_Distributor>
+          <gmd:distributorContact xlink:href="local://srv/api/registries/entries/d8d920c8-cc8c-47b7-ba1b-2b039ad0f4b3?lang=fre,ger,ita,eng,roh&amp;process=*//gmd:CI_RoleCode/@codeListValue~distributor"
+                                  xlink:show="embed">
+            <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
+              <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Canton du Valais - Service de la géoinformation (SGI) - CC GEO</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Canton du Valais - Service de la géoinformation (SGI) - CC GEO</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Kanton Wallis - Dienststelle für Geoinformation (DGI) - CC GEO</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#IT">Canton du Valais - Service de la géoinformation (SGI) - CC GEO</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN">Kanton Wallis - Dienststelle für Geoinformation (DGI) - CC GEO</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#RM">Kanton Wallis - Dienststelle für Geoinformation (DGI) - CC GEO</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:organisationName>
+              <gmd:positionName xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>CC GEO</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">CC GEO</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">CC GEO</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#IT">CC GEO</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN">CC GEO</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#RM">CC GEO</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:positionName>
+              <gmd:contactInfo>
+                <gmd:CI_Contact>
+                  <gmd:phone>
+                    <che:CHE_CI_Telephone gco:isoType="gmd:CI_Telephone">
+                      <gmd:voice>
+                        <gco:CharacterString>+41 27 606 28 00</gco:CharacterString>
+                      </gmd:voice>
+                    </che:CHE_CI_Telephone>
+                  </gmd:phone>
+                  <gmd:address>
+                    <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+                      <gmd:city>
+                        <gco:CharacterString>Sion</gco:CharacterString>
+                      </gmd:city>
+                      <gmd:postalCode>
+                        <gco:CharacterString>1950</gco:CharacterString>
+                      </gmd:postalCode>
+                      <gmd:country>
+                        <gco:CharacterString>CH</gco:CharacterString>
+                      </gmd:country>
+                      <gmd:electronicMailAddress>
+                        <gco:CharacterString>sitvs@admin.vs.ch</gco:CharacterString>
+                      </gmd:electronicMailAddress>
+                      <che:streetName>
+                        <gco:CharacterString>Rue du Scex</gco:CharacterString>
+                      </che:streetName>
+                      <che:streetNumber>
+                        <gco:CharacterString>4</gco:CharacterString>
+                      </che:streetNumber>
+                    </che:CHE_CI_Address>
+                  </gmd:address>
+                  <gmd:onlineResource>
+                    <gmd:CI_OnlineResource>
+                      <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                        <che:PT_FreeURL>
+                          <che:URLGroup>
+                            <che:LocalisedURL locale="#EN">https://www.geo.vs.ch</che:LocalisedURL>
+                          </che:URLGroup>
+                          <che:URLGroup>
+                            <che:LocalisedURL locale="#DE">https://geo.vs.ch/de/</che:LocalisedURL>
+                          </che:URLGroup>
+                          <che:URLGroup>
+                            <che:LocalisedURL locale="#FR">https://geo.vs.ch</che:LocalisedURL>
+                          </che:URLGroup>
+                          <che:URLGroup>
+                            <che:LocalisedURL locale="#IT">https://www.geo.vs.ch</che:LocalisedURL>
+                          </che:URLGroup>
+                          <che:URLGroup>
+                            <che:LocalisedURL locale="#RM">https://www.geo.vs.ch</che:LocalisedURL>
+                          </che:URLGroup>
+                        </che:PT_FreeURL>
+                      </gmd:linkage>
+                      <gmd:protocol>
+                        <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                      </gmd:protocol>
+                    </gmd:CI_OnlineResource>
+                  </gmd:onlineResource>
+                </gmd:CI_Contact>
+              </gmd:contactInfo>
+              <gmd:role>
+                <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode"
+                                 codeListValue="distributor"/>
+              </gmd:role>
+              <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Service de la géoinformation (SGI)</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Service de la géoinformation (SGI)</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Dienststelle für Geoinformation (DGI)</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#IT">Service de la géoinformation (SGI)</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN">Dienststelle für Geoinformation (DGI)</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#RM">Dienststelle für Geoinformation (DGI)</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </che:organisationAcronym>
+            </che:CHE_CI_ResponsibleParty>
+          </gmd:distributorContact>
+        </gmd:MD_Distributor>
+      </gmd:distributor>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <gmd:URL>https://sitonline.vs.ch/dangers/dangers_geologiques/fr/</gmd:URL>
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">https://sitonline.vs.ch/dangers/dangers_geologiques/fr/</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">https://sitonline.vs.ch/dangers/dangers_geologiques/de/</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Géoportail du Canton du Valais</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Géoportail du Canton du Valais</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Geoportal Kanton Wallis</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:name>
+              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Géoportail du Canton du Valais</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Géoportail du Canton du Valais</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Geoportal Kanton Wallis</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <gmd:URL>https://geodienste.ch/downloads/gefahrenkarten</gmd:URL>
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">https://geodienste.ch/downloads/gefahrenkarten</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">https://geodienste.ch/downloads/gefahrenkarten</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#IT">https://geodienste.ch/downloads/gefahrenkarten</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#EN">https://geodienste.ch/downloads/gefahrenkarten</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#RM">https://geodienste.ch/downloads/gefahrenkarten</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:DOWNLOAD-APP</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>geodienste.ch le portail intercantonal</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">geodienste.ch le portail intercantonal</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">geodienste.ch das interkantonale Portal</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:name>
+              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Téléchargement de géodonnées conformes au modèle minimal (divers formats)</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Téléchargement de géodonnées conformes au modèle minimal (divers formats)</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Download von modellkonforme Geodaten (verschiedene Formate)</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode"
+                                           codeListValue="download"/>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <gmd:URL>https://www.geocat.ch/geonetwork/srv/fre/md.viewer#/full_view/02a0e24c-4269-48a4-9501-564d66be075c</gmd:URL>
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">https://www.geocat.ch/geonetwork/srv/fre/md.viewer#/full_view/02a0e24c-4269-48a4-9501-564d66be075c</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">https://www.geocat.ch/geonetwork/srv/ger/md.viewer#/full_view/02a0e24c-4269-48a4-9501-564d66be075c</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Landing Page</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Landing Page</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Landing Page</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:name>
+              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Landing Page pour opendata</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Landing Page pour opendata</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Landing Page für opendata</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode"
+                                           codeListValue="information"/>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <gmd:URL>https://opendata.swiss/fr/perma/02a0e24c-4269-48a4-9501-564d66be075c@canton-du-valais-cc-geo</gmd:URL>
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">https://opendata.swiss/fr/perma/02a0e24c-4269-48a4-9501-564d66be075c@canton-du-valais-cc-geo</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">https://opendata.swiss/de/perma/02a0e24c-4269-48a4-9501-564d66be075c@canton-du-valais-cc-geo</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#IT">https://opendata.swiss/it/perma/02a0e24c-4269-48a4-9501-564d66be075c@canton-du-valais-cc-geo</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#EN">https://opendata.swiss/en/perma/02a0e24c-4269-48a4-9501-564d66be075c@canton-du-valais-cc-geo</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>OPENDATA:SWISS</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Permalink opendata.swiss</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Permalink opendata.swiss</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Permalink opendata.swiss</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#IT">Permalink opendata.swiss</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN">Permalink opendata.swiss</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:name>
+              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Permalink opendata.swiss</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Permalink opendata.swiss</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Permalink opendata.swiss</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#IT">Permalink opendata.swiss</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN">Permalink opendata.swiss</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+    </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+  <!--<gmd:dataQualityInfo>
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode"
+                              codeListValue="dataset"/>
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Cartes élaborées sur la base d'études réalisées par des bureaux spécialisés.</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Cartes élaborées sur la base d'études réalisées par des bureaux spécialisés.</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Die Gefahrenkarten basieren auf Studien, die durch spezalisierte Privatbüros erstellt werden.</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:statement>
+          <gmd:source>
+            <gmd:LI_Source>
+              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Etudes de terrain et modélisations</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Etudes de terrain et modélisations</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Feldstudien und Modellierung</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:description>
+              <gmd:scaleDenominator/>
+            </gmd:LI_Source>
+          </gmd:source>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>-->
+  <gmd:portrayalCatalogueInfo>
+    <che:CHE_MD_PortrayalCatalogueReference>
+      <gmd:portrayalCatalogueCitation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Modèle de représentation : Carte des dangers géologiques par processus détaillé, géodonnées de base No. 166.1</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Modèle de représentation : Carte des dangers géologiques par processus détaillé, géodonnées de base No. 166.1</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Modèle de représentation : Cartes de danger géologique, géodonnées de base No. 166.1</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2021-06-08</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"
+                                     codeListValue="publication"/>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </gmd:portrayalCatalogueCitation>
+      <che:portrayalCatalogueURL xsi:type="che:PT_FreeURL_PropertyType">
+        <che:PT_FreeURL>
+          <che:URLGroup>
+            <che:LocalisedURL locale="#FR">https://www.vs.ch/documents/17311/535148/Modele_Representation_Geologie_Danger_DANAT_SFCEP</che:LocalisedURL>
+          </che:URLGroup>
+          <che:URLGroup>
+            <che:LocalisedURL locale="#DE">https://www.vs.ch/documents/17311/535148/Modele_Representation_Geologie_Danger_DANAT_SFCEP</che:LocalisedURL>
+          </che:URLGroup>
+        </che:PT_FreeURL>
+      </che:portrayalCatalogueURL>
+    </che:CHE_MD_PortrayalCatalogueReference>
+  </gmd:portrayalCatalogueInfo>
+</che:CHE_MD_Metadata>

--- a/schemas/iso19139.che/src/test/resources/org/fao/geonet/schemas/inspireservice.xml
+++ b/schemas/iso19139.che/src/test/resources/org/fao/geonet/schemas/inspireservice.xml
@@ -1,0 +1,971 @@
+<che:CHE_MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                     xmlns:gts="http://www.isotc211.org/2005/gts"
+                     xmlns:gml="http://www.opengis.net/gml/3.2"
+                     xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                     xmlns:srv="http://www.isotc211.org/2005/srv"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xmlns:gco="http://www.isotc211.org/2005/gco"
+                     xmlns:che="http://www.geocat.ch/2008/che"
+                     xmlns:gsr="http://www.isotc211.org/2005/gsr"
+                     xmlns:gmi="http://www.isotc211.org/2005/gmi"
+                     xmlns:xlink="http://www.w3.org/1999/xlink"
+                     gco:isoType="gmd:MD_Metadata">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>788688b4-4694-45a8-8397-fbb871456957</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language>
+    <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger"/>
+  </gmd:language>
+  <gmd:characterSet>
+    <gmd:MD_CharacterSetCode codeListValue="utf8"
+                             codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode"/>
+  </gmd:characterSet>
+  <gmd:hierarchyLevel>
+    <gmd:MD_ScopeCode codeListValue="service"
+                      codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode"/>
+  </gmd:hierarchyLevel>
+  <gmd:hierarchyLevelName>
+    <gco:CharacterString>Service</gco:CharacterString>
+  </gmd:hierarchyLevelName>
+  <gmd:contact xlink:show="embed" xlink:title="rejected"
+               uuidref="9d0708c0-cd33-4c0d-93e3-25806ff595e0"
+               xlink:href="local://srv/api/registries/entries/9d0708c0-cd33-4c0d-93e3-25806ff595e0?lang=ger,fre,eng,ita&amp;process=gmd:role/gmd:CI_RoleCode/@codeListValue~pointOfContact">
+    <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
+      <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Koordination, Geo-Information und Services KOGIS, swisstopo</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">Koordination, Geo-Information und Services KOGIS, swisstopo</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Coordination, Services et Informations Géographiques (COSIG), swisstopo</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">Coordination, Geo-Information and Services (COGIS)</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#IT">Coordinazione, Servizi e Informazioni Geografiche COSIG, swisstopo</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:organisationName>
+      <gmd:positionName xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Info</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">Info</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Info</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">Info</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#IT">Info</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:positionName>
+      <gmd:contactInfo>
+        <gmd:CI_Contact>
+          <gmd:address>
+            <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+              <gmd:city>
+                <gco:CharacterString>Wabern</gco:CharacterString>
+              </gmd:city>
+              <gmd:postalCode>
+                <gco:CharacterString>3084</gco:CharacterString>
+              </gmd:postalCode>
+              <gmd:country>
+                <gco:CharacterString>CH</gco:CharacterString>
+              </gmd:country>
+              <gmd:electronicMailAddress>
+                <gco:CharacterString>info@geo.admin.ch</gco:CharacterString>
+              </gmd:electronicMailAddress>
+              <che:streetName>
+                <gco:CharacterString>Seftigenstrasse</gco:CharacterString>
+              </che:streetName>
+              <che:streetNumber>
+                <gco:CharacterString>264</gco:CharacterString>
+              </che:streetNumber>
+            </che:CHE_CI_Address>
+          </gmd:address>
+        </gmd:CI_Contact>
+      </gmd:contactInfo>
+      <gmd:role>
+        <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode"
+                         codeListValue="pointOfContact"/>
+      </gmd:role>
+      <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>KOGIS</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">KOGIS</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">COSIG</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">COGIS</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#IT">COSIG</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </che:organisationAcronym>
+    </che:CHE_CI_ResponsibleParty>
+  </gmd:contact>
+  <gmd:dateStamp>
+    <gco:DateTime>2021-03-01T20:57:46Z</gco:DateTime>
+  </gmd:dateStamp>
+  <gmd:metadataStandardName>
+    <gco:CharacterString>GM03_2</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:metadataStandardVersion>
+    <gco:CharacterString>1.0</gco:CharacterString>
+  </gmd:metadataStandardVersion>
+  <gmd:locale>
+    <gmd:PT_Locale id="FR">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre"/>
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode"
+                                 codeListValue="utf8"/>
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale id="EN">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng"/>
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode"
+                                 codeListValue="utf8"/>
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale id="IT">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ita"/>
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode"
+                                 codeListValue="utf8"/>
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale id="DE">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger"/>
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode"
+                                 codeListValue="utf8"/>
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:identificationInfo>
+    <srv:SV_ServiceIdentification>
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Web access elevation service - Profile</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Web access elevation service - Profile</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2014-09-11</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"
+                                     codeListValue="publication"/>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Der Web Access Elevation Service ist ein Konstrukt, der aus zwei Diensten besteht. Einerseits kann mit diesem Dienst eine Höhe (spezifischer Punkt), andererseits ein Profil (Polylinie) abgefragt werden.</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">Der Web Access Elevation Service ist ein Konstrukt, der aus zwei Diensten besteht. Einerseits kann mit diesem Dienst eine Höhe (spezifischer Punkt), andererseits ein Profil (Polylinie) abgefragt werden.</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">This service allows to obtain elevation information for a point or a polyline.</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:abstract>
+      <gmd:descriptiveKeywords xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=local.theme.geocat.ch&amp;id=http%3A%2F%2Fcustom.shared.obj.ch%2Fconcept%23ab642d3d-d74f-400c-bb01-81c6dde26247&amp;lang=ger,fre,eng,ita">
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Geobasisdaten</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Geobasisdaten</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">géodonnées de base</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">official geodata</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">geodati di base</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode"
+                                    codeListValue="theme"/>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>geocat.ch</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2022-10-11</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                                         codeListValue="publication"/>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="http://localhost:8080/geonetwork/srv/api/registries/vocabularies/local.theme.geocat.ch">
+                      geonetwork.thesaurus.local.theme.geocat.ch</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.gemet&amp;id=http%3A%2F%2Fwww.eionet.europa.eu%2Fgemet%2Fconcept%2F7882&amp;lang=ger,fre,eng,ita">
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Bodenprofil</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Bodenprofil</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">profil du sol</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">soil profile</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">profilo del suolo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode"
+                                    codeListValue="theme"/>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>GEMET</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2018-08-16</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                                         codeListValue="publication"/>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="http://localhost:8080/geonetwork/srv/api/registries/vocabularies/external.theme.gemet">
+                      geonetwork.thesaurus.external.theme.gemet</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.gemet&amp;id=http%3A%2F%2Fwww.eionet.europa.eu%2Fgemet%2Fconcept%2F14940&amp;lang=ger,fre,eng,ita">
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Online-Dienst</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Online-Dienst</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">service en ligne</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">on-line service</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">servizi online</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode"
+                                    codeListValue="theme"/>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>GEMET</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2018-08-16</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                                         codeListValue="publication"/>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="http://localhost:8080/geonetwork/srv/api/registries/vocabularies/external.theme.gemet">
+                      geonetwork.thesaurus.external.theme.gemet</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.gemet&amp;id=http%3A%2F%2Fwww.eionet.europa.eu%2Fgemet%2Fconcept%2F14891&amp;lang=ger,fre,eng,ita">
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Internet-Suchdienst</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Internet-Suchdienst</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">service de recherche sur Internet</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">internet search service</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">servizio di ricerca su internet</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode"
+                                    codeListValue="theme"/>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>GEMET</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2018-08-16</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                                         codeListValue="publication"/>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="http://localhost:8080/geonetwork/srv/api/registries/vocabularies/external.theme.gemet">
+                      geonetwork.thesaurus.external.theme.gemet</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <srv:serviceType>
+        <gco:LocalName>OGC:WFS</gco:LocalName>
+      </srv:serviceType>
+      <srv:serviceTypeVersion gco:nilReason="missing">
+        <gco:CharacterString/>
+      </srv:serviceTypeVersion>
+      <srv:accessProperties>
+        <gmd:MD_StandardOrderProcess>
+          <gmd:fees>
+            <gco:CharacterString>kostenpflichtiger Dienst</gco:CharacterString>
+          </gmd:fees>
+        </gmd:MD_StandardOrderProcess>
+      </srv:accessProperties>
+      <srv:extent xlink:show="embed">
+        <gmd:EX_Extent>
+          <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Schweiz</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Schweiz</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Schweiz</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Schweiz</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Schweiz</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:description>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicBoundingBox>
+              <gmd:westBoundLongitude>
+                <gco:Decimal>5.9561</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>10.492</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>45.8208</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>47.8085</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+          </gmd:geographicElement>
+          <gmd:geographicElement>
+            <gmd:EX_BoundingPolygon>
+              <gmd:polygon>
+                <gml:MultiSurface gml:id="d15650e333" srsName="urn:ogc:def:crs:EPSG:6.6:4326">
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="d15650e335" srsName="urn:ogc:def:crs:EPSG:6.6:4326">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList srsDimension="2">8.618636280062189 47.798328041187226 8.56787059268036 47.80849031653919 8.577093946674179 47.78154246111659 8.47233861776203 47.76355797497301 8.455065631041458 47.722311814345446 8.404436103499194 47.6980658931737 8.420678058582851 47.68386724508964 8.406041372835235 47.67326624538944 8.465642563289116 47.657046396177655 8.473516903820634 47.63830875139124 8.47377354943927 47.64982681786528 8.53153733550567 47.645790051484376 8.527019949682812 47.66039665220734 8.561162233612038 47.67030556384074 8.57772174315698 47.661609940849786 8.606660520537638 47.67213087534437 8.628814936203561 47.64965465541575 8.595525170688925 47.64287525361706 8.604965451086363 47.614014554878615 8.582365156504727 47.59613554624983 8.562851078060614 47.59943365642401 8.574418263148113 47.611932177076056 8.557348283217841 47.624563321131475 8.5155431371234 47.63392155529526 8.50826143997628 47.617508989389805 8.456608992658868 47.60235713051562 8.466946886377844 47.58420397670145 8.494550028567366 47.58120269667622 8.464723759568331 47.572296917916404 8.329919976256582 47.57091999120696 8.291058622008187 47.60940338580198 8.226316200760033 47.60506563756038 8.20610723157161 47.62100330884502 8.165554248321154 47.59431133885296 8.109470311593165 47.58237600924243 8.089351964850312 47.557729457540454 7.959434724641459 47.55822951398472 7.943285510293138 47.54397800805704 7.9108693938456165 47.551705683172614 7.892564613604744 47.58727747027764 7.822754725301581 47.58794427672559 7.79567777463287 47.55744971447046 7.690432438290842 47.532342518283286 7.634101389336508 47.5611184239991 7.68597523022143 47.56562222712119 7.671759349410461 47.587364910725796 7.693585093853014 47.60053739431434 7.645820786022669 47.59697358327785 7.619069438692521 47.57683507782764 7.589043392140367 47.589883276722865 7.584832229543853 47.57566221295602 7.499242409600111 47.53983837278987 7.531478482956719 47.52772267455172 7.522117298287668 47.514237631682406 7.497820217803921 47.52123828222296 7.502002963324432 47.4904455827498 7.476013206573158 47.480015635948654 7.431955606481069 47.49613741094128 7.421238399727966 47.48018787324829 7.456060526114958 47.47193668226339 7.402984884743579 47.43551769915619 7.329826516842244 47.44143854194357 7.245589822906587 47.42030527865714 7.231950921281409 47.43905094310476 7.170422611308535 47.443460723314324 7.201084244608172 47.4938873837936 7.128017920051794 47.50359624552073 7.07487846863898 47.488173886311394 7.02440631942109 47.50423018487721 6.982913989984602 47.49427780736028 7.001549722447383 47.45375050148312 6.939185139165493 47.43371165076098 6.938598383301501 47.406486000241365 6.9136157258748305 47.40466658920951 6.879804040178304 47.35244694203452 7.017907065945778 47.37288947245541 7.048924158141252 47.36184927502698 7.056629952856535 47.33439858831955 7.0097375783705145 47.324373731449576 6.99657023890242 47.29613363037909 6.940739805667862 47.286512801498304 6.955476003651965 47.24298068647845 6.841324177048777 47.17140406945645 6.85882922967132 47.16568195336144 6.849971095849776 47.156465949642694 6.70357257950394 47.082174650431135 6.691786359952591 47.066416111810334 6.718461378141072 47.05079840619861 6.618143266981125 46.99189599798589 6.505956387161875 46.966146820187234 6.496691392405917 46.97418502332112 6.432741617713 46.928461912328 6.464449478140517 46.89042106846364 6.430987588050665 46.81233426246198 6.458433024166044 46.78831651700287 6.45221837155222 46.77414846801139 6.269427506827404 46.682725712627416 6.110947650261327 46.57666226842364 6.156467052215122 46.545257343131425 6.072812976871985 46.46575680335995 6.086229351446508 46.44315112168987 6.064010897253175 46.41622894753581 6.170141699544227 46.36643653900748 6.102351067071493 46.28485915938185 6.124297897236064 46.25113287216107 5.974396733614979 46.21475629783562 5.963682516909239 46.19697247300705 5.995204568388246 46.18289952907865 5.956069521017492 46.13209255153297 5.993965237605585 46.1444323236656 6.035707389117514 46.134768592104976 6.051904630456517 46.15127161259754 6.135525015192553 46.1411622091261 6.222315515656701 46.200793679783665 6.294448638144876 46.224933021417186 6.310266002994845 46.25618313461082 6.294862985616501 46.26460224547861 6.266492687877919 46.247702764935255 6.237731769350922 46.27662255114306 6.2488270556117484 46.301555642943995 6.219531970054035 46.31188182547415 6.252942575070233 46.36042395967063 6.3351759322163606 46.403720858633676 6.425606061199492 46.415809545223496 6.519091938541009 46.456370889544125 6.681846860958989 46.454337187519585 6.821053398359342 46.42715645466993 6.80612140503136 46.37978175319494 6.770430480619563 46.35520725968662 6.864796368536654 46.28059493910186 6.803551338547016 46.20313726121392 6.797875728973468 46.13679941341284 6.899461101896673 46.12405501255298 6.875624884290133 46.04769458763862 6.936958888816314 46.06475392596505 6.984739670853903 46.00512589066723 7.010517748155932 45.99727523378875 7.02331766662111 45.97923507746766 7.009036492811234 45.969389578899026 7.0375865186945425 45.954271378179804 7.10116105641905 45.85926806981525 7.153530024033257 45.8792469640808 7.196575100868563 45.86027168192092 7.216426452471276 45.88877675668897 7.25686467445303 45.888215079856074 7.294499936906213 45.92179303381962 7.386325475591452 45.8971520752183 7.471632761477441 45.93405592794558 7.49917516836143 45.96241496055923 7.542753362860713 45.956938751448824 7.550123663325103 45.98655288979896 7.578597324660013 45.986008763270476 7.588780734911999 45.970512625753194 7.664183705624053 45.97567184102979 7.720470556466393 45.92378530163087 7.74774186425704 45.9410037866379 7.799492314069325 45.91738580061996 7.820381132572822 45.92695489206747 7.863567125875551 45.916694135362974 7.877416359497318 45.973854914032835 7.90868131387385 45.99696223697685 7.989086684844114 45.99592806398439 8.012405458504649 46.011964548824814 8.035407366666643 46.04403963497282 8.021655018069469 46.06936083066837 8.03434091055798 46.100835562068 8.108226860685585 46.111623197259235 8.15533894129209 46.14762570339897 8.1655043077905 46.182222348321574 8.085923125730213 46.266613169296114 8.137559224804834 46.30176263902905 8.19874657552904 46.302245879403976 8.223992007005194 46.334443453757935 8.262880325859532 46.34596185865502 8.263769479347692 46.364018454506684 8.312896878585121 46.37706131228847 8.31573008859634 46.39896091911765 8.288931519111179 46.408105088148005 8.307489288086021 46.42584661719364 8.438527368842006 46.464290757969664 8.465943833402452 46.444360530049714 8.471170430478548 46.395917736041575 8.465354830887328 46.3337569076758 8.427736810628607 46.29829486852924 8.455877653797202 46.263749561607376 8.44452345393419 46.24887152713405 8.532440164203726 46.2182759741861 8.573603905633853 46.16449949367639 8.603003980635963 46.155361807545496 8.592893814082606 46.142962787941485 8.611855229127308 46.12166207818017 8.648027942322969 46.12331893486171 8.713933067906513 46.09726400731825 8.742327945288906 46.12221452228632 8.760224869505114 46.101409321028996 8.806033606475804 46.10127512703101 8.852111641732916 46.07563277978381 8.785903495193976 45.98906658196133 8.83163573392935 45.98795087725819 8.859926313589623 45.96622308066523 8.893751809035823 45.95900544706403 8.892728579478156 45.93300480233621 8.945297781425204 45.866968205714194 8.912142773729192 45.8304346390899 8.955769610915146 45.84289852719272 8.997483774502006 45.83493379655325 8.993910637235885 45.821959738865885 9.031385823521433 45.82082256578074 9.054803926010967 45.87355476222308 9.089023334053305 45.900651436796046 9.019192410310422 45.92843178827057 9.013961478669778 45.960537925353435 8.988989940111678 45.97033259582151 9.028458855403631 45.993616053244736 9.009523150716218 46.037278381355335 9.077124267255016 46.06408573030701 9.089614531330499 46.08700631137725 9.072516727156831 46.11809355555517 9.18381430436044 46.17036436748236 9.220907529926903 46.228884040822834 9.248532724961631 46.2337584441773 9.252119064852293 46.26738261882456 9.300143857339151 46.32644723736576 9.276075097439021 46.36780208217315 9.280479050876675 46.41305281681741 9.247005668586768 46.44678615112301 9.277900467916574 46.46099709725338 9.282743322943928 46.496686771527656 9.31105305289909 46.50412968988443 9.3642623875124 46.50905998568033 9.41079275262245 46.46678204735053 9.46356392619829 46.50886305327646 9.44910061822943 46.48436797948147 9.46540657498994 46.469638317105215 9.460817188613708 46.37596081472163 9.49642777760614 46.3640930922552 9.549532909355147 46.302368600781826 9.634972308593506 46.28611304538263 9.676516702545811 46.303037456585834 9.710150280926081 46.291723740749426 9.735843445975245 46.350301963621696 9.776940533645845 46.33500469531092 9.906846158625648 46.38095337517087 9.92479462436451 46.36589971008536 9.953197902396505 46.379144168128995 9.996770373176766 46.3509223116029 9.980225523988514 46.32313423325401 10.000201540080026 46.31306157855969 9.996020761645907 46.28475294145628 10.055442900648876 46.26578257678538 10.043675510369669 46.2297314166795 10.070599041575628 46.2171052266096 10.145955067255718 46.2304689678557 10.176530987761655 46.25826299537186 10.104280290319954 46.33365473421113 10.166689324436769 46.40763537345529 10.143206388796804 46.42826510315872 10.080479472361128 46.42102383978217 10.041980324044557 46.44260659106212 10.043961889824887 46.54034716834551 10.100224086298605 46.582836156313334 10.102363122861842 46.61070878617389 10.128469447478567 46.6054956666775 10.192775494650952 46.62592249853604 10.215330032577883 46.616928343752626 10.23921333993791 46.6353188402693 10.25890071444405 46.6104306079083 10.24360782591516 46.577789500033 10.28665148039486 46.57024076461276 10.295446840994824 46.54988111332233 10.41814201889505 46.5513070696182 10.452811512615277 46.53066979577374 10.471533723435515 46.542843289630895 10.49204697023045 46.61532860647244 10.446087008646872 46.64125895134314 10.40229923123607 46.636799623226466 10.38183357021253 46.68429449167919 10.416018981451804 46.70899147732758 10.401044145178135 46.73419568691604 10.442641549173869 46.75399912116051 10.422732277555758 46.78823140442506 10.466545959460248 46.835883458876005 10.489365042929572 46.93777943633981 10.428654892191995 46.95614281387419 10.42660356178734 46.97567593276695 10.384717076190457 46.99998175268559 10.346536763850605 46.98958186596045 10.309380680311342 46.95019580427852 10.31608248405364 46.92517363793228 10.240592626192742 46.93124750678623 10.232701477865424 46.8662951765022 10.10518252328492 46.840899296301004 10.087363131066091 46.86118028610515 10.051228954191027 46.86393996868578 10.017850125277395 46.90161283438517 9.876159653587491 46.9346271426637 9.89233677039094 46.99035737987737 9.876279470126962 47.02122512576961 9.836152681009427 47.01252925276027 9.6818747847077 47.06209472393484 9.559793980168495 47.048564177578086 9.53976203137949 47.06513836025374 9.47605754836401 47.051791560419495 9.520354745019704 47.100144138645156 9.485699818322189 47.18118174592512 9.52982440893429 47.26937655965808 9.605094098438395 47.35128619658008 9.673877802609905 47.38387007829264 9.644469117153596 47.43383198614037 9.65900886916082 47.452198530504326 9.609315761093125 47.47049285807741 9.594832124659362 47.463617873556075 9.561810253824111 47.49678220720803 9.558735549544537 47.54188968007406 9.495618632910682 47.551451919836246 9.394728868894411 47.6203237557997 9.256575460163239 47.658706145300805 9.175820581258344 47.653936796861416 9.0217960297447 47.6866206495513 8.895139429328957 47.64791298434522 8.850104495141643 47.68148537325168 8.872763336538343 47.704063901103346 8.818867117088336 47.71287268217626 8.806451789091943 47.738307887571246 8.769916383103759 47.71794942595403 8.809945384213805 47.693265109994314 8.78965059651218 47.67524009697216 8.727984177170743 47.69267806037326 8.736306681212012 47.716152557390444 8.71128216322703 47.730072756693325 8.741488516279945 47.74807571774925 8.726117569152375 47.76270437082401 8.692637802750196 47.75615797672254 8.657027034273217 47.80036738344582 8.65304325171765 47.77336674467828 8.627690969145133 47.75926077920138 8.618636280062189 47.798328041187226</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                      <gml:interior>
+                        <gml:LinearRing>
+                          <gml:posList srsDimension="2">8.664335245856755 47.7133183576107 8.701562477574303 47.71517970401839 8.717719419944082 47.6907408075861 8.701588948539964 47.691933699712436 8.663349452144093 47.685903202374156 8.664335245856755 47.7133183576107</gml:posList>
+                        </gml:LinearRing>
+                      </gml:interior>
+                      <gml:interior>
+                        <gml:LinearRing>
+                          <gml:posList srsDimension="2">8.958591215050722 45.96478419177836 8.977017576754331 45.982964354222844 8.97566528543358 45.96168010399086 8.958591215050722 45.96478419177836</gml:posList>
+                        </gml:LinearRing>
+                      </gml:interior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                </gml:MultiSurface>
+              </gmd:polygon>
+            </gmd:EX_BoundingPolygon>
+          </gmd:geographicElement>
+        </gmd:EX_Extent>
+      </srv:extent>
+      <srv:coupledResource>
+        <srv:SV_CoupledResource>
+          <srv:operationName>
+            <gco:CharacterString>Profile</gco:CharacterString>
+          </srv:operationName>
+          <srv:identifier>
+            <gco:CharacterString>3fab2ac3-4271-46b2-823e-ab4814c59d36</gco:CharacterString>
+          </srv:identifier>
+          <gco:ScopedName/>
+        </srv:SV_CoupledResource>
+      </srv:coupledResource>
+      <srv:coupledResource>
+        <srv:SV_CoupledResource>
+          <srv:operationName>
+            <gco:CharacterString>Profile</gco:CharacterString>
+          </srv:operationName>
+          <srv:identifier>
+            <gco:CharacterString>691cb471-c3b5-48ec-a107-d0ad612fa70b</gco:CharacterString>
+          </srv:identifier>
+          <gco:ScopedName/>
+        </srv:SV_CoupledResource>
+      </srv:coupledResource>
+      <srv:couplingType>
+        <srv:SV_CouplingType codeList="http://www.isotc211.org/2005/iso19119/resources/Codelist/gmxCodelists.xml#SV_CouplingType"
+                             codeListValue="tight"/>
+      </srv:couplingType>
+      <srv:containsOperations>
+        <srv:SV_OperationMetadata>
+          <srv:operationName>
+            <gco:CharacterString>Profile.json</gco:CharacterString>
+          </srv:operationName>
+          <srv:DCP>
+            <srv:DCPList codeList="http://www.isotc211.org/2005/iso19119/resources/Codelist/gmxCodelists.xml#DCPList"
+                         codeListValue="WebServices"/>
+          </srv:DCP>
+          <srv:parameters>
+            <srv:SV_Parameter>
+              <srv:name>
+                <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>geom</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#DE">geom</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gco:aName>
+                <gco:attributeType>
+                  <gco:TypeName>
+                    <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                      <gco:CharacterString>CHARACTER</gco:CharacterString>
+                      <gmd:PT_FreeText>
+                        <gmd:textGroup>
+                          <gmd:LocalisedCharacterString locale="#DE">CHARACTER</gmd:LocalisedCharacterString>
+                        </gmd:textGroup>
+                      </gmd:PT_FreeText>
+                    </gco:aName>
+                  </gco:TypeName>
+                </gco:attributeType>
+              </srv:name>
+              <srv:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>A GeoJSON representation of a polyline (type = LineString).</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">A GeoJSON representation of a polyline (type = LineString).</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </srv:description>
+              <srv:optionality xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>required</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">required</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </srv:optionality>
+              <srv:repeatability>
+                <gco:Boolean>true</gco:Boolean>
+              </srv:repeatability>
+              <srv:valueType>
+                <gco:TypeName>
+                  <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString>CHARACTER</gco:CharacterString>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">CHARACTER</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gco:aName>
+                </gco:TypeName>
+              </srv:valueType>
+            </srv:SV_Parameter>
+          </srv:parameters>
+          <srv:parameters>
+            <srv:SV_Parameter>
+              <srv:name>
+                <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>nb_points</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#DE">nb_points</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gco:aName>
+                <gco:attributeType>
+                  <gco:TypeName>
+                    <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                      <gco:CharacterString>CHARACTER</gco:CharacterString>
+                      <gmd:PT_FreeText>
+                        <gmd:textGroup>
+                          <gmd:LocalisedCharacterString locale="#DE">CHARACTER</gmd:LocalisedCharacterString>
+                        </gmd:textGroup>
+                      </gmd:PT_FreeText>
+                    </gco:aName>
+                  </gco:TypeName>
+                </gco:attributeType>
+              </srv:name>
+              <srv:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>The number of points used for the polyline segmentation. Default “200”.</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">The number of points used for the polyline segmentation. Default “200”.</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </srv:description>
+              <srv:optionality xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>optional</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">optional</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </srv:optionality>
+              <srv:repeatability>
+                <gco:Boolean>true</gco:Boolean>
+              </srv:repeatability>
+              <srv:valueType>
+                <gco:TypeName>
+                  <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString>CHARACTER</gco:CharacterString>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">CHARACTER</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gco:aName>
+                </gco:TypeName>
+              </srv:valueType>
+            </srv:SV_Parameter>
+          </srv:parameters>
+          <srv:parameters>
+            <srv:SV_Parameter>
+              <srv:name>
+                <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>offset</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#DE">offset</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gco:aName>
+                <gco:attributeType>
+                  <gco:TypeName>
+                    <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                      <gco:CharacterString>INTEGER</gco:CharacterString>
+                      <gmd:PT_FreeText>
+                        <gmd:textGroup>
+                          <gmd:LocalisedCharacterString locale="#DE">INTEGER</gmd:LocalisedCharacterString>
+                        </gmd:textGroup>
+                      </gmd:PT_FreeText>
+                    </gco:aName>
+                  </gco:TypeName>
+                </gco:attributeType>
+              </srv:name>
+              <srv:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>The offset value (INTEGER) in order to use the exponential moving algorithm . For a given value the offset value specify the number of values before and after used to calculate the average.</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">The offset value (INTEGER) in order to use the exponential moving algorithm . For a given value the offset value specify the number of values before and after used to calculate the average.</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </srv:description>
+              <srv:optionality xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>optional</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">optional</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </srv:optionality>
+              <srv:repeatability>
+                <gco:Boolean>true</gco:Boolean>
+              </srv:repeatability>
+              <srv:valueType>
+                <gco:TypeName>
+                  <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString>INTEGER</gco:CharacterString>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">INTEGER</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gco:aName>
+                </gco:TypeName>
+              </srv:valueType>
+            </srv:SV_Parameter>
+          </srv:parameters>
+          <srv:parameters>
+            <srv:SV_Parameter>
+              <srv:name>
+                <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>callback</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#DE">callback</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gco:aName>
+                <gco:attributeType>
+                  <gco:TypeName>
+                    <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                      <gco:CharacterString>CHARACTER</gco:CharacterString>
+                      <gmd:PT_FreeText>
+                        <gmd:textGroup>
+                          <gmd:LocalisedCharacterString locale="#DE">CHARACTER</gmd:LocalisedCharacterString>
+                        </gmd:textGroup>
+                      </gmd:PT_FreeText>
+                    </gco:aName>
+                  </gco:TypeName>
+                </gco:attributeType>
+              </srv:name>
+              <srv:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Only available for profile.json. The name of the callback function.</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Only available for profile.json. The name of the callback function.</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </srv:description>
+              <srv:optionality xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>optional</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">optional</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </srv:optionality>
+              <srv:repeatability>
+                <gco:Boolean>true</gco:Boolean>
+              </srv:repeatability>
+              <srv:valueType>
+                <gco:TypeName>
+                  <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString>CHARACTER</gco:CharacterString>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">CHARACTER</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gco:aName>
+                </gco:TypeName>
+              </srv:valueType>
+            </srv:SV_Parameter>
+          </srv:parameters>
+          <srv:connectPoint>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <gmd:URL>https://api3.geo.admin.ch/rest/services/profile.json</gmd:URL>
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">https://api3.geo.admin.ch/rest/services/profile.json</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>- Andere -</gco:CharacterString>
+              </gmd:protocol>
+            </gmd:CI_OnlineResource>
+          </srv:connectPoint>
+        </srv:SV_OperationMetadata>
+      </srv:containsOperations>
+      <srv:containsOperations>
+        <srv:SV_OperationMetadata>
+          <srv:operationName>
+            <gco:CharacterString>Profile.csw</gco:CharacterString>
+          </srv:operationName>
+          <srv:DCP>
+            <srv:DCPList codeList="http://www.isotc211.org/2005/iso19119/resources/Codelist/gmxCodelists.xml#DCPList"
+                         codeListValue="WebServices"/>
+          </srv:DCP>
+          <srv:parameters>
+            <srv:SV_Parameter>
+              <srv:name>
+                <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>elevation_models</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#DE">elevation_models</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gco:aName>
+                <gco:attributeType>
+                  <gco:TypeName>
+                    <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                      <gco:CharacterString>CHARACTER</gco:CharacterString>
+                      <gmd:PT_FreeText>
+                        <gmd:textGroup>
+                          <gmd:LocalisedCharacterString locale="#DE">CHARACTER</gmd:LocalisedCharacterString>
+                        </gmd:textGroup>
+                      </gmd:PT_FreeText>
+                    </gco:aName>
+                  </gco:TypeName>
+                </gco:attributeType>
+              </srv:name>
+              <srv:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>A comma separated list of elevation models. Three elevation models are available DTM25, DTM2 (swissALTI3D) and COMB (a combination of DTM25 and DTM2). Default to “DTM25”.</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">A comma separated list of elevation models. Three elevation models are available DTM25, DTM2 (swissALTI3D) and COMB (a combination of DTM25 and DTM2). Default to “DTM25”.</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </srv:description>
+              <srv:optionality xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>optional</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">optional</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </srv:optionality>
+              <srv:repeatability>
+                <gco:Boolean>true</gco:Boolean>
+              </srv:repeatability>
+              <srv:valueType>
+                <gco:TypeName>
+                  <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString>CHARACTER</gco:CharacterString>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">CHARACTER</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gco:aName>
+                </gco:TypeName>
+              </srv:valueType>
+            </srv:SV_Parameter>
+          </srv:parameters>
+          <srv:parameters>
+            <srv:SV_Parameter>
+              <srv:name>
+                <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>nb_points</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#DE">nb_points</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gco:aName>
+                <gco:attributeType>
+                  <gco:TypeName>
+                    <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                      <gco:CharacterString>CHARACTER</gco:CharacterString>
+                      <gmd:PT_FreeText>
+                        <gmd:textGroup>
+                          <gmd:LocalisedCharacterString locale="#DE">CHARACTER</gmd:LocalisedCharacterString>
+                        </gmd:textGroup>
+                      </gmd:PT_FreeText>
+                    </gco:aName>
+                  </gco:TypeName>
+                </gco:attributeType>
+              </srv:name>
+              <srv:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>The number of points used for the polyline segmentation. Default “200”.</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">The number of points used for the polyline segmentation. Default “200”.</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </srv:description>
+              <srv:optionality xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>optional</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">optional</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </srv:optionality>
+              <srv:repeatability>
+                <gco:Boolean>true</gco:Boolean>
+              </srv:repeatability>
+              <srv:valueType>
+                <gco:TypeName>
+                  <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString>CHARACTER</gco:CharacterString>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">CHARACTER</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gco:aName>
+                </gco:TypeName>
+              </srv:valueType>
+            </srv:SV_Parameter>
+          </srv:parameters>
+          <srv:parameters>
+            <srv:SV_Parameter>
+              <srv:name>
+                <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>offset</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#DE">offset</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gco:aName>
+                <gco:attributeType>
+                  <gco:TypeName>
+                    <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                      <gco:CharacterString>INTEGER</gco:CharacterString>
+                      <gmd:PT_FreeText>
+                        <gmd:textGroup>
+                          <gmd:LocalisedCharacterString locale="#DE">INTEGER</gmd:LocalisedCharacterString>
+                        </gmd:textGroup>
+                      </gmd:PT_FreeText>
+                    </gco:aName>
+                  </gco:TypeName>
+                </gco:attributeType>
+              </srv:name>
+              <srv:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>The offset value (INTEGER) in order to use the exponential moving algorithm . For a given value the offset value specify the number of values before and after used to calculate the average.</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">The offset value (INTEGER) in order to use the exponential moving algorithm . For a given value the offset value specify the number of values before and after used to calculate the average.</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </srv:description>
+              <srv:optionality xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>optional</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">optional</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </srv:optionality>
+              <srv:repeatability>
+                <gco:Boolean>true</gco:Boolean>
+              </srv:repeatability>
+              <srv:valueType>
+                <gco:TypeName>
+                  <gco:aName xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString>INTEGER</gco:CharacterString>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">INTEGER</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gco:aName>
+                </gco:TypeName>
+              </srv:valueType>
+            </srv:SV_Parameter>
+          </srv:parameters>
+          <srv:connectPoint>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <gmd:URL>https://api3.geo.admin.ch/rest/services/profile.csv</gmd:URL>
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">https://api3.geo.admin.ch/rest/services/profile.csv</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol gco:nilReason="missing">
+                <gco:CharacterString/>
+              </gmd:protocol>
+            </gmd:CI_OnlineResource>
+          </srv:connectPoint>
+        </srv:SV_OperationMetadata>
+      </srv:containsOperations>
+      <srv:containsOperations/>
+      <srv:operatesOn uuidref="3fab2ac3-4271-46b2-823e-ab4814c59d36"
+                      xlink:href="http://www.geocat.ch/geonetwork/srv/eng/csw?service=CSW&amp;request=GetRecordById&amp;version=2.0.2&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id=3fab2ac3-4271-46b2-823e-ab4814c59d36"/>
+      <srv:operatesOn uuidref="691cb471-c3b5-48ec-a107-d0ad612fa70b"
+                      xlink:href="http://www.geocat.ch/geonetwork/srv/eng/csw?service=CSW&amp;request=GetRecordById&amp;version=2.0.2&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id=691cb471-c3b5-48ec-a107-d0ad612fa70b"/>
+    </srv:SV_ServiceIdentification>
+  </gmd:identificationInfo>
+</che:CHE_MD_Metadata>

--- a/schemas/iso19139/src/main/plugin/iso19139/convert/thesaurus-transformation.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/convert/thesaurus-transformation.xsl
@@ -59,6 +59,15 @@
     </xsl:call-template>
   </xsl:template>
 
+  <!-- Convert a concept to an ISO19139 gmd:MD_Keywords with an XLink which
+    will be resolved by XLink resolver with Anchor encoding. -->
+  <xsl:template name="to-iso19139-keyword-as-xlink-with-anchor">
+    <xsl:call-template name="to-iso19139-keyword">
+      <xsl:with-param name="withXlink" select="true()"/>
+      <xsl:with-param name="withAnchor" select="true()"/>
+    </xsl:call-template>
+  </xsl:template>
+
 
   <!-- Convert a concept to an ISO19139 keywords.
     If no keyword is provided, only thesaurus section is adaded.
@@ -143,7 +152,8 @@
                                    if (thesaurus/key) then thesaurus/key else /root/request/thesaurus,
                                   '&amp;id=', encode-for-uri(/root/request/id),
                                   if (/root/request/lang) then concat('&amp;lang=', /root/request/lang) else '',
-                                  if ($textgroupOnly) then '&amp;textgroupOnly' else '')"/>
+                                  if ($textgroupOnly) then '&amp;textgroupOnly' else '',
+                                  if ($withAnchor) then '&amp;transformation=to-iso19139-keyword-with-anchor' else '')"/>
         </xsl:when>
         <xsl:otherwise>
           <xsl:call-template name="to-md-keywords">

--- a/web-ui/src/main/resources/catalog/components/admin/registry/RegistryService.js
+++ b/web-ui/src/main/resources/catalog/components/admin/registry/RegistryService.js
@@ -141,8 +141,8 @@
           } else if (type === 're3gistry' && r.data.registry) {
             angular.forEach(r.data.registry.registers, function (value, key) {
               itemClass.push({
-                key: value.register.id,
-                label: value.register.label.text,
+                key: value.register ? value.register.id : value.id,
+                label: value.register ? value.register.label.text : value.label.text,
                 description: ''})
             });
             deferred.resolve(itemClass);

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql-geocat/v4/inspire-themes.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql-geocat/v4/inspire-themes.sql
@@ -126,7 +126,7 @@ SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%
 WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F1%';
 
 UPDATE metadata
-SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F1',
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F2',
                    'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fgg')
 WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F2%';
 

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql-geocat/v4/inspire-themes.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql-geocat/v4/inspire-themes.sql
@@ -1,0 +1,173 @@
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F10',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fel')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F10%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F11',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Flc')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F11%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F12',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Foi')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F12%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F13',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fge')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F13%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F14',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fsu')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F14%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F15',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fbu')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F15%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F16',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fso')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F16%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F17',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Flu')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F17%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F18',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fhh')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F18%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F19',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fus')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F19%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F20',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fef')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F20%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F21',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fpf')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F21%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F22',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Faf')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F22%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F23',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fpd')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F23%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F24',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fam')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F24%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F25',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fnz')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F25%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F26',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fac')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F26%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F27',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fmf')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F27%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F28',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fof')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F28%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F29',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fsr')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F29%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F30',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fbr')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F30%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F31',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fhb')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F31%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F32',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fsd')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F32%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F33',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fer')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F33%';
+
+
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F1',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Frs')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F1%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F1',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fgg')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F2%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F3',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fgn')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F3%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F4',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fau')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F4%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F5',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fad')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F5%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F6',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fcp')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F6%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F7',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Ftn')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F7%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F8',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fhy')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F8%';
+
+UPDATE metadata
+SET data = replace(data, 'http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F9',
+                   'http%3A%2F%2Finspire.ec.europa.eu%2Ftheme%2Fps')
+WHERE data LIKE '%http%3A%2F%2Frdfdata.eionet.europa.eu%2Finspirethemes%2Fthemes%2F9%';
+
+
+
+UPDATE metadata
+SET data = replace(data, 'thesaurus=external.theme.inspire-theme',
+                   'thesaurus=external.theme.httpinspireeceuropaeutheme-theme')
+WHERE data LIKE '%thesaurus=external.theme.inspire-theme%';

--- a/web/src/main/webapp/WEB-INF/config-etf-validator.xml
+++ b/web/src/main/webapp/WEB-INF/config-etf-validator.xml
@@ -75,7 +75,7 @@
     <entry key="iso19139::TG version 2.0 - Network services" value=".//srv:SV_ServiceIdentification"/>
     <entry key="iso19139.che::TG version 2.0 - Data sets and series"
            value="gmd:hierarchyLevel[*/@codeListValue = 'dataset' or */@codeListValue = 'series']"/>
-    <entry key="iso19139.che::TG version 2.0 - Network services" value=".//srv:SV_ServiceIdentification"/>
+    <entry key="iso19139.che::TG version 2.0 - Network services" value="gmd:hierarchyLevel[*/@codeListValue = 'service']"/>
     <entry key="iso19115-3.2018::TG version 2.0 - Data sets and series"
            value="mdb:metadataScope[*/mdb:resourceScope/*/@codeListValue = 'dataset' or */mdb:resourceScope/*/@codeListValue = 'series']"/>
     <entry key="iso19115-3.2018::TG version 2.0 - Network services" value=".//srv:SV_ServiceIdentification"/>
@@ -94,7 +94,7 @@
   -->
   <util:map id="validatorAdditionalConfig">
     <entry key="defaultTestSuite" value="TG version 2.0 - Data sets and series"/>
-    <entry key="maxNumberOfEtfChecks" value="20"/>
+    <entry key="maxNumberOfEtfChecks" value="40"/>
     <entry key="intervalBetweenEtfChecks" value="5000"/>
   </util:map>
 

--- a/web/src/main/webapp/WEB-INF/config-etf-validator.xml
+++ b/web/src/main/webapp/WEB-INF/config-etf-validator.xml
@@ -73,6 +73,9 @@
     <entry key="iso19139::TG version 2.0 - Data sets and series"
            value="gmd:hierarchyLevel[*/@codeListValue = 'dataset' or */@codeListValue = 'series']"/>
     <entry key="iso19139::TG version 2.0 - Network services" value=".//srv:SV_ServiceIdentification"/>
+    <entry key="iso19139.che::TG version 2.0 - Data sets and series"
+           value="gmd:hierarchyLevel[*/@codeListValue = 'dataset' or */@codeListValue = 'series']"/>
+    <entry key="iso19139.che::TG version 2.0 - Network services" value=".//srv:SV_ServiceIdentification"/>
     <entry key="iso19115-3.2018::TG version 2.0 - Data sets and series"
            value="mdb:metadataScope[*/mdb:resourceScope/*/@codeListValue = 'dataset' or */mdb:resourceScope/*/@codeListValue = 'series']"/>
     <entry key="iso19115-3.2018::TG version 2.0 - Network services" value=".//srv:SV_ServiceIdentification"/>

--- a/web/src/main/webapp/WEB-INF/data/config/codelist/external/thesauri/theme/httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory-SpatialDataServiceCategory.rdf
+++ b/web/src/main/webapp/WEB-INF/data/config/codelist/external/thesauri/theme/httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory-SpatialDataServiceCategory.rdf
@@ -1,0 +1,987 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <skos:ConceptScheme xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory">
+    <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">Classification of spatial data services</dc:title>
+    <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/" xml:lang="en">The keywords are based on the geographic services taxonomy of EN ISO 19119. This taxonomy is organised in categories, the subcategories defining the value domain of the classification of spatial data services.</dc:description>
+    <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/" xml:lang="de">Grundlage der Schlüsselwörter ist die Taxonomie für geografische Dienste in EN ISO 19119. Diese Taxonomie ist unterteilt in Klassen, zu deren Unterklassen der erlaubte Wertebereich der zugehörigen Geodatendienste angegeben wird.</dc:description>
+    <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/" xml:lang="fr">Les mots clés sont fondés sur la taxonomie des services géographiques de la norme EN ISO 19119. Cette taxonomie est organisée en catégories, elles-mêmes divisées en sous-catégories qui déterminent le domaine de valeur de la classification des services de données géographiques.</dc:description>
+    <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/" xml:lang="it">Le parole chiave sono basate sulla tassonomia dei servizi geografici della norma EN ISO 19119. Questa tassonomia C( organizzata in categorie, a loro volta divise in sottocategorie che determinano il dominio di valore della classificazione dei servizi di dati territoriali.</dc:description>
+    <dcterms:issued xmlns:dcterms="http://purl.org/dc/terms/">2008-12-03</dcterms:issued>
+    <dcterms:modified xmlns:dcterms="http://purl.org/dc/terms/">2008-12-03</dcterms:modified>
+    <skos:hasTopConcept rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanInteractionService" />
+    <skos:hasTopConcept rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoManagementService" />
+    <skos:hasTopConcept rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/taskManagementService" />
+    <skos:hasTopConcept rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+    <skos:hasTopConcept rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService" />
+    <skos:hasTopConcept rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/temporalProcessingService" />
+    <skos:hasTopConcept rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/metadataProcessingService" />
+    <skos:hasTopConcept rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comService" />
+  </skos:ConceptScheme>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanInteractionService">
+    <skos:prefLabel xml:lang="en">Geographic human interaction services</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Geografische Dienste für Anwender</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Services géographiques avec interaction humaine</skos:prefLabel>
+    <skos:prefLabel xml:lang="it">Servizi geografici con interazione umana</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanCatalogueViewer" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanGeographicViewer" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanGeographicSpreadsheetViewer" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanServiceEditor" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanChainDefinitionEditor" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanWorkflowEnactmentManager" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanGeographicFeatureEditor" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanGeographicSymbolEditor" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanFeatureGeneralizationEditor" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanGeographicDataStructureViewer" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanCatalogueViewer">
+    <skos:prefLabel xml:lang="en">Catalogue viewer</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Client service that allows a user to interact with a catalogue to locate, browse, and manage metadata about geographic data or geographic services.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Katalogdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Als Dienst bereitgestellte Anwendung, die es dem Nutzer ermöglicht, Metadaten zu Geodatensätzen oder Geodatendiensten in einem Katalog aufzufinden, sie zu betrachten und zu bearbeiten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Visualiseur de catalogue</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service client permettant l’interaction de l’utilisateur avec un catalogue afin de localiser, parcourir et gérer des métadonnées concernant des données ou des services géographiques.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Visualizzatore del catalogo</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio client che consente all'utente di interagire con un catalogo al fine di localizzare, passare in rassegna e gestire i metadati concernenti dati o servizi geografici.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanInteractionService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanGeographicViewer">
+    <skos:prefLabel xml:lang="en">Geographic viewer</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Client service that allows a user to view one or more feature collections or coverages.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für geografische Visualisierung</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Als Dienst bereitgestellte Anwendung, die es dem Nutzer ermöglicht, eine oder mehrere Objektgruppen oder Rasterdaten zu betrachten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de visualisation géographique</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service client permettant à l’utilisateur de visualiser une ou plusieurs compilations d’éléments ou couvertures.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Visualizzatore geografico</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio client che consente all'utente di visualizzare una o più collezioni di elementi o coperture.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanInteractionService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanGeographicSpreadsheetViewer">
+    <skos:prefLabel xml:lang="en">Geographic spreadsheet viewer</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Client service that allows a user to interact with multiple data objects and to request calculations similar to an arithmetic spreadsheet but extended to geographic data.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für geografische Tabellenkalkulation</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Als Dienst bereitgestellte Anwendung, die es dem Nutzer ermöglicht, mehrere Datenobjekte auszuwählen und damit Berechnungen durchzuführen, ähnlich einer Tabellenkalkulation, aber erweitert auf Geodaten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de visualisation de feuilles de calcul géographiques</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service client permettant l’interaction de l’utilisateur avec plusieurs objets de données; l’utilisateur peut également demander des calculs analogues à ceux d’une feuille de calcul arithmétique, mais étendus à des données géographiques.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Visualizzatore di fogli elettronici geografici</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio client, esteso ai dati geografici, che consente all'utente di interagire con vari oggetti di dati e richiedere calcoli analoghi a quelli di un foglio di calcolo.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanInteractionService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanServiceEditor">
+    <skos:prefLabel xml:lang="en">Service editor</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Client service that allows a user to control geographic processing services.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Editor für Verarbeitungsdienste</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Als Dienst bereitgestellte Anwendung, die es dem Nutzer ermöglicht, geografische Verarbeitungsdienste zu steuern.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Éditeur de services</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service client permettant à l’utilisateur de contrôler les services de traitement géographique.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Editor di servizi</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio client che consente all'utente di controllare i servizi di trattamento geografico.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanInteractionService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanChainDefinitionEditor">
+    <skos:prefLabel xml:lang="en">Chain definition editor</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Provides user interaction with a chain definition service.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Editor für die Definition von Bearbeitungsketten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Ermöglicht dem Nutzer die interaktive Arbeit mit einem Dienst für die Definition von Bearbeitungsketten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Éditeur pour la définition de chaînes</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant l’interaction de l’utilisateur avec un service de définition de chaînes.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Editor per la definizione di catene</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Consente all'utente di interagire con un servizio di definizione di catene.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanInteractionService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanWorkflowEnactmentManager">
+    <skos:prefLabel xml:lang="en">Workflow enactment manager</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Provides user interaction with a workflow enactment service.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Aufrufprogramm für Bearbeitungsketten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Ermöglicht dem Nutzer die interaktive Arbeit mit einem Dienst zur Ausführung von Bearbeitungsketten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Gestionnaire de contrôle de processus</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant l’interaction de l’utilisateur avec un service de contrôle de processus.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Gestore di esecuzione del workflow</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Consente all'utente di interagire con un servizio di esecuzione del workflow.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanInteractionService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanGeographicFeatureEditor">
+    <skos:prefLabel xml:lang="en">Geographic feature editor</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Geographic viewer that allows a user to interact with feature data.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Editor für geografische Objekte</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Als Dienst bereitgestellte Anwendung, die es dem Nutzer ermöglicht, Daten geografischer Objekte zu bearbeiten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Éditeur d’éléments géographiques</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Visualiseur géographique permettant l’interaction de l’utilisateur avec les données relatives aux éléments géographiques.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Editor di elementi geografici (geographic feature)</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Visualizzatore geografico che consente all'utente di interagire con i dati relativi agli elementi geografici.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanInteractionService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanGeographicSymbolEditor">
+    <skos:prefLabel xml:lang="en">Geographic symbol editor</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Client service that allows a human to select and manage symbol libraries.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Editor für geografische Symbole</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Als Dienst bereitgestellte Anwendung, die es dem Nutzer ermöglicht, Symbolbibliotheken auszuwählen und zu verwalten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Éditeur de symboles géographiques</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service client permettant à un utilisateur humain de sélectionner et de gérer des bibliothèques de symboles.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Editor di simboli geografici</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio client che consente a un utente umano di selezionare e gestire biblioteche di simboli.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanInteractionService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanFeatureGeneralizationEditor">
+    <skos:prefLabel xml:lang="en">Feature generalisation editor</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Client service that allows a user to modify the cartographic characteristics of a feature or feature collection by simplifying its visualisation, while maintaining its salient elements – the spatial equivalent of simplification.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Editor für die Objektgeneralisierung</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Als Dienst bereitgestellte Anwendung, die es dem Nutzer ermöglicht, die kartografische Darstellung eines Objekts oder einer Objektgruppe unter Beibehaltung ihrer wesentlichen Elemente zu vereinfachen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Éditeur de généralisation d’éléments</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service client permettant à l’utilisateur de modifier les caractéristiques cartographiques d’un élément ou d’une compilation d’éléments en simplifiant leur visualisation, tout en conservant les éléments essentiels, ce qui correspond à l’équivalent spatial de la simplification.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Editor di generalizzazione di elementi (feature)</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio client che consente all'utente di modificare le caratteristiche cartografiche di un elemento o di una collezione di elementi semplificandone la visualizzazione, ma mantenendone le componenti essenziali — si tratta dell'equivalente spaziale della semplificazione.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanInteractionService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanGeographicDataStructureViewer">
+    <skos:prefLabel xml:lang="en">Geographic data-structure viewer</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Client service that allows a user to access part of data set to see its internal structure.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Betrachter für geografische Datenstrukturen</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Als Dienst bereitgestellte Anwendung, die es dem Nutzer ermöglicht, die innere Struktur (von Teilen) eines Datensatzes zu betrachten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Visualiseur de la structure des données géographiques</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service client permettant à l’utilisateur d’accéder à une partie de série de données pour en voir la structure interne.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Visualizzatore della struttura dei dati geografici</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio client che consente all'utente di accedere a una parte del set di dati per vederne la struttura interna.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/humanInteractionService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoManagementService">
+    <skos:prefLabel xml:lang="en">Geographic model/information management service</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Geografische Dienste für die Verwaltung von Daten und Datenmodellen</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Services de gestion des modèles/informations géographiques</skos:prefLabel>
+    <skos:prefLabel xml:lang="it">Servizio di gestione dei modelli/informazioni geografiche</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoFeatureAccessService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoMapAccessService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoCoverageAccessService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoSensorDescriptionService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoProductAccessService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoFeatureTypeService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoCatalogueService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoRegistryService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoGazetteerService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoOrderHandlingService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoStandingOrderService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoFeatureAccessService">
+    <skos:prefLabel xml:lang="en">Feature access service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that provides a client access to and management of a feature store.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für den Zugriff auf Objekte</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der es einer Anwendung ermöglicht, auf einen Datenspeicher mit geografischen Objekten zuzugreifen und diesen zu verwalten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service d’accès aux éléments</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant au client d’accéder à un magasin d’éléments et de le gérer.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di accesso a elementi (feature)</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente al cliente di accedere e di gestire una raccolta di elementi.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoManagementService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoMapAccessService">
+    <skos:prefLabel xml:lang="en">Map access service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that provides a client access to a geographic graphics, i.e. pictures of geographic data.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für den Zugriff auf grafische Darstellungen</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der es einer Anwendung ermöglicht, auf grafische Darstellungen von geografischen Daten zuzugreifen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service d’accès aux cartes</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant au client d’accéder à des graphiques géographiques, c’est-à-dire à des représentations de données géographiques.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di accesso a mappe (map)</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente al cliente di accedere a grafici geografici, ossia rappresentazioni di dati geografici.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoManagementService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoCoverageAccessService">
+    <skos:prefLabel xml:lang="en">Coverage access service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that provides a client access to and management of a coverage store.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für den Zugriff auf Rasterdaten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der es einer Anwendung ermöglicht, auf einen Datenspeicher mit Rasterdaten zuzugreifen und diesen zu verwalten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service d’accès aux couvertures</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant au client d’accéder à un magasin de couvertures et de le gérer.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di accesso a coperture (coverage)</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente al cliente di accedere e di gestire una raccolta di coperture (coverage).</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoManagementService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoSensorDescriptionService">
+    <skos:prefLabel xml:lang="en">Sensor description service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that provides the description of a coverage sensor, including sensor location and orientation, as well as the sensor’s geometric, dynamic, and radiometric characteristics for geo-processing purposes.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für die Beschreibung von Sensoren</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der die Beschreibung eines Rasterdatensensors für Zwecke der Geodatenverarbeitung bereitstellt. Zur Beschreibung gehören Standort und Orientierung des Sensors sowie seine geometrischen, dynamischen und radiometrischen Eigenschaften.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de description des capteurs</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service fournissant la description des capteurs de couvertures à des fins de géotraitement. La description comprend notamment la position et l’orientation des capteurs ainsi que leurs caractéristiques géométriques, dynamiques et radiométriques.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di descrizione dei sensori</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che fornisce la descrizione di un sensore comprendente la posizione e l'orientamento nonché le caratteristiche geometriche, dinamiche e radiometriche dello stesso ai fini del processamento dei dati territoriali.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoManagementService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoProductAccessService">
+    <skos:prefLabel xml:lang="en">Product access service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that provides access to and management of a geographic product store.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für den Zugriff auf Produkte</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der es ermöglicht, auf einen Datenspeicher mit geografischen Produkten zuzugreifen und diesen zu verwalten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service d’accès aux produits</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant d’accéder à un magasin de produits géographiques et de le gérer.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di accesso ai prodotti</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente al cliente di accedere e gestire una raccolta di prodotti geografici.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoManagementService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoFeatureTypeService">
+    <skos:prefLabel xml:lang="en">Feature type service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that provides a client to access to and management of a store of feature type definitions.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für den Zugriff auf Objektarten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der es einer Anwendung ermöglicht, auf einen Datenspeicher mit Definitionen von Objektarten zuzugreifen und diesen zu verwalten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de types d’éléments</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant au client d’accéder à un magasin de définitions de types d’éléments et de le gérer.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di tipi di elementi (feature type)</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente al cliente di accedere e gestire una raccolta di definizioni di tipi di elementi.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoManagementService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoCatalogueService">
+    <skos:prefLabel xml:lang="en">Catalogue service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that provides discovery and management services on a store of metadata about instances.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Katalogdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst für die Suche in einer Sammlung von Metadaten über Instanzen und ihre Verwaltung.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de catalogue</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de rechercher des métadonnées dans un magasin de métadonnées sur les ressources d’information, et de le gérer.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di catalogo</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di ricercare e gestire servizi relativi a una raccolta di metadati sulle istanze.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoManagementService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoRegistryService">
+    <skos:prefLabel xml:lang="en">Registry Service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that provides access to store of metadata about types.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Registerdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst für die Suche in einer Sammlung von Metadaten über Datentypen und ihre Verwaltung.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de registre</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant d’accéder à un magasin de métadonnées sur les catégories de ressources d’information.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di registro</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di accedere a una raccolta di metadati sulle categorie di risorse di informazione (type).</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoManagementService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoGazetteerService">
+    <skos:prefLabel xml:lang="en">Gazetteer service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that provides access to a directory of instances of a class or classes of real-world phenomena containing some information regarding position.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Gazetteerdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der real existierenden Objekten aus einem Verzeichnis der Instanzen einer oder mehrerer Klassen Positionsangaben zuordnet.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service toponymique</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant d’accéder à un répertoire d’occurrences d’une ou plusieurs catégories de phénomènes du monde réel contenant des informations ayant trait à la position.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio toponimico</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di accedere a un repertorio di occorrenze di una o più categorie di fenomeni del mondo reale contenente informazioni riguardanti la posizione.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoManagementService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoOrderHandlingService">
+    <skos:prefLabel xml:lang="en">Order handling service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that provides a client with the ability to order products from a provider.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Auftragsdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der es einer Anwendung ermöglicht, bei einem Anbieter Produkte zu bestellen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de gestion des commandes</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant aux clients de commander des produits auprès d’un fournisseur.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di gestione degli ordini</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente ai clienti di ordinare dei prodotti da un fornitore.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoManagementService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoStandingOrderService">
+    <skos:prefLabel xml:lang="en">Standing order service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Order handling service that allows a user to request that a product over a geographic area be disseminated when it becomes available.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dauerauftragsdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der es einem Nutzer ermöglicht, ein Produkt über ein geografisches Gebiet zu bestellen, das nach Erscheinen ausgeliefert wird.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de commande en attente</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service de gestion des commandes permettant à l’utilisateur de demander qu’un produit couvrant une zone géographique déterminée soit diffusé lorsqu’il devient disponible.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di ordini permanenti</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio di gestione degli ordini che consente all'utente di richiedere che un prodotto che copre una determinata area geografica sia diffuso non appena disponibile.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoManagementService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/taskManagementService">
+    <skos:prefLabel xml:lang="en">Geographic workflow/task management services</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Geografische Dienste für die Verwaltung von Bearbeitungsketten und Aufgaben</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Services de gestion du processus/des tâches géographiques</skos:prefLabel>
+    <skos:prefLabel xml:lang="it">Servizi di gestione di workflow/compiti geografici</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/chainDefinitionService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/workflowEnactmentService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/subscriptionService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/chainDefinitionService">
+    <skos:prefLabel xml:lang="en">Chain definition service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service to define a chain and to enable it to be executed by the workflow enactment service.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für die Definition von Bearbeitungsketten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst für die Definition von Bearbeitungsketten und für die Veranlassung ihrer Ausführung durch den folgenden Dienst (302).</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de définition de chaîne</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de définir une chaîne et de la faire exécuter par le service de contrôle de processus.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di definizione di catene</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di definire una catena e di farla eseguire dal servizio di esecuzione del workflow.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/taskManagementService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/workflowEnactmentService">
+    <skos:prefLabel xml:lang="en">Workflow enactment service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The workflow enactment service interprets a chain and controls the instantiation of services and sequencing of activities.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für die Ausführung von Bearbeitungsketten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dieser Dienst interpretiert eine Bearbeitungskette und steuert die Instanzenbildung von Diensten sowie den Ablauf der Bearbeitungsschritte.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de contrôle de processus</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Le service de contrôle de processus interprète une chaîne et contrôle l’exécution des services et le séquençage des activités.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di esecuzione del workflow</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Il servizio di esecuzione del worfklow interpreta una catena e controlla le istanze dei servizi e la sequenzialità delle attività.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/taskManagementService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/subscriptionService">
+    <skos:prefLabel xml:lang="en">Subscription service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service to allow clients to register for notification about events.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Abonnementdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der es Anwendungen ermöglicht, über Ereignisse benachrichtigt zu werden.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service d’abonnement</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant aux clients de s’abonner afin d’être informés des événements.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di abbonamento</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente al cliente di abbonarsi per essere informato sugli eventi.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/taskManagementService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService">
+    <skos:prefLabel xml:lang="en">Geographic processing services – spatial</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Geografische Verarbeitungsdienste — raumbezogen</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Services de traitement géographique — aspects spatiaux</skos:prefLabel>
+    <skos:prefLabel xml:lang="it">Servizi di trattamento geografico — aspetti territoriali</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialCoordinateConversionService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialCoordinateTransformationService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialCoverageVectorConversionService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialImageCoordinateConversionService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialRectificationService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialOrthorectificationService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialSensorGeometryModelAdjustmentService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialImageGeometryModelConversionService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialSubsettingService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialSamplingService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialTilingChangeService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialDimensionMeasurementService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialFeatureManipulationService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialFeatureMatchingService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialFeatureGeneralizationService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialRouteDeterminationService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialPositioningService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProximityAnalysisService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialCoordinateConversionService">
+    <skos:prefLabel xml:lang="en">Coordinate conversion service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service to change coordinates from one coordinate system to another coordinate system that is related to the same datum.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für die Konversion von Koordinaten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der Koordinaten aus einem Bezugssystem in die eines anderen mit gleichem Datum umrechnet.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de conversion des coordonnées</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de modifier les coordonnées d’un système de coordonnées en coordonnées d’un autre système fondé sur le même datum géodésique.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di conversione delle coordinate</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di convertire le coordinate da un sistema di coordinate a un altro nell'ambito dello stesso dato geodetico.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialCoordinateTransformationService">
+    <skos:prefLabel xml:lang="en">Coordinate transformation service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service to change coordinates from a coordinate reference system based on one datum to a coordinate reference system based on a second datum.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für die Transformation von Koordinaten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der Koordinaten aus einem Bezugssystem in die eines anderen mit abweichendem Datum umrechnet.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de transformation des coordonnées</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de modifier les coordonnées d’un système de référence fondé sur un datum géodésique en coordonnées d’un système de référence fondé sur un autre datum.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di trasformazione delle coordinate</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di trasformare le coordinate da un sistema di riferimento basato su un dato a un altro sistema basato su un dato differente.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialCoverageVectorConversionService">
+    <skos:prefLabel xml:lang="en">Coverage/vector conversion service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service to change the spatial representation from a coverage schema to a vector schema, or vice versa.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für die Umwandlung zwischen Raster- und Vektordaten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der bei der räumlichen Abbildung von Daten vom Raster- zum Vektorschema oder umgekehrt übergeht.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de conversion couverture/vecteur</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de modifier la représentation spatiale pour passer d’un schéma de couverture à un schéma vectoriel, ou vice versa.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di conversione di raster/vettoriale</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di modificare la rappresentazione spaziale da uno schema di tipo raster a uno schema di tipo vettoriale, o viceversa.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialImageCoordinateConversionService">
+    <skos:prefLabel xml:lang="en">Image coordinate conversion service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">A coordinate transformation or coordinate conversion service to change the coordinate reference system for an image.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für die Konversion von Bildkoordinaten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Koordinatentransformations- oder Koordinatenkonversionsdienst für den Wechsel des Bezugssystems von Bilddaten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de conversion des coordonnées des images</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service de transformation ou de conversion des coordonnées permettant de modifier le système de référence des coordonnées pour une image.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di conversione delle coordinate delle immagini</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio di trasformazione o di conversione delle coordinate che consente di modificare il sistema di riferimento delle coordinate per un'immagine.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialRectificationService">
+    <skos:prefLabel xml:lang="en">Rectification service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service for transforming an image into a perpendicular parallel projection and therefore a constant scale.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Entzerrungsdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst für die Transformation von Bilddaten in eine rechtwinklige Parallelprojektion und damit in einen einheitlichen Maßstab.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de rectification</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de transformer une image en une projection parallèle perpendiculaire, et donc à une échelle constante.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di rettifica</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di trasformare un'immagine in una proiezione ortogonale e dunque a una scala costante.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialOrthorectificationService">
+    <skos:prefLabel xml:lang="en">Orthorectification service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">A rectification service that removes image tilt and displacement due to terrain elevation.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Ortho-Entzerrungsdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Entzerrungsdienst, der eine durch unterschiedliche Geländehöhe bedingte Schieflage des Bildes und Verschiebungen entfernt.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service d’orthorectification</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service de rectification qui élimine l’inclinaison et le décalage de l’image dû au relief du terrain.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di ortorettifica</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio di rettifica che elimina l'inclinazione e lo spostamento dell'immagine dovuti all'elevazione del terreno.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialSensorGeometryModelAdjustmentService">
+    <skos:prefLabel xml:lang="en">Sensor geometry model adjustment service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that adjusts sensor geometry models to improve the match of the image with other images and/or known ground positions.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für die Justierung von Geometriemodellen von Sensoren</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dieser Dienst justiert Geometriemodelle von Sensoren, um die Bilddaten an andere Bilder und/oder bekannte Bezugspunkte am Boden anzupassen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service d’ajustement des modèles géométriques des capteurs</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant d’ajuster les modèles géométriques des capteurs pour améliorer la concordance de l’image avec d’autres images et/ou positions au sol connues.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di adeguamento dei modelli geometrici dei sensori</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che adegua i modelli geometrici dei sensori per migliorare la corrispondenza dell'immagine con altre immagini e/o posizioni al suolo note.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialImageGeometryModelConversionService">
+    <skos:prefLabel xml:lang="en">Image geometry model conversion service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that converts sensor geometry models into a different but equivalent sensor geometry model.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für die Konversion von Geometriemodellen</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dieser Dienst rechnet das Geometriemodell eines Sensors in ein anderes, äquivalentes Geometriemodell um.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de conversion des modèles géométriques des images</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de convertir les modèles géométriques des capteurs en un modèle géométrique différent, mais équivalent.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di conversione dei modelli geometrici delle immagini</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che converte i modelli geometrici dei sensori in un modello geometrico diverso ma equivalente.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialSubsettingService">
+    <skos:prefLabel xml:lang="en">Subsetting service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that extracts data from an input in a continuous spatial region either by geographic location or by grid coordinates.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Geografischer Ausschneidedienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der aus Eingabedaten anhand von Ortsangaben oder Gitterkoordinaten ein zusammenhängendes Gebiet ausschneidet.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de définition de sous-ensembles</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant d’extraire des données d’un ensemble spatial continu, sur la base soit de la position géographique, soit des coordonnées de la grille.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di definizione dei sottoinsiemi</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che estrae da un input all'interno di una regione spaziale continua, in base alla posizione geografica o alle coordinate della griglia.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialSamplingService">
+    <skos:prefLabel xml:lang="en">Sampling service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that extracts data from an input using a consistent sampling scheme either by geographic location or by grid coordinates.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Raumbezogener Auswahldienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der aus Eingabedaten anhand von Ortsangaben oder Gitterkoordinaten nach einem konsistenten Schema bestimmte Daten auswählt.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service d’échantillonnage</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant d’extraire des données au moyen d’un système d’échantillonnage cohérent, sur la base soit de la position géographique, soit des coordonnées de la grille.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di campionamento</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che estrae dei dati da un input mediante un sistema di campionamento coerente, in base alla posizione geografica o alle coordinate della griglia.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialTilingChangeService">
+    <skos:prefLabel xml:lang="en">Tiling change service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that changes the tiling of geographic data.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Kachelungsdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dieser Dienst ändert die Kachelung von Geodaten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de modification du dallage</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de modifier le dallage des données géographiques.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di modifica della mosaicatura (tiling)</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che modifica la mosaicatura dei dati geografici.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialDimensionMeasurementService">
+    <skos:prefLabel xml:lang="en">Dimension measurement service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service to compute dimensions of objects visible in an image or other geodata.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Messungsdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der die Abmessungen von Objekten in Bilddaten oder anderen Geodaten berechnet.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de mesure des dimensions</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service qui calcule les dimensions des objets visibles sur une image ou sur d’autres données géographiques.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di misura delle dimensioni</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che calcola le dimensioni degli oggetti visibili in un'immagine o in altri dati geografici.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialFeatureManipulationService">
+    <skos:prefLabel xml:lang="en">Feature manipulation services</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Register one feature to another, an image, or another data set or coordinate set; correcting for relative translation shifts, rotational differences, scale differences, and perspective differences. Verify that all features in the Feature Collection are topologically consistent according to the topology rules of the Feature Collection, and identifies and/or corrects any inconsistencies that are discovered.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Objektbearbeitungsdienste</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Zuordnung eines Objektes zu einem anderen Objekt, zu einem Bild, zu einem anderen Daten- oder Koordinatensatz; Korrektur von relativen Verschiebungen sowie von Unterschieden im Drehwinkel, im Maßstab und in der Perspektive. Überprüfung, ob alle Objekte in der Objektgruppe mit den Topologieregeln der Gruppe übereinstimmen; dieser Dienst identifiziert und/oder korrigiert alle entdeckten unlogischen Sachverhalte.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Services de manipulation des éléments géographiques</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Ces services permettent de caler un élément sur un autre, sur une image, ou sur une autre série de données ou de coordonnées, de corriger les décalages relatifs, les différences de rotation, les différences d’échelle et les différences de perspective, de vérifier que tous les éléments figurant dans la compilation d’éléments sont topologiquement cohérents au regard des règles de topologie de la compilation d’éléments, et de recenser et/ou corriger les éventuelles incohérences décelées.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizi di manipolazione degli elementi geografici</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizi che consentono di registrare un elemento con un altro, un'immagine, o un'altra serie di dati o di coordinate, correggendo le relative traslazioni, le differenze di rotazione, le differenze di scala e le differenze di prospettiva. Questi servizi consentono inoltre di verificare che tutti gli elementi che figurano nella collezione di elementi (Feature Collection) siano topologicamente coerenti rispetto alle regole topologiche della collezione di elementi e individuano e/o correggono le eventuali incoerenze individuate.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialFeatureMatchingService">
+    <skos:prefLabel xml:lang="en">Feature matching service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that determines which features and portions of features represent the same real world entity from multiple data sources, e.g., edge matching and limited conflation.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Vergleichsdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dieser Dienst ermittelt z. B. durch Kantenabgleich und begrenzte Verschmelzung, welche Objekte und Objektteile aus verschiedenen Datenquellen dasselbe reale Objekt darstellen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service d’appariement d’éléments</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service qui détermine quels éléments et parties d’éléments provenant de diverses sources de données représentent la même entité du monde réel, par exemple, appariement des contours et conflation limitée.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di corrispondenza di elementi</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che determina quali elementi e parti di elementi provenienti da varie fonti di dati rappresentano la stessa entità del mondo reale, ad esempio, corrispondenza di confini (edge matching) e fusione limitata (limited conflation).</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialFeatureGeneralizationService">
+    <skos:prefLabel xml:lang="en">Feature generalisation service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that reduces spatial variation in a feature collection to increase the effectiveness of communication by counteracting the undesirable effects of data reduction.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Generalisierungsdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der den räumlichen Detaillierungsgrad einer Objektgruppe vermindert, um Sachverhalte klarer darzustellen, ohne auf wesentliche Bestandteile zu verzichten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de généralisation d’éléments</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service qui réduit la variation spatiale dans une compilation d’éléments afin de renforcer l’efficacité de la communication en remédiant aux effets indésirables de la réduction de données.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di generalizzazione di elementi</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che riduce la variazione spaziale in una collezione di elementi al fine di rafforzare l'efficacia della comunicazione rimediando agli effetti indesiderati della riduzione dei dati.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialRouteDeterminationService">
+    <skos:prefLabel xml:lang="en">Route determination service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service to determine the optimal path between two specified points based on the input parameters and properties contained in the Feature Collection.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Routensuchdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dieser Dienst bestimmt die für gegebene Eingabeparameter und Eigenschaften der Objektgruppe optimale Verbindung zwischen zwei vorgegebenen Punkten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de détermination d’itinéraire</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service qui, sur la base des paramètres d’entrée et des propriétés contenus dans la compilation d’éléments, détermine le trajet optimal entre deux points donnés.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di determinazione dell'itinerario</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che determina il percorso ottimale tra due punti specifici sulla base dei parametri di input e delle proprietà contenuti nella collezione di elementi.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialPositioningService">
+    <skos:prefLabel xml:lang="en">Positioning service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service provided by a position-providing device to use, obtain and unambiguously interpret position information, and determines whether the results meet the requirements of the use.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Positionierungsdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Von einem positionsgebenden Gerät bereitgestellter Dienst für die Nutzung, Ermittlung und eindeutige Interpretation von Positionsangaben sowie für die Prüfung, ob die erhaltenen Angaben den Nutzungsanforderungen genügen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de positionnement</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service fourni par un appareil de géopositionnement, permettant d’utiliser, d’obtenir et d’interpréter sans équivoque les informations concernant la position, ainsi que de déterminer si les résultats répondent aux exigences de l’utilisation.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di posizionamento</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio fornito da un dispositivo di posizionamento che consente di utilizzare, ottenere e interpretare in modo univoco le informazioni concernenti la posizione, nonché di determinare se i risultati soddisfano i requisiti dell'utilizzo.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProximityAnalysisService">
+    <skos:prefLabel xml:lang="en">Proximity analysis service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Given a position or geographic feature, finds all objects with a given set of attributes that are located within a user-specified distance of the position or feature.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Analysedienst für räumliche Nachbarschaftsbeziehungen</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dieser Dienst ermittelt zu einer gegebenen Position oder einem gegebenen geografischen Objekt alle Objekte mit gegebenen Eigenschaften, die innerhalb einer vom Nutzer festgelegten Entfernung liegen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service d’analyse de proximité</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Ce service trouve, pour une position ou un élément géographique donné, tous les éléments ayant une série d’attributs spécifique qui sont situés à une distance définie par l’utilisateur par rapport à la position ou à l’élément.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di analisi di prossimità</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Data una posizione o un elemento geografico, questo servizio trova tutti gli oggetti che hanno una serie di attributi specifici, ubicati entro una distanza specificata dall'utente rispetto alla posizione o all'elemento.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/spatialProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService">
+    <skos:prefLabel xml:lang="en">Geographic processing services – thematic</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Geografische Verarbeitungsdienste – themenbezogen</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Services de traitement géographique — aspects thématiques</skos:prefLabel>
+    <skos:prefLabel xml:lang="it">Servizi di trattamento geografico — aspetti tematici</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicGoparameterCalculationService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicClassificationService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicFeatureGeneralizationService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicSubsettingService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicSpatialCountingService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicChangeDetectionService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicGeographicInformationExtractionService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicImageProcessingService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicReducedResolutionGenerationService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicImageManipulationService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicImageUnderstandingService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicImageSynthesisService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicMultibandImageManipulationService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicObjectDetectionService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicGeoparsingService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicGeocodingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicGoparameterCalculationService">
+    <skos:prefLabel xml:lang="en">Geoparameter calculation service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service to derive application-oriented quantitative results that are not available from the raw data itself.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Berechnungsdienst für Geoparameter</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst zur Berechnung von anwendungsspezifischen Datenwerten, die in den Rohdaten nicht enthalten sind.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de calcul des géoparamètres</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service qui dérive des résultats quantitatifs, axés sur les applications, qui ne peuvent pas être obtenus à partir des seules données brutes.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di calcolo dei geoparametri</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che deriva risultati quantitativi, orientati alle applicazioni, che non possono essere ottenuti direttamente dai dati grezzi.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicClassificationService">
+    <skos:prefLabel xml:lang="en">Thematic classification service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service to classify regions of geographic data based on thematic attributes.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für die thematische Klassifizierung</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dieser Dienst klassifiziert Gebiete geografischer Daten anhand thematischer Attribute.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de classification thématique</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service qui classe des zones de données géographiques sur la base des attributs thématiques.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di classificazione tematica</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di classificare delle aree di dati geografici in base ad attributi tematici.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicFeatureGeneralizationService">
+    <skos:prefLabel xml:lang="en">Feature generalisation service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that generalises feature types in a feature collection to increase the effectiveness of communication by counteracting the undesirable effects of data reduction.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Generalisierungsdienst für Objektarten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der die Objektarten in einer Objektgruppe vermindert, um Sachverhalte klarer darzustellen, ohne auf wesentliche Bestandteile zu verzichten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de généralisation d’éléments</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service qui généralise les types d’éléments contenus dans une compilation d’éléments afin de renforcer l’efficacité de la communication en remédiant aux effets indésirables de la réduction de données.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di generalizzazione di elementi</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che generalizza i tipi di elementi contenuti in una collezione di elementi al fine di rafforzare l'efficacia della comunicazione rimediando agli effetti indesiderati della riduzione dei dati.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicSubsettingService">
+    <skos:prefLabel xml:lang="en">Subsetting service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that extracts data from an input based on parameter values.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Themenbezogener Ausschneidedienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der je nach vorgegebenen Parametern Daten aus einer Eingabemenge auswählt.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de définition de sous-ensembles</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant d’extraire des données sur la base des paramètres d’entrée.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di definizione dei sottoinsiemi</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che estrae dei dati da un input sulla base di valori di parametro.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicSpatialCountingService">
+    <skos:prefLabel xml:lang="en">Spatial counting service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that counts geographic features.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Zähldienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dieser Dienst zählt geografische Objekte.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de comptage géographique</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de compter les éléments géographiques.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di conteggio territoriale</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che conta gli elementi geografici.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicChangeDetectionService">
+    <skos:prefLabel xml:lang="en">Change detection service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service to find differences between two data sets that represent the same geographical area at different times.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Erkennungsdienst für Veränderungen</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dieser Dienst ermittelt Unterschiede zwischen zwei Datensätzen, die dasselbe geografische Gebiet zu verschiedenen Zeitpunkten beschreiben.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de détection des changements</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de déceler les différences entre deux séries de données qui représentent la même zone géographique à des moments différents.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di rilevazione dei cambiamenti</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di rilevare le differenze tra due serie di dati che rappresentano la stessa area geografica in momenti diversi.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicGeographicInformationExtractionService">
+    <skos:prefLabel xml:lang="en">Geographic information extraction services</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Services supporting the extraction of feature and terrain information from remotely sensed and scanned images.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Auszugsdienst für geografische Informationen</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dieser Dienst unterstützt die Berechnung von Objekt- und Geländeinformationen aus Bilddaten der Fernerkundung.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Services d’extraction d’informations géographiques</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Services permettant l’extraction d’informations sur les éléments et le terrain à partir d’images de télédétection et d’images scannées.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di estrazione di informazioni geografiche</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizi che consentono l'estrazione di informazioni topografiche e sugli elementi a partire da immagini satellitari e scannerizzate.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicImageProcessingService">
+    <skos:prefLabel xml:lang="en">Image processing service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service to change the values of thematic attributes of an image using a mathematical function.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Themenbezogener Bildverarbeitungsdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der die Werte themenbezogener Bildeigenschaften über eine mathematische Funktion verändert.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de traitement d’images</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de modifier les valeurs des attributs thématiques d’une image au moyen d’une fonction mathématique.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di trattamento delle immagini</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di modificare i valori degli attributi tematici di un'immagine mediante una funzione matematica</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicReducedResolutionGenerationService">
+    <skos:prefLabel xml:lang="en">Reduced resolution generation service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that reduces the resolution of an image.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Auflösungsreduzierungsdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der die Auflösung eines Bildes verringert.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de réduction de la résolution</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de réduire la résolution d’une image.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di riduzione della risoluzione</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che riduce la risoluzione di un'immagine.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicImageManipulationService">
+    <skos:prefLabel xml:lang="en">Image Manipulation Services</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Services for manipulating data values in images: changing colour and contrast values, applying various filters, manipulating image resolution, noise removal, "striping", systematic-radiometric corrections, atmospheric attenuation, changes in scene illumination, etc.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Bildbearbeitungsdienste</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienste, mit denen sich die Datenwerte von Bildern bearbeiten lassen: Änderung von Farben und Kontrast, Anwendung von Filtern, Änderung der Auflösung, Entrauschen, Streifenbildung, systematische radiometrische Korrekturen, atmosphärische Abschwächung, Änderung der Helligkeit usw.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Services de manipulation d’images</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Services permettant de manipuler les valeurs des données dans les images: modification des valeurs de couleur et de contraste, application de différents filtres, manipulation de la résolution de l’image, réduction du bruit, réduction des stries, corrections radiométriques, atténuation atmosphérique, changement d’illumination de la scène, etc.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizi di manipolazione delle immagini</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizi che consentono di manipolare i valori dei dati nelle immagini: modifica dei valori del colore e del contrasto, applicazione di vari filtri, manipolazione della risoluzione dell'immagine, riduzione del rumore, striping, correzioni radiometriche sistematiche, attenuazioni atmosferiche, modifiche dell'illuminazione della scena ecc.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicImageUnderstandingService">
+    <skos:prefLabel xml:lang="en">Image understanding services</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Services that provide automated image change detection, registered image differencing, significance-of-difference analysis and display, and area-based and model-based differencing.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Interpretationsdienste für Bilder</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienste für die automatisierte Erkennung von Bildveränderungen, für Differenzverfahren zwischen zugeordneten Bildern, die Analyse und Darstellung der Bedeutung von Differenzen sowie für die flächen- und modellbasierte Differenzbildung.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Services de compréhension d’images</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Services permettant la détection automatisée des changements d’images, la différenciation des images rectifiées, l’analyse et l’affichage de l’importance des différences, et la différenciation par zone et par modèle.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizi di comprensione di immagini</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizi che consentono la rilevazione automatica dei cambiamenti di immagine, la differenziazione delle immagini rettificate, l'analisi e la visualizzazione della significatività delle differenze e la differenziazione per area e per modello.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicImageSynthesisService">
+    <skos:prefLabel xml:lang="en">Image synthesis services</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Services for creating or transforming images using computer-based spatial models, perspective transformations, and manipulations of image characteristics to improve visibility, sharpen resolution, and/or reduce the effects of cloud cover or haze.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Bildsynthesedienste</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienste zur Erzeugung oder Umformung von Bildern unter Nutzung von computergestützten räumlichen Modellen, Perspektiv-Transformationen und Methoden der Bildbearbeitung, um die Sichtbarkeit zu verbessern, die Auflösung zu schärfen und/oder die Wirkung von Wolkenbedeckung oder Dunst zu verringern.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Services de synthèse d’images</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Services permettant de créer ou de transformer des images au moyen de modèles spatiaux informatisés, de transformations de perspective, et de manipulations de caractéristiques de l’image en vue d’améliorer la visibilité et la résolution et/ou de réduire les effets de la couverture nuageuse ou de la brume.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizi di sintesi di immagini</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizi che consentono di creare o trasformare delle immagini utilizzando modelli spaziali informatici, effettuare delle trasformazioni di prospettiva, manipolare le caratteristiche delle immagini al fine di migliorare la visibilità e la risoluzione e/o ridurre gli effetti della nuvolosità e della foschia.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicMultibandImageManipulationService">
+    <skos:prefLabel xml:lang="en">Multiband image manipulation</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Services that modify an image using the multiple bands of the image.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Multiband-Bildbearbeitungsdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst für die Bildbearbeitung unter Nutzung der verschiedenen in den Bilddaten enthaltenen Frequenzbänder.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Manipulation d’images multibandes</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Services permettant de modifier une image en utilisant les différentes bandes spectrales de l’image.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Manipolazione di immagini multibanda</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che modifica un'immagine utilizzando le varie bande dell'immagine.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicObjectDetectionService">
+    <skos:prefLabel xml:lang="en">Object detection service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service to detect real-world objects in an image.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Objekterkennungsdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst zur Erkennung realer Objekte in einem Bild.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de détection d’objets</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de détecter les objets du monde réel dans une image.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di rilevazione di oggetti</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di rilevare gli oggetti del mondo reale in un'immagine.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicGeoparsingService">
+    <skos:prefLabel xml:lang="en">Geoparsing service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service to scan text documents for location-based references, such as a place names, addresses, postal codes, etc., in preparation for passage to a geocoding service.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Geoparserdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Um die Übergabe an einen Geocodierungsdienst vorzubereiten, können Textdokumente mit diesem Dienst nach Ortsangaben wie Ortsnamen, Adressen, Postleitzahlen usw. durchsucht werden.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service d’analyse géosémantique</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de rechercher dans les documents textuels les références à des lieux, comme les toponymes, les adresses, les codes postaux, etc., dans la perspective d’un service de géocodage.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di analisi sintattica (geoparsing)</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di cercare nei documenti testuali i riferimenti a dei luoghi, come i toponimi, gli indirizzi, i codici postali eccetera in preparazione al passaggio a un servizio di geocodifica.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicGeocodingService">
+    <skos:prefLabel xml:lang="en">Geocoding service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service to augment location-based text references with geographic coordinates (or some other spatial reference).</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Geocodierungsdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, mit dem Ortsangaben in Texten durch geografische Koordinaten (oder einen anderen Raumbezug) ergänzt werden können.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de géocodage</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant, dans les textes, de compléter les références à des lieux en indiquant les coordonnées géographiques (ou une autre référence spatiale).</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di geocodifica</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di arricchire i riferimenti geotestuali con le coordinate geografiche (o altri riferimenti spaziali).</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/thematicProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/temporalProcessingService">
+    <skos:prefLabel xml:lang="en">Geographic processing services – temporal</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Geografische Verarbeitungsdienste — zeitbezogen</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Services de traitement géographique — aspects temporels</skos:prefLabel>
+    <skos:prefLabel xml:lang="it">Servizi di processamento geografico — aspetti temporali</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/temporalReferenceSystemTransformationService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/temporalSubsettingService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/temporalSamplingService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/temporalProximityAnalysisService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/temporalReferenceSystemTransformationService">
+    <skos:prefLabel xml:lang="en">Temporal reference system transformation service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service to change the values of temporal instances from one temporal reference system to another temporal reference system.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Transformationsdienst für den Zeitbezug</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Mit diesem Dienst können Zeitangaben aus einem Zeitbezugssystem in ein anderes umgerechnet werden.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de transformation du système de référence temporel</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de modifier les valeurs des occurrences temporelles d’un système de référence temporelle à un autre système de référence temporelle.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di trasformazione del sistema di riferimento temporale</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di modificare i valori delle occorrenze temporali da un sistema di riferimento temporale a un altro.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/temporalProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/temporalSubsettingService">
+    <skos:prefLabel xml:lang="en">Subsetting service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that extracts data from an input in a continuous interval based on temporal position values.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Zeitbezogener Ausschneidedienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der aus Eingabedaten Daten auswählt, die in einem zusammenhängenden Zeitintervall mit vorgegebenem Anfangs- und Endzeitpunkt liegen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de définition de sous-ensembles</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant d’extraire des données dans un intervalle continu sur la base de valeurs de position temporelle.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di definizione dei sottoinsiemi</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che estrae dati da un input in un intervallo continuo sulla base di valori di posizione temporale.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/temporalProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/temporalSamplingService">
+    <skos:prefLabel xml:lang="en">Sampling service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that extracts data from an input using a consistent sampling scheme based on temporal position values.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Zeitbezogener Auswahldienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der aus Eingabedaten anhand von Zeitangaben nach einem konsistenten Schema bestimmte Daten auswählt.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service d’échantillonnage</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant d’extraire des données au moyen d’un système d’échantillonnage cohérent sur la base des valeurs de position temporelle.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di campionamento</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che estrae dati da un input usando un sistema di campionamento coerente basato su valori di posizione temporale.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/temporalProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/temporalProximityAnalysisService">
+    <skos:prefLabel xml:lang="en">Temporal proximity analysis service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Given a temporal interval or event, find all objects with a given set of attributes that are located within a user-specified interval from the interval or event.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Analysedienst für zeitbezogene Nachbarschaftsbeziehungen</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dieser Dienst ermittelt zu einem gegebenen Zeitraum oder Ereignis alle Objekte mit gegebenen Eigenschaften, deren zeitlicher Abstand vom Bezugszeitraum oder Bezugsereignis einen vom Nutzer festgelegten Wert nicht überschreitet.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service d’analyse de proximité</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Ce service trouve, pour un intervalle temporel ou un événement donné, tous les objets ayant une série d’attributs spécifique qui sont situés dans un intervalle défini par l’utilisateur par rapport à l’intervalle ou à l’élément.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di analisi di prossimità temporale</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Dato un intervallo temporale o un evento determinati, questo servizio trova tutti gli oggetti che hanno una serie di attributi specifici, ubicati in un intervallo stabilito dall'utente rispetto all'intervallo o all'evento.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/temporalProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/metadataProcessingService">
+    <skos:prefLabel xml:lang="en">Geographic processing services – metadata</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Geografische Verarbeitungsdienste — Metadaten</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Services de traitement géographique — métadonnées</skos:prefLabel>
+    <skos:prefLabel xml:lang="it">Servizi di processamento geografico — metadati</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/metadataStatisticalCalculationService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/metadataGeographicAnnotationService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/metadataStatisticalCalculationService">
+    <skos:prefLabel xml:lang="en">Statistical calculation service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service to calculate the statistics of a data set.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für statistische Berechnungen</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dieser Dienst berechnet statistische Daten aus einem Datensatz.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de calcul statistique</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de calculer les statistiques d’un ensemble de données.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di calcolo statistico</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di calcolare le statistiche di un insieme di dati.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/metadataProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/metadataGeographicAnnotationService">
+    <skos:prefLabel xml:lang="en">Geographic annotation services</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Services to add ancillary information to an image or a feature in a feature collection.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Ergänzungsdienst für Geodaten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, mit dem sich Bildern oder Objekten einer Objektgruppe ergänzende Informationen hinzufügen lassen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Services d’annotation géographique</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Services permettant d’ajouter des informations complémentaires à une image ou un élément dans une compilation d’éléments.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizi di annotazione geografica</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di aggiungere informazioni complementari a un'immagine o un elemento in una collezione di elementi.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/metadataProcessingService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comService">
+    <skos:prefLabel xml:lang="en">Geographic communication services</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Geografische Nachrichtenübermittlungsdienste</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Services de communication géographique</skos:prefLabel>
+    <skos:prefLabel xml:lang="it">Servizi di comunicazione geografica</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comEncodingService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comTransferService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comGeographicCompressionService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comGeographicFormatConversionService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comMessagingService" />
+    <skos:narrower rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comRemoteFileAndExecutableManagement" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comEncodingService">
+    <skos:prefLabel xml:lang="en">Encoding service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that provides implementation of an encoding rule and provides an interface to encoding and decoding functionality.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Codierungsdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der nach einer Verschlüsselungsvorschrift arbeitet und eine Schnittstelle zur Verschlüsselung (Codierung) und Entschlüsselung (Decodierung) besitzt.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service d’encodage</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant la mise en œuvre d’une règle d’encodage et servant d’interface pour la fonctionnalité d’encodage et de décodage.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di codifica</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente l'attuazione di una regola di codificazione e che funge da interfaccia per la funzione di codifica e decodifica.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comTransferService">
+    <skos:prefLabel xml:lang="en">Transfer service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that provides implementation of one or more transfer protocols, which allows data transfer between distributed information systems over offline or online communication media.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Übertragungsdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der nach einem oder mehreren Übertragungsprotokollen arbeitet und damit die Datenübertragung zwischen verteilten Informationssystemen über Online- oder Offline-Medien ermöglicht.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de transfert</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant la mise en œuvre d’un ou plusieurs protocoles de transfert, ce qui permet le transfert de données entre des systèmes d’information distribués via des moyens de communication hors ligne ou en ligne.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di trasferimento</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di attuare uno o più protocolli di trasferimento, permettendo il trasferimento di dati tra sistemi di informazione distribuiti mediante mezzi di comunicazione off-line o on-line.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comGeographicCompressionService">
+    <skos:prefLabel xml:lang="en">Geographic compression service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that converts spatial portions of a feature collection to and from compressed form.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Kompressionsdienst für Geodaten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der Daten zu räumlich abgegrenzten Teilen einer Objektgruppe in eine komprimierte Form oder komprimierte Daten zurück in die Ausgangsform wandelt.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de compression géographique</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de convertir les parties spatiales d’une compilation d’éléments pour les faire passer de la forme non compressée à la forme compressée, et vice versa.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di compressione geografica</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di convertire le parti spaziali di una collezione di elementi da e in forma compressa.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comGeographicFormatConversionService">
+    <skos:prefLabel xml:lang="en">Geographic format conversion service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that converts from one geographic data format to another.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Umformatierungsdienst für Geodaten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der das Format von Geodaten ändert.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de conversion de format géographique</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de passer d’un format de données géographiques à un autre.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di conversione di formato geografico</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di passare da un formato di dati geografici a un altro.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comMessagingService">
+    <skos:prefLabel xml:lang="en">Messaging service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that allows multiple users to simultaneously view, comment about, and request edits of feature collections.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Nachrichtenübermittlungsdienst</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienst, der es verschiedenen Nutzern ermöglicht, gleichzeitig Objektgruppen zu betrachten und zu kommentieren sowie Änderungsanträge zu stellen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de messagerie</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant simultanément à plusieurs utilisateurs de visualiser et de commenter des compilations d’éléments et d’en demander des révisions.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di messaggeria</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente simultaneamente a più utenti di visualizzare e commentare collezioni di elementi e di chiederne la revisione.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comService" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comRemoteFileAndExecutableManagement">
+    <skos:prefLabel xml:lang="en">Remote file and executable management</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that provides access to secondary storage of geographic features as if it were local to the client.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienst für den Zugriff auf externe Daten und Programme</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Mit diesem Dienst kann auf externe Speichermedien für geografische Objekte und Programme zugegriffen werden, als ob diese lokal verfügbar wären.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Gestion des fichiers éloignés et des fichiers exécutables</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant d’accéder à un stockage distant des éléments géographiques comme s’il s’agissait de ressources locales.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Gestione di file remoti e di file eseguibili</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di accedere a uno stoccaggio secondario di elementi geografici come se si trattasse di risorse locali.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory" />
+    <skos:broader rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/comService" />
+  </skos:Concept>
+</rdf:RDF>
+

--- a/web/src/main/webapp/WEB-INF/data/config/codelist/external/thesauri/theme/httpinspireeceuropaeumetadatacodelistSpatialDataServiceType-SpatialDataServiceType.rdf
+++ b/web/src/main/webapp/WEB-INF/data/config/codelist/external/thesauri/theme/httpinspireeceuropaeumetadatacodelistSpatialDataServiceType-SpatialDataServiceType.rdf
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <skos:ConceptScheme xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType">
+    <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/" xml:lang="en">Spatial data service type</dc:title>
+    <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/" xml:lang="de">Art des Geodatendienstes</dc:title>
+    <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/" xml:lang="fr">Type de service de données géographiques</dc:title>
+    <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/" xml:lang="it">Tipo di servizio di dati territoriali</dc:title>
+    <dcterms:issued xmlns:dcterms="http://purl.org/dc/terms/">2022-10-21T09:19:39</dcterms:issued>
+    <dcterms:modified xmlns:dcterms="http://purl.org/dc/terms/">2022-10-21T09:19:39</dcterms:modified>
+  </skos:ConceptScheme>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery">
+    <skos:prefLabel xml:lang="en">Discovery Service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Services making it possible to search for spatial data sets and services on the basis of the content of the corresponding metadata and to display the content of the metadata.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Suchdienste</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienste, die es ermöglichen, auf Grundlage des Inhalts entsprechender Metadaten nach Geodatensätzen und -diensten zu suchen und den Inhalt der Metadaten anzuzeigen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de recherche</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Services permettant de rechercher des séries et services de données géographiques sur la base du contenu des métadonnées correspondantes et d’afficher le contenu des métadonnées.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di ricerca</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizi di ricerca che consentono di ricercare set di dati territoriali e i servizi a essi relativi in base al contenuto dei metadati corrispondenti e di visualizzare il contenuto dei metadati.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view">
+    <skos:prefLabel xml:lang="en">View Service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that makes it possible, as a minimum, to display, navigate, zoom in and out, pan or overlay viewable spatial data sets and to display legend information and any relevant content of metadata.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Darstellungsdienste</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienste, die es mindestens ermöglichen, darstellbare Geodatensätze anzuzeigen, in ihnen zu navigieren, sie zu vergrößern/verkleinern, zu verschieben, Daten zu überlagern sowie Informationen aus Legenden und sonstige relevante Inhalte von Metadaten anzuzeigen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de consultation</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant au moins de visualiser, de naviguer, de zoomer en avant et en arrière, de déplacer à l’écran, ou de superposer des séries de données géographiques qui peuvent être consultées et d’afficher les légendes ainsi que tout contenu pertinent de métadonnées.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di consultazione</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di eseguire almeno le seguenti operazioni: visualizzazione, navigazione, variazione della scala di visualizzazione (zoom in e zoom out), variazione della porzione di territorio inquadrata (pan), sovrapposizione dei set di dati territoriali consultabili e visualizzazione delle informazioni contenute nelle legende e qualsiasi contenuto pertinente dei metadati.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download">
+    <skos:prefLabel xml:lang="en">Download Service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that enables copies of spatial data sets, or parts of such sets, to be downloaded and, where practicable, accessed directly.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Download-Dienste</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienste, mit denen Kopien von vollständigen Geodatensätzen oder Teilen solcher Sätze heruntergeladen werden können oder die gegebenenfalls den direkten Zugriff darauf ermöglichen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de téléchargement</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de télécharger des copies de séries de données géographiques, ou de parties de ces séries, et lorsque cela est réalisable, d’y avoir accès directement.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di scaricamento</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che permette di scaricare copie di set di dati territoriali o di una parte di essi e, ove possibile, di accedervi direttamente.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/transformation">
+    <skos:prefLabel xml:lang="en">Transformation Service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that enables spatial data sets to be transformed with a view to achieving interoperability.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Transformationsdienste</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienste zur Umwandlung von Geodatensätzen, um Interoperabilität zu erreichen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service de transformation</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de transformer des séries de données géographiques en vue d’assurer l’interopérabilité.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di conversione</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio di conversione che consente di trasformare i set di dati territoriali, onde conseguire l'interoperabilità.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/invoke">
+    <skos:prefLabel xml:lang="en">Invoke Spatial Data Service</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Service that allows defining both the data inputs and data outputs expected by the spatial service and a workflow or service chain combining multiple services. It also allows defining the external web service interface of the workflow or service chain.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Dienste zum Abrufen von Geodatendiensten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Dienste, über die von einem Geodatendienst erwartete Datenein- und Datenausgaben sowie eine Bearbeitungs- oder Dienstleistungskette zur Zusammenfassung mehrerer Dienste festgelegt werden können. Sie ermöglichen auch die Festlegung einer externen Webdienstschnittstelle für die Bearbeitungs- oder Dienstleistungskette.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Service d’appel de services de données géographiques</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Service permettant de définir à la fois les données d’entrée et de sortie demandées par le service de données géographiques et un processus ou une chaîne de services combinant plusieurs services. Il permet aussi de définir une interface externe du service internet pour le processus ou la chaîne de services.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizio di richiesta dei servizi di dati territoriali</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Servizio che consente di definire i dati in entrata (input) e in uscita (output) richiesti dal servizio di dati territoriali e un workflow o una catena di servizi che combina più servizi. Consente inoltre di definire un'interfaccia esterna del servizio web per il workflow o la catena di servizi.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/other">
+    <skos:prefLabel xml:lang="en">Other Service</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Sonstige Dienste</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Autre service</skos:prefLabel>
+    <skos:prefLabel xml:lang="it">Altri servizi</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType" />
+  </skos:Concept>
+</rdf:RDF>
+


### PR DESCRIPTION
This improves:
* ISO19139 formatter not handling all type of multilingual URL
* ISO19139 formatter not removing extended topic category (causing XSD validation issue on INSPIRE validator)
* Editing / Add default ISO19139 inflate mechanism to support `gmd:pass` set to `unknown` for conformance results
* Configure ETF validation for iso19139.che
* Backport INSPIRE Registry import fix (https://github.com/geonetwork/core-geonetwork/pull/6617)
* Migrate INSPIRE themes to thesaurus provided by the INSPIRE Registry
* Add an XSL process to improve conformity of Geobasisdaten  



To deploy and apply the INSPIRE improvements:
* Merge Pull request https://github.com/geoadmin/geocat/pull/229
* Deploy it
* Thesaurus update: Load INSPIRE thesaurus from the INSPIRE registry (or [from geocat.ch source code in github](https://github.com/geoadmin/geocat/tree/d83ef8c72a0883fb6e860b836171726a615409c5/web/src/main/webapp/WEB-INF/data/config/codelist/external/thesauri/theme))
  * INSPIRE themes
  * Spatial scope
  * Priority Datasets
  * Spatial data service type
  * Classification of spatial data services
* Update INSPIRE themes
  * Apply SQL https://github.com/geoadmin/geocat/blob/d83ef8c72a0883fb6e860b836171726a615409c5/web/src/main/webapp/WEB-INF/classes/setup/sql-geocat/v4/inspire-themes.sql
  * Remove the old INSPIRE themes (using rdfdata.eionet.europa.eu in concept URL - the new one use inspire.ec.europa.eu).
* Catalogue configuration:
  * Add INSPIRE validator key (see documentation)
  * Add specification to the list of exception for XLink resolution
* Apply XSL process geocat-inspire-conformity (see documentation)

