### PR TITLE
SEO / Set HTML head title and description

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -459,6 +459,17 @@ public final class XslUtil {
         return source.isPresent() ? source.get().getLogo() : "";
     }
 
+    public static String getDiscoveryServiceUuid(String key) {
+        Optional<Source> source = getSource(key);
+        if (source.isPresent() && source.get().getType() == SourceType.subportal) {
+            return source.get().getServiceRecord();
+        } else {
+            SettingManager settingsMan = ApplicationContextHolder.get().getBean(SettingManager.class);
+            String uuid = settingsMan.getValue(SYSTEM_CSW_CAPABILITY_RECORD_UUID);
+            return "-1".equals(uuid) ? "" : uuid;
+        }
+    }
+
     private static Optional<Source> getSource(String idOrUuid) {
         SettingManager settingsMan = ApplicationContextHolder.get().getBean(SettingManager.class);
         if (StringUtils.isEmpty(idOrUuid)) {

--- a/web/src/main/webapp/xslt/base-layout.xsl
+++ b/web/src/main/webapp/xslt/base-layout.xsl
@@ -41,14 +41,40 @@
   <xsl:template match="/">
     <html ng-app="{$angularModule}" lang="{$lang2chars}" id="ng-app">
       <head>
-        <title>
-            <xsl:value-of select="util:getNodeName('', $lang, true())"/>
-        </title>
+        <xsl:variable name="discoveryServiceRecordUuid"
+                      select="util:getDiscoveryServiceUuid('')"/>
+        <xsl:variable name="nodeName"
+                      select="util:getNodeName('', $lang, true())"/>
+
+        <xsl:variable name="htmlHeadTitle"
+                      select="if ($discoveryServiceRecordUuid != '')
+                              then util:getIndexField(
+                                        $lang,
+                                        $discoveryServiceRecordUuid,
+                                        'resourceTitleObject',
+                                        $lang)
+                              else if (contains($nodeName, '|'))
+                              then substring-before($nodeName, '|')
+                              else $nodeName"/>
+
+
+        <xsl:variable name="htmlHeadDescription"
+                      select="if ($discoveryServiceRecordUuid != '')
+                              then util:getIndexField(
+                                        $lang,
+                                        $discoveryServiceRecordUuid,
+                                        'resourceAbstractObject',
+                                        $lang)
+                              else if (contains($nodeName, '|'))
+                              then substring-after($nodeName, '|')
+                              else $nodeName"/>
+
+        <title><xsl:value-of select="$htmlHeadTitle"/></title>
         <meta charset="utf-8"/>
         <meta name="viewport" content="initial-scale=1.0"/>
         <meta name="apple-mobile-web-app-capable" content="yes"/>
 
-        <meta name="description" content=""/>
+        <meta name="description" content="{$htmlHeadDescription}"/>
         <meta name="keywords" content=""/>
 
 


### PR DESCRIPTION
Linked to https://jira.swisstopo.ch/browse/MGEO_SB-885

Currently HTML head description is set to an empty value. Google is indexing the cookie warning in GeoNetwork case when no HTML head is found (probably because it is the first HTML text content found).

Use the service metadata configured for the main node (see admin > settings > record to use for GetCapabilities) and same for portal.

If no service metadata record configured, default title and description to node name (or site name for the main portal).

Follow up of:
* https://github.com/geonetwork/core-geonetwork/commit/611be2a0f5a514be9fa3b80a14b0dd785c94dba9
* https://github.com/geonetwork/core-geonetwork/pull/4758