### PR TITLE
Maintenance Swagger API to clean data dir of orphaned metadata absent from DB

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/maintenance/DatadirCleaner.java
+++ b/services/src/main/java/org/fao/geonet/api/maintenance/DatadirCleaner.java
@@ -1,7 +1,10 @@
 package org.fao.geonet.api.maintenance;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -12,9 +15,11 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.stream.Stream;
 
 @RequestMapping(value = {"/{portal}/api/maintenance"})
@@ -24,6 +29,11 @@ public class DatadirCleaner {
 
     @Autowired
     GeonetworkDataDirectory geonetworkDataDirectory;
+    @Autowired
+    IMetadataUtils metadataUtils;
+
+    private BufferedWriter orphanedDataFile;
+    private Path orphanedDataFilePath;
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Clean data dir")
     @RequestMapping(
@@ -33,18 +43,37 @@ public class DatadirCleaner {
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("hasAuthority('UserAdmin')")
     @ResponseBody
-    public Object cleanDataDir() {
-        cleanFile();
-        return "cleaned";
+    public ObjectNode cleanDataDir() throws IOException {
+        return cleanFile();
     }
 
-    public void cleanFile() {
+    public ObjectNode cleanFile() throws IOException {
         Path rootPath = geonetworkDataDirectory.getMetadataDataDir();
+        orphanedDataFilePath = rootPath.resolve("orphanedDataFiles.txt");
+        try(BufferedWriter bw = Files.newBufferedWriter(orphanedDataFilePath, StandardOpenOption.WRITE)) {
+            orphanedDataFile = bw;
+            listFilesEatingException(rootPath) //
+                .flatMap(this::listFilesEatingException)
+                .filter(this::isOrphanedPath)
+                .forEach(this::deleteAndLogToFile);
 
-        listFilesEatingException(rootPath) //
-            .flatMap(this::listFilesEatingException)
-            .map(Path::toString)
-            .forEach(System.err::println);
+            ObjectNode status = new ObjectMapper().createObjectNode();
+            status.put("status", "Cleaned the orphaned data: see details in " + orphanedDataFilePath.toString());
+            return status;
+        }
+    }
+
+    private void deleteAndLogToFile(Path path) {
+        try {
+            orphanedDataFile.append(path.toAbsolutePath().toString());
+            orphanedDataFile.newLine();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private boolean isOrphanedPath(Path path) {
+        return !metadataUtils.exists(Integer.parseInt(path.getFileName().toString()));
     }
 
     private Stream<Path> listFilesEatingException(Path path) {

--- a/services/src/main/java/org/fao/geonet/api/maintenance/DatadirCleaner.java
+++ b/services/src/main/java/org/fao/geonet/api/maintenance/DatadirCleaner.java
@@ -1,6 +1,8 @@
 package org.fao.geonet.api.maintenance;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -10,10 +12,18 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
 @RequestMapping(value = {"/{portal}/api/maintenance"})
 @Tag(name = "maintenance")
 @Controller("maintenance")
 public class DatadirCleaner {
+
+    @Autowired
+    GeonetworkDataDirectory geonetworkDataDirectory;
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Clean data dir")
     @RequestMapping(
@@ -24,6 +34,25 @@ public class DatadirCleaner {
     @PreAuthorize("hasAuthority('UserAdmin')")
     @ResponseBody
     public Object cleanDataDir() {
+        cleanFile();
         return "cleaned";
+    }
+
+    public void cleanFile() {
+        Path rootPath = geonetworkDataDirectory.getMetadataDataDir();
+
+        listFilesEatingException(rootPath) //
+            .flatMap(this::listFilesEatingException)
+            .map(Path::toString)
+            .forEach(System.err::println);
+    }
+
+    private Stream<Path> listFilesEatingException(Path path) {
+        try {
+            return Files.list(path);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return Stream.of();
+        }
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/maintenance/DatadirCleaner.java
+++ b/services/src/main/java/org/fao/geonet/api/maintenance/DatadirCleaner.java
@@ -1,0 +1,29 @@
+package org.fao.geonet.api.maintenance;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@RequestMapping(value = {"/{portal}/api/maintenance"})
+@Tag(name = "maintenance")
+@Controller("maintenance")
+public class DatadirCleaner {
+
+    @io.swagger.v3.oas.annotations.Operation(summary = "Clean data dir")
+    @RequestMapping(
+        path = "/cleanDatadir",
+        produces = MediaType.APPLICATION_JSON_VALUE,
+        method = RequestMethod.GET)
+    @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("hasAuthority('UserAdmin')")
+    @ResponseBody
+    public Object cleanDataDir() {
+        return "cleaned";
+    }
+}

--- a/services/src/main/java/org/fao/geonet/api/maintenance/DatadirCleaner.java
+++ b/services/src/main/java/org/fao/geonet/api/maintenance/DatadirCleaner.java
@@ -3,6 +3,7 @@ package org.fao.geonet.api.maintenance;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.commons.io.FileUtils;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
@@ -77,6 +79,7 @@ public class DatadirCleaner {
         }
         if (orphanedPath) {
             String toLog = path.toAbsolutePath().toString();
+            FileUtils.deleteQuietly(path.toFile().getAbsoluteFile());
             toReturn.add(toLog);
             toReturn.add(String.format("SQL# select count(*) from metadata where id = %s", path.getFileName().toString()));
         }

--- a/services/src/main/java/org/fao/geonet/api/maintenance/DatadirCleaner.java
+++ b/services/src/main/java/org/fao/geonet/api/maintenance/DatadirCleaner.java
@@ -63,8 +63,8 @@ public class DatadirCleaner {
                 .flatMap(this::processPath) //
                 .forEach(pw::println);
         }
-        ObjectNode status = new ObjectMapper().createObjectNode()
-            .put("status", "Cleaned the orphaned data: see details in " + orphanedDataFilePath.toString());
+        ObjectNode status = new ObjectMapper().createObjectNode();
+        status.put("status", "Cleaned the orphaned data: see details in " + orphanedDataFilePath);
         return status;
     }
 
@@ -75,16 +75,16 @@ public class DatadirCleaner {
         try {
             orphanedPath = isOrphanedPath(path);
         } catch (RuntimeException e) {
-            toReturn.add(String.format("ERROR# %s", path.toString()));
+            toReturn.add("ERROR# %s" + path);
         }
         if (orphanedPath) {
             String toLog = path.toAbsolutePath().toString();
             FileUtils.deleteQuietly(path.toFile().getAbsoluteFile());
             toReturn.add(toLog);
-            toReturn.add(String.format("SQL# select count(*) from metadata where id = %s", path.getFileName().toString()));
+            toReturn.add("SQL# select count(*) from metadata where id = " + path.getFileName());
         }
         if (i % 100 == 0) {
-            toReturn.add(String.format("got %d", i));
+            toReturn.add(String.format("Processed %d paths", i));
             pwToFlush.flush();
         }
         return toReturn.stream();


### PR DESCRIPTION
Due to a missing delete, a metadata was deleted from the db but its associated entries in the datadir were not  deleted at the same time.
To delete the orphaned entries a new swagger entry point was added.