### PR TITLE
Add Google Analytics Tag to html pages - MGEO_SB-834

### DIFF
--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -311,4 +311,17 @@
       }]);
     </script>
   </xsl:template>
+
+  <!-- Google Analytics 4 -->
+  <xsl:template name="ga4-load">
+    <!-- Google tag (gtag.js) -->
+    <script async="async" src="https://www.googletagmanager.com/gtag/js?id=G-C0NWPQVB2N"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-C0NWPQVB2N');
+    </script> 
+  </xsl:template>
 </xsl:stylesheet>

--- a/web/src/main/webapp/xslt/base-layout.xsl
+++ b/web/src/main/webapp/xslt/base-layout.xsl
@@ -60,6 +60,7 @@
               title="{concat($env/system/site/name, ' - ', $env/system/site/organization)}"/>
 
         <xsl:call-template name="css-load"/>
+        <xsl:call-template name="ga4-load"/>
       </head>
 
 

--- a/web/src/main/webapp/xslt/common/render-html.xsl
+++ b/web/src/main/webapp/xslt/common/render-html.xsl
@@ -90,6 +90,7 @@
               title="{$title}"/>
 
         <xsl:call-template name="css-load-nojs"/>
+        <xsl:call-template name="ga4-load"/>
 
       </head>
 


### PR DESCRIPTION
Add Google Analytics 4 Tag to all html rendered page at the end of the head section.